### PR TITLE
feat: implement deformable_feature_aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Porting the Sparse4D v3 3D object detection model to Tenstorrent devices (Wormho
 - [ ] model module by module convert by tt-nn
   - [x] ResNet50
   - [x] FPN Neck
-  - [ ] DeformableFeature Aggregation
+  - [x] DeformableFeature Aggregation
   - [ ] MultiheadAttention
   - [ ] AsymmetricFFN
   - [ ] Instance Bank

--- a/model/deformable_feature_aggregation.py
+++ b/model/deformable_feature_aggregation.py
@@ -1,0 +1,727 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+# =============================================================================
+# DeformableFeatureAggregation for TT Devices (Device-Only)
+#
+# All operations run on TT device using ttnn ops. No host-device transfers
+# during forward pass except final output retrieval.
+#
+# Forward flow:
+#   1. kps_generator: anchor → 3D key points (ttnn ops)
+#   2. project_points: 3D → 2D via projection matrix (ttnn.matmul)
+#   3. get_weights: instance_feature → attention weights (ttnn.linear + softmax)
+#   4. feature_sampling: grid_sample per FPN level (ttnn.grid_sample)
+#   5. multi_view_level_fusion: weighted sum (ttnn.multiply + ttnn.sum)
+#   6. output_proj: ttnn.linear + residual
+# =============================================================================
+
+from typing import Dict, List, Tuple
+import time
+
+import torch
+import ttnn
+from loguru import logger
+
+# Anchor box field indices (Sparse4D convention)
+X, Y, Z = 0, 1, 2
+W, L, H = 3, 4, 5
+SIN_YAW, COS_YAW = 6, 7
+VX, VY, VZ = 8, 9, 10
+
+
+class DeformableFeatureAggregation:
+    def __init__(
+        self,
+        device,
+        parameters,
+        model_config: Dict,
+        embed_dims: int = 256,
+        num_groups: int = 8,
+        num_levels: int = 4,
+        num_cams: int = 6,
+        num_pts: int = 13,
+        num_learnable_pts: int = 6,
+        use_camera_embed: bool = True,
+        residual_mode: str = "cat",
+    ) -> None:
+        self.device = device
+        self.embed_dims = embed_dims
+        self.num_groups = num_groups
+        self.group_dims = embed_dims // num_groups  # 32
+        self.num_levels = num_levels
+        self.num_cams = num_cams
+        self.num_pts = num_pts
+        self.num_learnable_pts = num_learnable_pts
+        self.use_camera_embed = use_camera_embed
+        self.residual_mode = residual_mode
+        self.model_config = model_config
+
+        # --- Move all parameters to TT device ---
+        # Note: PyTorch nn.Linear stores weight as [out, in],
+        # but ttnn.linear expects weight as [in, out], so we transpose.
+
+        # KPS Generator
+        self.fix_scale = self._to_device(parameters["kps_fix_scale"])  # [7, 3]
+        self.learnable_fc_weight = self._to_device(
+            parameters["kps_learnable_fc_weight"].t()
+        )  # [256, 18]
+        self.learnable_fc_bias = self._to_device_bias(
+            parameters["kps_learnable_fc_bias"]
+        )  # [1,1,1,18]
+
+        # Camera encoder
+        if use_camera_embed:
+            self.cam_linear1_weight = self._to_device(
+                parameters["cam_linear1_weight"].t()
+            )  # [12, 256]
+            self.cam_linear1_bias = self._to_device_bias(parameters["cam_linear1_bias"])
+            self.cam_ln1_weight = self._to_device_1d(parameters["cam_ln1_weight"])
+            self.cam_ln1_bias = self._to_device_1d(parameters["cam_ln1_bias"])
+            self.cam_linear2_weight = self._to_device(
+                parameters["cam_linear2_weight"].t()
+            )  # [256, 256]
+            self.cam_linear2_bias = self._to_device_bias(parameters["cam_linear2_bias"])
+            self.cam_ln2_weight = self._to_device_1d(parameters["cam_ln2_weight"])
+            self.cam_ln2_bias = self._to_device_1d(parameters["cam_ln2_bias"])
+
+        # Weights FC
+        self.weights_fc_weight = self._to_device(
+            parameters["weights_fc_weight"].t()
+        )  # [256, 416]
+        self.weights_fc_bias = self._to_device_bias(
+            parameters["weights_fc_bias"]
+        )  # [1,1,1,416]
+
+        # Output projection
+        self.output_proj_weight = self._to_device(
+            parameters["output_proj_weight"].t()
+        )  # [256, 256]
+        self.output_proj_bias = self._to_device_bias(
+            parameters["output_proj_bias"]
+        )  # [1,1,1,256]
+
+    def _to_device(self, tensor: torch.Tensor) -> ttnn.Tensor:
+        """Move weight tensor to device in TILE layout."""
+        if tensor.dim() == 1:
+            tensor = tensor.unsqueeze(0)
+        if tensor.dim() == 2:
+            # Pad to tile-aligned if needed
+            pass
+        t = ttnn.from_torch(tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device)
+        return t
+
+    def _to_device_bias(self, tensor: torch.Tensor) -> ttnn.Tensor:
+        """Move bias tensor to device as [1, 1, 1, N] in TILE layout."""
+        if tensor.dim() == 1:
+            tensor = tensor.reshape(1, 1, 1, -1)
+        t = ttnn.from_torch(tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device)
+        return t
+
+    def _to_device_1d(self, tensor: torch.Tensor) -> ttnn.Tensor:
+        """Move 1D tensor (LayerNorm weight/bias) to device as [1, 1, 1, N]."""
+        if tensor.dim() == 1:
+            tensor = tensor.reshape(1, 1, 1, -1)
+        t = ttnn.from_torch(tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device)
+        return t
+
+    def _kps_generator(
+        self,
+        anchor: ttnn.Tensor,
+        instance_feature: ttnn.Tensor,
+        bs: int,
+        num_anchor: int,
+    ) -> ttnn.Tensor:
+        """Generate 3D key points from anchor boxes on device.
+
+        Args:
+            anchor: [bs, num_anchor, 11] on device (TILE)
+            instance_feature: [bs, num_anchor, embed_dims] on device (TILE)
+
+        Returns:
+            key_points: [bs*num_anchor*num_pts, 3] on device
+        """
+        # Extract size [W, L, H] and compute exp
+        # anchor [..., 3:6] -> size
+        size_wlh = ttnn.slice(
+            anchor, [0, 0, W], [bs, num_anchor, H + 1]
+        )  # [bs, num_anchor, 3]
+        size = ttnn.exp(size_wlh)  # [bs, num_anchor, 3]
+
+        # Reshape size for broadcasting: [bs*num_anchor, 1, 3]
+        size_3d = ttnn.reshape(size, (bs * num_anchor, 1, 3))
+
+        # Fixed key points: fix_scale [7, 3] * size [bs*num_anchor, 1, 3]
+        # Broadcast multiply
+        fix_scale_dev = self.fix_scale  # [7, 3] on device
+        # Expand fix_scale to [1, 7, 3] for broadcast with [bs*num_anchor, 1, 3]
+        fix_scale_3d = ttnn.reshape(fix_scale_dev, (1, 7, 3))
+
+        # size_for_fix: [bs*num_anchor, 1, 3] broadcast with [1, 7, 3]
+        fix_kps = ttnn.multiply(fix_scale_3d, size_3d)  # [bs*num_anchor, 7, 3]
+
+        # Learnable key points: linear(instance_feature) -> sigmoid - 0.5
+        # instance_feature: [bs, num_anchor, 256] -> flatten to [bs*num_anchor, 1, 256]
+        inst_flat = ttnn.reshape(
+            instance_feature, (1, 1, bs * num_anchor, self.embed_dims)
+        )
+        learnable = ttnn.linear(
+            inst_flat, self.learnable_fc_weight, bias=self.learnable_fc_bias
+        )  # [1, 1, bs*num_anchor, 18]
+        learnable = ttnn.reshape(
+            learnable, (bs * num_anchor, self.num_learnable_pts, 3)
+        )  # [bs*num_anchor, 6, 3]
+        learnable = ttnn.sigmoid(learnable)
+        half = ttnn.from_torch(
+            torch.full((1, 1, 1), 0.5),
+            layout=ttnn.TILE_LAYOUT,
+            device=self.device,
+        )
+        learnable = ttnn.subtract(learnable, half)  # sigmoid - 0.5
+
+        # learnable * size: [bs*num_anchor, 6, 3] * [bs*num_anchor, 1, 3]
+        learnable_kps = ttnn.multiply(learnable, size_3d)  # [bs*num_anchor, 6, 3]
+
+        # Concat fixed + learnable: [bs*num_anchor, 13, 3]
+        key_points = ttnn.concat([fix_kps, learnable_kps], dim=1)
+
+        # Rotate by yaw angle (element-wise, no rotation matrix needed)
+        # cos_yaw, sin_yaw from anchor[:, :, 6:8]
+        cos_yaw = ttnn.slice(anchor, [0, 0, COS_YAW], [bs, num_anchor, COS_YAW + 1])
+        sin_yaw = ttnn.slice(anchor, [0, 0, SIN_YAW], [bs, num_anchor, SIN_YAW + 1])
+        # [bs, num_anchor, 1] -> [bs*num_anchor, 1, 1] for broadcast
+        cos_yaw = ttnn.reshape(cos_yaw, (bs * num_anchor, 1, 1))
+        sin_yaw = ttnn.reshape(sin_yaw, (bs * num_anchor, 1, 1))
+
+        # kp_x = key_points[..., 0:1], kp_y = key_points[..., 1:2], kp_z = key_points[..., 2:3]
+        kp_x = ttnn.slice(key_points, [0, 0, 0], [bs * num_anchor, self.num_pts, 1])
+        kp_y = ttnn.slice(key_points, [0, 0, 1], [bs * num_anchor, self.num_pts, 2])
+        kp_z = ttnn.slice(key_points, [0, 0, 2], [bs * num_anchor, self.num_pts, 3])
+
+        # rot_x = cos*kp_x - sin*kp_y
+        # rot_y = sin*kp_x + cos*kp_y
+        rot_x = ttnn.subtract(
+            ttnn.multiply(cos_yaw, kp_x), ttnn.multiply(sin_yaw, kp_y)
+        )
+        rot_y = ttnn.add(ttnn.multiply(sin_yaw, kp_x), ttnn.multiply(cos_yaw, kp_y))
+        # rot_z = kp_z (unchanged)
+
+        # Concat rotated: [bs*num_anchor, num_pts, 3]
+        key_points = ttnn.concat([rot_x, rot_y, kp_z], dim=-1)
+
+        # Translate to anchor center: anchor[..., 0:3] = [X, Y, Z]
+        center = ttnn.slice(anchor, [0, 0, X], [bs, num_anchor, Z + 1])
+        center = ttnn.reshape(center, (bs * num_anchor, 1, 3))
+        key_points = ttnn.add(key_points, center)
+
+        # Reshape to [bs, num_anchor, num_pts, 3]
+        # For matmul in projection we keep [bs, num_anchor*num_pts, 3]
+        key_points = ttnn.reshape(key_points, (bs, num_anchor * self.num_pts, 3))
+
+        return key_points
+
+    def _project_points(
+        self,
+        key_points: ttnn.Tensor,
+        projection_mat: ttnn.Tensor,
+        image_wh: ttnn.Tensor,
+        bs: int,
+        num_anchor: int,
+    ) -> ttnn.Tensor:
+        """Project 3D key points to normalized 2D per camera on device.
+
+        Args:
+            key_points: [bs, num_anchor*num_pts, 3] on device
+            projection_mat: [bs, num_cams, 4, 4] on device
+            image_wh: [bs, num_cams, 2] on device
+
+        Returns:
+            points_2d_grid: [bs*num_cams, num_anchor, num_pts, 2] on device (ROW_MAJOR, float32)
+        """
+        n_pts_total = num_anchor * self.num_pts
+
+        # Append ones for homogeneous: [bs, n_pts_total, 4]
+        ones = ttnn.from_torch(
+            torch.ones(bs, n_pts_total, 1),
+            layout=ttnn.TILE_LAYOUT,
+            device=self.device,
+        )
+        pts_homo = ttnn.concat([key_points, ones], dim=-1)  # [bs, n_pts_total, 4]
+
+        # Per-camera projection via loop (avoid 6D tensor)
+        all_cam_points = []
+        for cam_idx in range(self.num_cams):
+            # proj: [bs, 4, 4] for this camera
+            proj = ttnn.slice(
+                projection_mat,
+                [0, cam_idx, 0, 0],
+                [bs, cam_idx + 1, 4, 4],
+            )  # [bs, 1, 4, 4]
+            proj = ttnn.reshape(proj, (bs, 4, 4))
+
+            # pts_homo: [bs, n_pts_total, 4]
+            # result = pts_homo @ proj^T -> [bs, n_pts_total, 4]
+            proj_t = ttnn.transpose(proj, -2, -1)  # [bs, 4, 4]
+            projected = ttnn.matmul(pts_homo, proj_t)  # [bs, n_pts_total, 4]
+
+            # Perspective divide: xy / max(z, 1e-5)
+            xy = ttnn.slice(projected, [0, 0, 0], [bs, n_pts_total, 2])
+            z = ttnn.slice(projected, [0, 0, 2], [bs, n_pts_total, 3])
+            z_clamped = ttnn.clamp(z, min=1e-5)
+            xy_div = ttnn.multiply(
+                xy, ttnn.reciprocal(z_clamped)
+            )  # [bs, n_pts_total, 2]
+
+            # Normalize by image_wh: [bs, 1, 2] for this cam
+            wh = ttnn.slice(image_wh, [0, cam_idx, 0], [bs, cam_idx + 1, 2])
+            wh = ttnn.reshape(wh, (bs, 1, 2))
+            xy_norm = ttnn.multiply(
+                xy_div, ttnn.reciprocal(wh)
+            )  # [bs, n_pts_total, 2] in [0,1]
+
+            # Convert to grid_sample range [-1, 1]
+            two = ttnn.from_torch(
+                torch.full((1, 1, 1), 2.0),
+                layout=ttnn.TILE_LAYOUT,
+                device=self.device,
+            )
+            one = ttnn.from_torch(
+                torch.full((1, 1, 1), 1.0),
+                layout=ttnn.TILE_LAYOUT,
+                device=self.device,
+            )
+            xy_grid = ttnn.subtract(ttnn.multiply(xy_norm, two), one)
+            # [bs, n_pts_total, 2]
+
+            # Reshape to [bs, num_anchor, num_pts, 2]
+            xy_grid = ttnn.reshape(xy_grid, (bs, num_anchor, self.num_pts, 2))
+            all_cam_points.append(xy_grid)
+
+        # Stack cameras: concat along dim0 after reshape
+        # Each is [bs, num_anchor, num_pts, 2]
+        # We want [bs*num_cams, num_anchor, num_pts, 2]
+        points_2d = ttnn.concat(all_cam_points, dim=0)
+        # [bs*num_cams, num_anchor, num_pts, 2]
+
+        return points_2d
+
+    def _camera_encoder(
+        self,
+        projection_mat: ttnn.Tensor,
+        bs: int,
+    ) -> ttnn.Tensor:
+        """Camera encoder on device: Linear→ReLU→LN→Linear→ReLU→LN.
+
+        Args:
+            projection_mat: [bs, num_cams, 4, 4] on device
+
+        Returns:
+            camera_embed: [bs, num_cams, 256] on device (TILE)
+        """
+        # Extract first 3 rows of 4x4: [bs, num_cams, 3, 4] -> [bs, num_cams, 12]
+        cam_input = ttnn.slice(projection_mat, [0, 0, 0, 0], [bs, self.num_cams, 3, 4])
+        cam_input = ttnn.reshape(cam_input, (1, 1, bs * self.num_cams, 12))
+
+        # Linear1: [bs*num_cams, 12] -> [bs*num_cams, 256]
+        x = ttnn.linear(cam_input, self.cam_linear1_weight, bias=self.cam_linear1_bias)
+        x = ttnn.relu(x)
+        x = ttnn.layer_norm(x, weight=self.cam_ln1_weight, bias=self.cam_ln1_bias)
+
+        # Linear2: [bs*num_cams, 256] -> [bs*num_cams, 256]
+        x = ttnn.linear(x, self.cam_linear2_weight, bias=self.cam_linear2_bias)
+        x = ttnn.relu(x)
+        x = ttnn.layer_norm(x, weight=self.cam_ln2_weight, bias=self.cam_ln2_bias)
+
+        # Reshape to [bs, num_cams, 256]
+        x = ttnn.reshape(x, (bs, self.num_cams, self.embed_dims))
+        return x
+
+    def _get_weights(
+        self,
+        instance_feature: ttnn.Tensor,
+        anchor_embed: ttnn.Tensor,
+        projection_mat: ttnn.Tensor,
+        bs: int,
+        num_anchor: int,
+    ) -> ttnn.Tensor:
+        """Compute attention weights on device.
+
+        Args:
+            instance_feature: [bs, num_anchor, embed_dims] on device
+            anchor_embed: [bs, num_anchor, embed_dims] on device
+            projection_mat: [bs, num_cams, 4, 4] on device
+
+        Returns:
+            weights: [bs*num_anchor, num_cams*num_levels*num_pts, num_groups] on device
+        """
+        feature = ttnn.add(instance_feature, anchor_embed)  # [bs, num_anchor, 256]
+
+        if self.use_camera_embed:
+            camera_embed = self._camera_encoder(projection_mat, bs)
+            # [bs, num_cams, 256]
+
+            # feature[:, :, None] + camera_embed[:, None]
+            # -> [bs, num_anchor, num_cams, 256]
+            # Reshape for broadcast add:
+            feat_exp = ttnn.reshape(feature, (bs, num_anchor, 1, self.embed_dims))
+            cam_exp = ttnn.reshape(
+                camera_embed, (bs, 1, self.num_cams, self.embed_dims)
+            )
+            feature = ttnn.add(feat_exp, cam_exp)
+            # [bs, num_anchor, num_cams, 256]
+
+            # Flatten for linear: [1, 1, bs*num_anchor*num_cams, 256]
+            feature = ttnn.reshape(
+                feature, (1, 1, bs * num_anchor * self.num_cams, self.embed_dims)
+            )
+        else:
+            feature = ttnn.reshape(feature, (1, 1, bs * num_anchor, self.embed_dims))
+
+        # weights_fc: -> [..., 416] where 416 = num_groups * num_levels * num_pts
+        weights = ttnn.linear(
+            feature, self.weights_fc_weight, bias=self.weights_fc_bias
+        )
+
+        # Reshape for softmax: [..., num_cams*num_levels*num_pts, num_groups]
+        total_clp = self.num_cams * self.num_levels * self.num_pts
+        if self.use_camera_embed:
+            # [1, 1, bs*num_anchor*num_cams, 416]
+            # 416 = num_levels * num_pts * num_groups = 4 * 13 * 8
+            # Reshape to [bs*num_anchor, num_cams*num_levels*num_pts, num_groups]
+            weights = ttnn.reshape(
+                weights,
+                (
+                    1,
+                    1,
+                    bs * num_anchor,
+                    self.num_cams * self.num_levels * self.num_pts * self.num_groups,
+                ),
+            )
+            # For softmax over cams*levels*pts dim:
+            # [bs*num_anchor, cams*levels*pts, groups]
+            weights = ttnn.reshape(
+                weights, (bs * num_anchor, total_clp, self.num_groups)
+            )
+        else:
+            weights = ttnn.reshape(
+                weights, (bs * num_anchor, total_clp, self.num_groups)
+            )
+
+        # Softmax over dim=1 (cams*levels*pts)
+        weights = ttnn.softmax(weights, dim=1)
+
+        return weights
+
+    def _feature_sampling(
+        self,
+        feature_maps: List[ttnn.Tensor],
+        points_2d: ttnn.Tensor,
+        spatial_shapes: List[Tuple[int, int]],
+        bs: int,
+        num_anchor: int,
+    ) -> ttnn.Tensor:
+        """Sample features from FPN maps on device (fully device-only).
+
+        Uses per-camera slice + concat to rearrange without host transfer.
+        grid_sample results [bs*num_cams, num_anchor, num_pts, embed_dims] are
+        sliced per camera, then interleaved per level via concat.
+
+        Weight order from _get_weights: for each cam, for each level, for each pt.
+        So we need: cam0_lvl0_pts, cam0_lvl1_pts, ..., cam0_lvl3_pts, cam1_lvl0_pts, ...
+
+        Args:
+            feature_maps: List of ttnn.Tensor [1, 1, N*H*W, C] from FPN (on device)
+            points_2d: [bs*num_cams, num_anchor, num_pts, 2] on device
+            spatial_shapes: [(H, W)] per FPN level
+
+        Returns:
+            features: [bs*num_anchor, num_cams*num_levels*num_pts, embed_dims] on device
+        """
+        n_batch = bs * self.num_cams
+
+        # 1. grid_sample per level
+        all_level_features = []
+        for level_idx, fm_tt in enumerate(feature_maps):
+            h, w = spatial_shapes[level_idx]
+            logger.debug(f"==== DFA grid_sample level {level_idx}: spatial={h}x{w}")
+
+            # Reshape feature map: [1, 1, N*H*W, C] -> [N, H, W, C] (NHWC)
+            fm = ttnn.to_memory_config(fm_tt, ttnn.DRAM_MEMORY_CONFIG)
+            fm = ttnn.to_layout(fm, ttnn.ROW_MAJOR_LAYOUT)
+            fm = ttnn.reshape(fm, (n_batch, h, w, self.embed_dims))
+
+            # Grid: [bs*num_cams, num_anchor, num_pts, 2]
+            grid = ttnn.to_layout(points_2d, ttnn.ROW_MAJOR_LAYOUT)
+            grid = ttnn.to_memory_config(grid, ttnn.DRAM_MEMORY_CONFIG)
+
+            # grid_sample (NHWC)
+            sampled = ttnn.grid_sample(
+                fm,
+                grid,
+                mode="bilinear",
+                align_corners=False,
+                padding_mode="zeros",
+            )
+            # [bs*num_cams, num_anchor, num_pts, embed_dims]
+
+            sampled = ttnn.to_layout(sampled, ttnn.TILE_LAYOUT)
+            sampled = ttnn.to_memory_config(sampled, ttnn.DRAM_MEMORY_CONFIG)
+
+            all_level_features.append(sampled)
+
+        # 2. Rearrange via slice + concat (no host transfer)
+        #
+        # Each level result: [bs*num_cams, num_anchor, num_pts, embed_dims]
+        #   dim0 layout: [cam0_bs, cam1_bs, ..., cam5_bs]  (cam varies fastest? no, bs*cams)
+        #   actually: dim0 = bs*num_cams, ordered as [b0c0, b0c1, ..., b0c5, b1c0, ...]
+        #
+        # We need final: [bs*num_anchor, cams*levels*pts, embed_dims]
+        #   with order: cam0_lvl0_pts, cam0_lvl1_pts, ..., cam0_lvl3_pts, cam1_lvl0_pts, ...
+        #
+        # Strategy:
+        #   For each cam: slice cam's data from each level → concat levels
+        #   Then concat all cams
+        #   Finally reshape to merge anchor into batch dim
+
+        chunks = []
+        for cam_idx in range(self.num_cams):
+            for level_idx in range(self.num_levels):
+                sampled = all_level_features[level_idx]
+                # [bs*num_cams, num_anchor, num_pts, embed_dims]
+                # cam_idx's slice: rows [cam_idx*bs : (cam_idx+1)*bs]
+                # But dim0 order is [b0c0, b0c1, ..., b0c5, b1c0, ...]
+                # i.e. for bs=1: [c0, c1, c2, c3, c4, c5]
+                # for bs=2: [b0c0, b0c1, ..., b0c5, b1c0, ..., b1c5]
+                # So cam_idx for batch b is at index b*num_cams + cam_idx
+
+                # For general bs, we need to gather all batches for this cam.
+                # With bs=1 (typical inference), cam_idx maps to row cam_idx directly.
+                # For bs>1, we slice each batch separately and concat.
+                if bs == 1:
+                    chunk = ttnn.slice(
+                        sampled,
+                        [cam_idx, 0, 0, 0],
+                        [cam_idx + 1, num_anchor, self.num_pts, self.embed_dims],
+                    )
+                    # [1, num_anchor, num_pts, embed_dims]
+                    chunks.append(chunk)
+                else:
+                    for b in range(bs):
+                        row = b * self.num_cams + cam_idx
+                        chunk = ttnn.slice(
+                            sampled,
+                            [row, 0, 0, 0],
+                            [row + 1, num_anchor, self.num_pts, self.embed_dims],
+                        )
+                        # [1, num_anchor, num_pts, embed_dims]
+                        chunks.append(chunk)
+
+        # Concat all chunks along pts dim (dim=2)
+        # Each chunk: [1, num_anchor, num_pts, embed_dims]  (bs=1)
+        # or [1, num_anchor, num_pts, embed_dims] per batch (bs>1)
+        #
+        # For bs=1: 6 cams * 4 levels = 24 chunks
+        #   concat dim=2 → [1, num_anchor, 24*num_pts, embed_dims]
+        #   = [1, num_anchor, cams*levels*pts, embed_dims]
+        if bs == 1:
+            features = ttnn.concat(chunks, dim=2)
+            # [1, num_anchor, num_cams*num_levels*num_pts, embed_dims]
+            features = ttnn.reshape(
+                features,
+                (
+                    num_anchor,
+                    self.num_cams * self.num_levels * self.num_pts,
+                    self.embed_dims,
+                ),
+            )
+        else:
+            # Group chunks by batch: each batch has cams*levels chunks
+            batch_features = []
+            for b in range(bs):
+                # chunks for batch b: indices [b, b+bs, b+2*bs, ...]
+                # Actually chunks are ordered: cam0_lvl0_b0, cam0_lvl0_b1, ..., cam0_lvl1_b0, ...
+                # Let's re-index: for cam c, level l, batch b → index = (c*num_levels + l)*bs + b
+                b_chunks = []
+                for c in range(self.num_cams):
+                    for l in range(self.num_levels):
+                        idx = (c * self.num_levels + l) * bs + b
+                        b_chunks.append(chunks[idx])
+                b_feat = ttnn.concat(b_chunks, dim=2)
+                # [1, num_anchor, cams*levels*pts, embed_dims]
+                batch_features.append(b_feat)
+            features = ttnn.concat(batch_features, dim=0)
+            # [bs, num_anchor, cams*levels*pts, embed_dims]
+            features = ttnn.reshape(
+                features,
+                (
+                    bs * num_anchor,
+                    self.num_cams * self.num_levels * self.num_pts,
+                    self.embed_dims,
+                ),
+            )
+
+        # Deallocate grid_sample results
+        for sampled in all_level_features:
+            ttnn.deallocate(sampled)
+
+        return features
+
+    def _multi_view_level_fusion(
+        self,
+        features: ttnn.Tensor,
+        weights: ttnn.Tensor,
+        bs: int,
+        num_anchor: int,
+    ) -> ttnn.Tensor:
+        """Weighted fusion on device.
+
+        Args:
+            features: [bs*num_anchor, cams*levels*pts, embed_dims] on device
+            weights: [bs*num_anchor, cams*levels*pts, num_groups] on device
+
+        Returns:
+            output: [bs*num_anchor, embed_dims] on device
+        """
+        total_clp = self.num_cams * self.num_levels * self.num_pts
+
+        # Split embed_dims into groups: [bs*num_anchor, clp, num_groups, group_dims]
+        features = ttnn.reshape(
+            features, (bs * num_anchor, total_clp, self.num_groups, self.group_dims)
+        )
+
+        # Expand weights: [bs*num_anchor, clp, num_groups, 1]
+        weights = ttnn.reshape(
+            weights, (bs * num_anchor, total_clp, self.num_groups, 1)
+        )
+
+        # Weighted features
+        features = ttnn.multiply(features, weights)
+        # [bs*num_anchor, clp, num_groups, group_dims]
+
+        # Sum over clp dimension (dim=1)
+        features = ttnn.sum(features, dim=1)
+        # [bs*num_anchor, 1, num_groups, group_dims]
+
+        # Reshape: [bs*num_anchor, num_groups*group_dims] = [bs*num_anchor, embed_dims]
+        features = ttnn.reshape(features, (1, 1, bs * num_anchor, self.embed_dims))
+
+        return features
+
+    def run(
+        self,
+        instance_feature: ttnn.Tensor,
+        anchor: ttnn.Tensor,
+        anchor_embed: ttnn.Tensor,
+        feature_maps: List[ttnn.Tensor],
+        projection_mat: ttnn.Tensor,
+        image_wh: ttnn.Tensor,
+        spatial_shapes: List[Tuple[int, int]],
+        bs: int,
+        num_anchor: int,
+    ) -> ttnn.Tensor:
+        """Full forward pass of DeformableFeatureAggregation on device.
+
+        Args:
+            instance_feature: [bs, num_anchor, embed_dims] on device (TILE)
+            anchor: [bs, num_anchor, 11] on device (TILE)
+            anchor_embed: [bs, num_anchor, embed_dims] on device (TILE)
+            feature_maps: List of ttnn.Tensor from FPN [1, 1, N*H*W, C]
+            projection_mat: [bs, num_cams, 4, 4] on device (TILE)
+            image_wh: [bs, num_cams, 2] on device (TILE)
+            spatial_shapes: [(H, W)] per FPN level
+            bs: batch size
+            num_anchor: number of anchors
+
+        Returns:
+            output: [bs, num_anchor, embed_dims] (add) or
+                    [bs, num_anchor, 2*embed_dims] (cat) on device
+        """
+        # 1. Generate 3D key points
+        key_points = self._kps_generator(anchor, instance_feature, bs, num_anchor)
+        # [bs, num_anchor*num_pts, 3]
+
+        # 2. Project to 2D per camera
+        points_2d = self._project_points(
+            key_points, projection_mat, image_wh, bs, num_anchor
+        )
+        # [bs*num_cams, num_anchor, num_pts, 2]
+
+        # 3. Compute attention weights
+        weights = self._get_weights(
+            instance_feature, anchor_embed, projection_mat, bs, num_anchor
+        )
+        # [bs*num_anchor, num_cams*num_levels*num_pts, num_groups]
+
+        # 4. Feature sampling (grid_sample on device)
+        features = self._feature_sampling(
+            feature_maps, points_2d, spatial_shapes, bs, num_anchor
+        )
+        # [bs*num_anchor, num_cams*num_levels*num_pts, embed_dims]
+
+        # 5. Multi-view level fusion
+        features = self._multi_view_level_fusion(features, weights, bs, num_anchor)
+        # [1, 1, bs*num_anchor, embed_dims]
+
+        # 6. Output projection
+        output = ttnn.linear(
+            features, self.output_proj_weight, bias=self.output_proj_bias
+        )
+        # [1, 1, bs*num_anchor, embed_dims]
+
+        # 7. Residual
+        inst_flat = ttnn.reshape(
+            instance_feature, (1, 1, bs * num_anchor, self.embed_dims)
+        )
+        if self.residual_mode == "add":
+            output = ttnn.add(output, inst_flat)
+            output = ttnn.reshape(output, (bs, num_anchor, self.embed_dims))
+        elif self.residual_mode == "cat":
+            output = ttnn.concat([output, inst_flat], dim=-1)
+            output = ttnn.reshape(output, (bs, num_anchor, 2 * self.embed_dims))
+
+        return output
+
+
+def preprocess_dfa_parameters(pt_model) -> dict:
+    """Extract parameters from PyTorch DeformableFeatureAggregation model.
+
+    Args:
+        pt_model: PyTorch DeformableFeatureAggregation instance
+            (from mmdet3d_plugin.models.blocks)
+
+    Returns:
+        dict of torch tensors for DeformableFeatureAggregation.__init__
+    """
+    params = {}
+
+    # KPS Generator
+    params["kps_fix_scale"] = pt_model.kps_generator.fix_scale.data.clone()
+    params["kps_learnable_fc_weight"] = (
+        pt_model.kps_generator.learnable_fc.weight.data.clone()
+    )
+    params["kps_learnable_fc_bias"] = (
+        pt_model.kps_generator.learnable_fc.bias.data.clone()
+    )
+
+    # Camera encoder (if exists)
+    if pt_model.camera_encoder is not None:
+        enc = pt_model.camera_encoder
+        params["cam_linear1_weight"] = enc[0].weight.data.clone()
+        params["cam_linear1_bias"] = enc[0].bias.data.clone()
+        params["cam_ln1_weight"] = enc[2].weight.data.clone()
+        params["cam_ln1_bias"] = enc[2].bias.data.clone()
+        params["cam_linear2_weight"] = enc[3].weight.data.clone()
+        params["cam_linear2_bias"] = enc[3].bias.data.clone()
+        params["cam_ln2_weight"] = enc[5].weight.data.clone()
+        params["cam_ln2_bias"] = enc[5].bias.data.clone()
+
+    # Weights FC
+    params["weights_fc_weight"] = pt_model.weights_fc.weight.data.clone()
+    params["weights_fc_bias"] = pt_model.weights_fc.bias.data.clone()
+
+    # Output projection
+    params["output_proj_weight"] = pt_model.output_proj.weight.data.clone()
+    params["output_proj_bias"] = pt_model.output_proj.bias.data.clone()
+
+    return params

--- a/test/dfa_pcc.py
+++ b/test/dfa_pcc.py
@@ -1,0 +1,673 @@
+"""
+DeformableFeatureAggregation PCC Test: PyTorch vs TT-NN (Device-Only)
+
+Compares the TT-NN DeformableFeatureAggregation (device-only, all ttnn ops)
+against the PyTorch fallback path (F.grid_sample) for numerical accuracy.
+
+Metrics:
+  - PCC: Pearson Correlation (pattern similarity)
+  - MaxDiff: worst-case absolute error
+  - MeanDiff: average absolute error
+  - RelErr: mean relative error (|a-b| / max(|a|, |b|))
+  - Allclose: torch.allclose with configurable atol/rtol
+  - Sample values: side-by-side comparison of actual tensor values
+
+Tests:
+  1. grid_sample only: per-level feature sampling
+  2. End-to-end: full DFA forward pass (device-only)
+
+Usage:
+  python test/dfa_pcc.py
+  python test/dfa_pcc.py --ckpt ckpt/latest.pth
+"""
+
+import argparse
+import os
+import sys
+
+TT_METAL_HOME = os.environ.get(
+    "TT_METAL_HOME", os.path.expanduser("~/project/tt-metal")
+)
+sys.path.insert(0, TT_METAL_HOME)
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.expanduser("~/project/Sparse4D"))
+
+import torch
+import torch.nn.functional as F
+import ttnn
+
+from model.deformable_feature_aggregation import (
+    DeformableFeatureAggregation,
+    preprocess_dfa_parameters,
+)
+
+
+# ============================================================
+# Comparison Utilities
+# ============================================================
+
+def compute_pcc(a: torch.Tensor, b: torch.Tensor) -> float:
+    """Pearson Correlation Coefficient."""
+    a = a.double().flatten()
+    b = b.double().flatten()
+    a = a - a.mean()
+    b = b - b.mean()
+    denom = a.norm() * b.norm()
+    if denom == 0:
+        return 1.0 if a.norm() == 0 and b.norm() == 0 else 0.0
+    return (torch.dot(a, b) / denom).item()
+
+
+def compute_relative_error(a: torch.Tensor, b: torch.Tensor, eps: float = 1e-6) -> float:
+    """Mean relative error: mean(|a-b| / max(|a|, |b|, eps))."""
+    a = a.float().flatten()
+    b = b.float().flatten()
+    denom = torch.max(a.abs(), b.abs()).clamp(min=eps)
+    return (((a - b).abs() / denom).mean()).item()
+
+
+def compare_tensors(
+    pt: torch.Tensor,
+    tt: torch.Tensor,
+    name: str,
+    atol: float = 1e-2,
+    rtol: float = 1e-2,
+    num_samples: int = 10,
+):
+    """Print comprehensive comparison between PyTorch and TT-NN tensors."""
+    pt_f = pt.float()
+    tt_f = tt.float()
+    diff = (pt_f - tt_f).abs()
+
+    pcc = compute_pcc(pt, tt)
+    max_diff = diff.max().item()
+    mean_diff = diff.mean().item()
+    rel_err = compute_relative_error(pt, tt)
+    allclose = torch.allclose(pt_f, tt_f, atol=atol, rtol=rtol)
+
+    print(f"\n  --- {name} ---")
+    print(f"  Shape:     {list(pt.shape)}")
+    print(f"  PCC:       {pcc:.6f}")
+    print(f"  MaxDiff:   {max_diff:.6f}")
+    print(f"  MeanDiff:  {mean_diff:.6f}")
+    print(f"  RelErr:    {rel_err:.6f}")
+    print(f"  Allclose:  {allclose}  (atol={atol}, rtol={rtol})")
+
+    # Value range
+    print(f"  PT range:  [{pt_f.min().item():.4f}, {pt_f.max().item():.4f}]  mean={pt_f.mean().item():.4f}")
+    print(f"  TT range:  [{tt_f.min().item():.4f}, {tt_f.max().item():.4f}]  mean={tt_f.mean().item():.4f}")
+
+    # Sample values
+    pt_flat = pt_f.flatten()
+    tt_flat = tt_f.flatten()
+    n = min(num_samples, pt_flat.numel())
+    print(f"\n  Sample values (first {n}):")
+    print(f"  {'Index':<8} {'PyTorch':>12} {'TT-NN':>12} {'Diff':>12}")
+    print(f"  {'-'*7:<8} {'-'*11:>12} {'-'*11:>12} {'-'*11:>12}")
+    for i in range(n):
+        d = (pt_flat[i] - tt_flat[i]).abs().item()
+        print(f"  {i:<8} {pt_flat[i].item():>12.6f} {tt_flat[i].item():>12.6f} {d:>12.6f}")
+
+    # Worst diff locations
+    diff_flat = diff.flatten()
+    _, worst_indices = diff_flat.topk(min(5, diff_flat.numel()))
+    print(f"\n  Top-5 worst diffs:")
+    print(f"  {'Index':<8} {'PyTorch':>12} {'TT-NN':>12} {'Diff':>12}")
+    print(f"  {'-'*7:<8} {'-'*11:>12} {'-'*11:>12} {'-'*11:>12}")
+    for idx in worst_indices:
+        i = idx.item()
+        d = diff_flat[i].item()
+        print(f"  {i:<8} {pt_flat[i].item():>12.6f} {tt_flat[i].item():>12.6f} {d:>12.6f}")
+
+    return {
+        "pcc": pcc,
+        "max_diff": max_diff,
+        "mean_diff": mean_diff,
+        "rel_err": rel_err,
+        "allclose": allclose,
+    }
+
+
+# ============================================================
+# Model loading & input creation
+# ============================================================
+
+def load_sparse4d_model(ckpt_path: str):
+    """Load Sparse4D model and return the DeformableFeatureAggregation module."""
+    from mmcv import Config
+    from mmdet3d.models import build_model
+
+    cfg_path = os.path.join(
+        os.path.dirname(ckpt_path),
+        "sparse4dv3_temporal_r50_1x8_bs6_256x704.py",
+    )
+    if not os.path.exists(cfg_path):
+        cfg_path = os.path.expanduser(
+            "~/project/Sparse4D/projects/configs/"
+            "sparse4dv3_temporal_r50_1x8_bs6_256x704.py"
+        )
+
+    cfg = Config.fromfile(cfg_path)
+    model = build_model(cfg.model, test_cfg=cfg.get("test_cfg"))
+
+    if ckpt_path and os.path.exists(ckpt_path):
+        ckpt = torch.load(ckpt_path, map_location="cpu")
+        state_dict = ckpt.get("state_dict", ckpt)
+        model.load_state_dict(state_dict, strict=False)
+        print(f"  Loaded checkpoint: {ckpt_path}")
+
+    model.eval()
+    return model
+
+
+# Anchor indices
+X, Y, Z = 0, 1, 2
+W, L, H = 3, 4, 5
+SIN_YAW, COS_YAW = 6, 7
+VX, VY, VZ = 8, 9, 10
+
+
+def create_dummy_inputs(
+    bs: int = 1,
+    num_anchor: int = 900,
+    num_cams: int = 6,
+    embed_dims: int = 256,
+    spatial_shapes: list = None,
+):
+    """Create dummy inputs for DFA testing."""
+    if spatial_shapes is None:
+        spatial_shapes = [(64, 176), (32, 88), (16, 44), (8, 22)]
+
+    torch.manual_seed(42)
+
+    instance_feature = torch.randn(bs, num_anchor, embed_dims)
+    anchor = torch.randn(bs, num_anchor, 11)
+    anchor[..., W:H + 1] = torch.randn(bs, num_anchor, 3) * 0.5
+    yaw = torch.randn(bs, num_anchor, 1)
+    anchor[..., SIN_YAW] = torch.sin(yaw).squeeze(-1)
+    anchor[..., COS_YAW] = torch.cos(yaw).squeeze(-1)
+
+    anchor_embed = torch.randn(bs, num_anchor, embed_dims)
+    projection_mat = torch.randn(bs, num_cams, 4, 4)
+    image_wh = torch.tensor([[704.0, 256.0]]).unsqueeze(0).expand(bs, num_cams, 2).contiguous()
+
+    feature_maps_pt = []
+    for h, w in spatial_shapes:
+        fm = torch.randn(bs, num_cams, embed_dims, h, w)
+        feature_maps_pt.append(fm)
+
+    metas = {
+        "projection_mat": projection_mat,
+        "image_wh": image_wh,
+    }
+
+    return instance_feature, anchor, anchor_embed, feature_maps_pt, metas
+
+
+# ============================================================
+# Standalone PyTorch reference DFA (no mmcv/mmdet dependency)
+# ============================================================
+
+class _KPSGenerator(torch.nn.Module):
+    """Pure PyTorch SparseBox3DKeyPointsGenerator."""
+    def __init__(self, embed_dims=256, num_learnable_pts=6, fix_scale=None):
+        super().__init__()
+        if fix_scale is None:
+            fix_scale = [[0, 0, 0]]
+        self.fix_scale = torch.nn.Parameter(
+            torch.tensor(fix_scale, dtype=torch.float32), requires_grad=False
+        )
+        self.num_pts = len(fix_scale) + num_learnable_pts
+        self.num_learnable_pts = num_learnable_pts
+        if num_learnable_pts > 0:
+            self.learnable_fc = torch.nn.Linear(embed_dims, num_learnable_pts * 3)
+
+    def forward(self, anchor, instance_feature=None):
+        bs, num_anchor = anchor.shape[:2]
+        size = anchor[..., None, [W, L, H]].exp()
+        key_points = self.fix_scale * size
+        if self.num_learnable_pts > 0 and instance_feature is not None:
+            learnable_scale = (
+                self.learnable_fc(instance_feature)
+                .reshape(bs, num_anchor, self.num_learnable_pts, 3)
+                .sigmoid() - 0.5
+            )
+            key_points = torch.cat([key_points, learnable_scale * size], dim=-2)
+
+        rotation_mat = anchor.new_zeros([bs, num_anchor, 3, 3])
+        rotation_mat[:, :, 0, 0] = anchor[:, :, COS_YAW]
+        rotation_mat[:, :, 0, 1] = -anchor[:, :, SIN_YAW]
+        rotation_mat[:, :, 1, 0] = anchor[:, :, SIN_YAW]
+        rotation_mat[:, :, 1, 1] = anchor[:, :, COS_YAW]
+        rotation_mat[:, :, 2, 2] = 1
+        key_points = torch.matmul(
+            rotation_mat[:, :, None], key_points[..., None]
+        ).squeeze(-1)
+        key_points = key_points + anchor[..., None, [X, Y, Z]]
+        return key_points
+
+
+class _PTDeformableFeatureAggregation(torch.nn.Module):
+    """Pure PyTorch DeformableFeatureAggregation (fallback path only)."""
+    def __init__(
+        self, embed_dims=256, num_groups=8, num_levels=4, num_cams=6,
+        num_learnable_pts=6, use_camera_embed=True, residual_mode="cat",
+        fix_scale=None,
+    ):
+        super().__init__()
+        self.embed_dims = embed_dims
+        self.num_groups = num_groups
+        self.group_dims = embed_dims // num_groups
+        self.num_levels = num_levels
+        self.num_cams = num_cams
+        self.residual_mode = residual_mode
+        self.use_deformable_func = False
+
+        self.kps_generator = _KPSGenerator(embed_dims, num_learnable_pts, fix_scale)
+        self.num_pts = self.kps_generator.num_pts
+        self.output_proj = torch.nn.Linear(embed_dims, embed_dims)
+        self.proj_drop = torch.nn.Dropout(0.0)
+
+        if use_camera_embed:
+            self.camera_encoder = torch.nn.Sequential(
+                torch.nn.Linear(12, embed_dims),
+                torch.nn.ReLU(inplace=True),
+                torch.nn.LayerNorm(embed_dims),
+                torch.nn.Linear(embed_dims, embed_dims),
+                torch.nn.ReLU(inplace=True),
+                torch.nn.LayerNorm(embed_dims),
+            )
+            self.weights_fc = torch.nn.Linear(
+                embed_dims, num_groups * num_levels * self.num_pts
+            )
+        else:
+            self.camera_encoder = None
+            self.weights_fc = torch.nn.Linear(
+                embed_dims, num_groups * num_cams * num_levels * self.num_pts
+            )
+
+    def forward(self, instance_feature, anchor, anchor_embed, feature_maps, metas, **kwargs):
+        bs, num_anchor = instance_feature.shape[:2]
+        key_points = self.kps_generator(anchor, instance_feature)
+        weights = self._get_weights(instance_feature, anchor_embed, metas)
+        features = self.feature_sampling(
+            feature_maps, key_points,
+            metas["projection_mat"], metas.get("image_wh"),
+        )
+        features = self.multi_view_level_fusion(features, weights)
+        features = features.sum(dim=2)
+        output = self.proj_drop(self.output_proj(features))
+        if self.residual_mode == "add":
+            output = output + instance_feature
+        elif self.residual_mode == "cat":
+            output = torch.cat([output, instance_feature], dim=-1)
+        return output
+
+    def _get_weights(self, instance_feature, anchor_embed, metas=None):
+        bs, num_anchor = instance_feature.shape[:2]
+        feature = instance_feature + anchor_embed
+        if self.camera_encoder is not None:
+            camera_embed = self.camera_encoder(
+                metas["projection_mat"][:, :, :3].reshape(bs, self.num_cams, -1)
+            )
+            feature = feature[:, :, None] + camera_embed[:, None]
+        weights = (
+            self.weights_fc(feature)
+            .reshape(bs, num_anchor, -1, self.num_groups)
+            .softmax(dim=-2)
+            .reshape(bs, num_anchor, self.num_cams, self.num_levels, self.num_pts, self.num_groups)
+        )
+        return weights
+
+    @staticmethod
+    def project_points(key_points, projection_mat, image_wh=None):
+        pts_extend = torch.cat(
+            [key_points, torch.ones_like(key_points[..., :1])], dim=-1
+        )
+        points_2d = torch.matmul(
+            projection_mat[:, :, None, None], pts_extend[:, None, ..., None]
+        ).squeeze(-1)
+        points_2d = points_2d[..., :2] / torch.clamp(points_2d[..., 2:3], min=1e-5)
+        if image_wh is not None:
+            points_2d = points_2d / image_wh[:, :, None, None]
+        return points_2d
+
+    def feature_sampling(self, feature_maps, key_points, projection_mat, image_wh=None):
+        num_levels = len(feature_maps)
+        num_cams = feature_maps[0].shape[1]
+        bs, num_anchor, num_pts = key_points.shape[:3]
+        points_2d = self.project_points(key_points, projection_mat, image_wh)
+        points_2d = points_2d * 2 - 1
+        points_2d = points_2d.flatten(end_dim=1)
+        features = []
+        for fm in feature_maps:
+            features.append(F.grid_sample(fm.flatten(end_dim=1), points_2d))
+        features = torch.stack(features, dim=1)
+        features = features.reshape(
+            bs, num_cams, num_levels, -1, num_anchor, num_pts
+        ).permute(0, 4, 1, 2, 5, 3)
+        return features
+
+    def multi_view_level_fusion(self, features, weights):
+        bs, num_anchor = weights.shape[:2]
+        features = weights[..., None] * features.reshape(
+            features.shape[:-1] + (self.num_groups, self.group_dims)
+        )
+        features = features.sum(dim=2).sum(dim=2)
+        features = features.reshape(bs, num_anchor, self.num_pts, self.embed_dims)
+        return features
+
+
+def build_pt_dfa():
+    """Build standalone PyTorch DFA (no mmcv dependency)."""
+    return _PTDeformableFeatureAggregation(
+        embed_dims=256, num_groups=8, num_levels=4, num_cams=6,
+        num_learnable_pts=6, use_camera_embed=True, residual_mode="cat",
+        fix_scale=[
+            [0, 0, 0], [0.45, 0, 0], [-0.45, 0, 0],
+            [0, 0.45, 0], [0, -0.45, 0], [0, 0, 0.45],
+            [0, 0, -0.45],
+        ],
+    )
+
+
+def preprocess_dfa_parameters_from_pt(pt_model):
+    """Extract parameters from standalone PT DFA (same interface as preprocess_dfa_parameters)."""
+    params = {}
+    params["kps_fix_scale"] = pt_model.kps_generator.fix_scale.data.clone()
+    params["kps_learnable_fc_weight"] = pt_model.kps_generator.learnable_fc.weight.data.clone()
+    params["kps_learnable_fc_bias"] = pt_model.kps_generator.learnable_fc.bias.data.clone()
+    if pt_model.camera_encoder is not None:
+        enc = pt_model.camera_encoder
+        params["cam_linear1_weight"] = enc[0].weight.data.clone()
+        params["cam_linear1_bias"] = enc[0].bias.data.clone()
+        params["cam_ln1_weight"] = enc[2].weight.data.clone()
+        params["cam_ln1_bias"] = enc[2].bias.data.clone()
+        params["cam_linear2_weight"] = enc[3].weight.data.clone()
+        params["cam_linear2_bias"] = enc[3].bias.data.clone()
+        params["cam_ln2_weight"] = enc[5].weight.data.clone()
+        params["cam_ln2_bias"] = enc[5].bias.data.clone()
+    params["weights_fc_weight"] = pt_model.weights_fc.weight.data.clone()
+    params["weights_fc_bias"] = pt_model.weights_fc.bias.data.clone()
+    params["output_proj_weight"] = pt_model.output_proj.weight.data.clone()
+    params["output_proj_bias"] = pt_model.output_proj.bias.data.clone()
+    return params
+
+
+def pytorch_dfa_forward(pt_model, instance_feature, anchor, anchor_embed, feature_maps, metas):
+    """Run PyTorch DeformableFeatureAggregation forward (fallback path)."""
+    pt_model.eval()
+    with torch.no_grad():
+        if hasattr(pt_model, 'use_deformable_func'):
+            orig_flag = pt_model.use_deformable_func
+            pt_model.use_deformable_func = False
+        output = pt_model(
+            instance_feature=instance_feature,
+            anchor=anchor,
+            anchor_embed=anchor_embed,
+            feature_maps=feature_maps,
+            metas=metas,
+        )
+        if hasattr(pt_model, 'use_deformable_func'):
+            pt_model.use_deformable_func = orig_flag
+    return output
+
+
+# ============================================================
+# Test 1: grid_sample per FPN level
+# ============================================================
+
+def test_grid_sample_pcc(device):
+    """Test ttnn.grid_sample vs torch.grid_sample per FPN level."""
+    print("\n" + "=" * 65)
+    print("  [Test 1] grid_sample: ttnn vs PyTorch (per FPN level)")
+    print("=" * 65)
+
+    spatial_shapes = [(64, 176), (32, 88), (16, 44), (8, 22)]
+    num_cams = 6
+    embed_dims = 256
+    num_anchor = 900
+    num_pts = 13
+
+    torch.manual_seed(42)
+
+    grid = torch.randn(num_cams, num_anchor, num_pts, 2).float()
+    grid = grid.clamp(-1.0, 1.0)
+
+    all_results = []
+    for level_idx, (h, w) in enumerate(spatial_shapes):
+        fm_nchw = torch.randn(num_cams, embed_dims, h, w).float()
+        pt_out = F.grid_sample(
+            fm_nchw, grid, mode="bilinear", align_corners=False, padding_mode="zeros"
+        )
+
+        fm_nhwc = fm_nchw.permute(0, 2, 3, 1).contiguous().to(torch.bfloat16)
+        fm_tt = ttnn.from_torch(
+            fm_nhwc, layout=ttnn.ROW_MAJOR_LAYOUT, device=device
+        )
+        grid_tt = ttnn.from_torch(
+            grid.float(), layout=ttnn.ROW_MAJOR_LAYOUT, device=device
+        )
+
+        tt_out = ttnn.grid_sample(
+            fm_tt, grid_tt, mode="bilinear", align_corners=False, padding_mode="zeros"
+        )
+        tt_out_torch = ttnn.to_torch(tt_out)
+
+        tt_out_nchw = tt_out_torch.permute(0, 3, 1, 2).contiguous()
+
+        result = compare_tensors(
+            pt_out, tt_out_nchw,
+            name=f"Level {level_idx} [{num_cams},{embed_dims},{h},{w}]",
+        )
+        all_results.append(result)
+
+        ttnn.deallocate(fm_tt)
+        ttnn.deallocate(grid_tt)
+        ttnn.deallocate(tt_out)
+
+    print(f"\n  {'Level':<8} {'PCC':>10} {'MaxDiff':>10} {'MeanDiff':>10} {'RelErr':>10} {'Allclose':>10}")
+    print(f"  {'-'*7:<8} {'-'*9:>10} {'-'*9:>10} {'-'*9:>10} {'-'*9:>10} {'-'*9:>10}")
+    for i, r in enumerate(all_results):
+        print(
+            f"  {i:<8} {r['pcc']:>10.6f} {r['max_diff']:>10.4f} "
+            f"{r['mean_diff']:>10.6f} {r['rel_err']:>10.6f} {str(r['allclose']):>10}"
+        )
+
+    avg_pcc = sum(r["pcc"] for r in all_results) / len(all_results)
+    print(f"\n  Average PCC: {avg_pcc:.6f}")
+    return avg_pcc
+
+
+# ============================================================
+# Test 2: End-to-end DFA (device-only)
+# ============================================================
+
+def test_e2e_pcc(device, ckpt_path: str = None, bs: int = 1, num_anchor: int = 900):
+    """Test end-to-end DFA: PyTorch vs TT-NN (device-only)."""
+    print("\n" + "=" * 65)
+    print(f"  [Test 2] End-to-end DFA: PyTorch vs TT-NN (device-only, bs={bs})")
+    print("=" * 65)
+
+    spatial_shapes = [(64, 176), (32, 88), (16, 44), (8, 22)]
+    num_cams = 6
+    embed_dims = 256
+
+    instance_feature, anchor, anchor_embed, feature_maps_pt, metas = (
+        create_dummy_inputs(bs, num_anchor, num_cams, embed_dims, spatial_shapes)
+    )
+
+    if ckpt_path and os.path.exists(ckpt_path):
+        print(f"  Using checkpoint: {ckpt_path}")
+        full_model = load_sparse4d_model(ckpt_path)
+        pt_dfa = None
+        for op in full_model.head.op_config_map.values():
+            if hasattr(op, 'module') and hasattr(op.module, 'kps_generator'):
+                pt_dfa = op.module
+                break
+        if pt_dfa is None:
+            for attr_name in dir(full_model.head):
+                attr = getattr(full_model.head, attr_name)
+                if hasattr(attr, 'kps_generator'):
+                    pt_dfa = attr
+                    break
+        if pt_dfa is None:
+            print("  ERROR: Could not find DeformableFeatureAggregation in model")
+            return 0.0
+    else:
+        print("  Using random weights (no checkpoint)")
+        pt_dfa = build_pt_dfa()
+        pt_dfa.eval()
+
+    if ckpt_path and os.path.exists(ckpt_path):
+        params = preprocess_dfa_parameters(pt_dfa)
+    else:
+        params = preprocess_dfa_parameters_from_pt(pt_dfa)
+
+    model_config = {
+        "MATH_FIDELITY": ttnn.MathFidelity.HiFi4,
+        "WEIGHTS_DTYPE": ttnn.bfloat16,
+        "ACTIVATIONS_DTYPE": ttnn.bfloat16,
+    }
+
+    tt_dfa = DeformableFeatureAggregation(
+        device=device,
+        parameters=params,
+        model_config=model_config,
+        embed_dims=256,
+        num_groups=8,
+        num_levels=4,
+        num_cams=6,
+        num_pts=13,
+        num_learnable_pts=6,
+        use_camera_embed=True,
+        residual_mode="cat",
+    )
+
+    # PyTorch forward
+    with torch.no_grad():
+        pt_output = pytorch_dfa_forward(
+            pt_dfa, instance_feature, anchor, anchor_embed,
+            feature_maps_pt, metas,
+        )
+
+    # Prepare inputs as ttnn tensors on device
+    instance_feature_tt = ttnn.from_torch(
+        instance_feature.float(), layout=ttnn.TILE_LAYOUT, device=device
+    )
+    anchor_tt = ttnn.from_torch(
+        anchor.float(), layout=ttnn.TILE_LAYOUT, device=device
+    )
+    anchor_embed_tt = ttnn.from_torch(
+        anchor_embed.float(), layout=ttnn.TILE_LAYOUT, device=device
+    )
+    projection_mat_tt = ttnn.from_torch(
+        metas["projection_mat"].float(), layout=ttnn.TILE_LAYOUT, device=device
+    )
+    image_wh_tt = ttnn.from_torch(
+        metas["image_wh"].float(), layout=ttnn.TILE_LAYOUT, device=device
+    )
+
+    # Prepare feature maps for TT
+    feature_maps_tt = []
+    for level_idx, (h, w) in enumerate(spatial_shapes):
+        fm_pt = feature_maps_pt[level_idx]
+        fm_flat = fm_pt.reshape(bs * num_cams, embed_dims, h, w)
+        fm_nhwc = fm_flat.permute(0, 2, 3, 1).contiguous()
+        fm_ttnn_format = fm_nhwc.reshape(1, 1, bs * num_cams * h * w, embed_dims)
+        fm_tt = ttnn.from_torch(
+            fm_ttnn_format.float(),
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=device,
+        )
+        feature_maps_tt.append(fm_tt)
+
+    # TT forward (device-only)
+    with torch.no_grad():
+        tt_output = tt_dfa.run(
+            instance_feature_tt,
+            anchor_tt,
+            anchor_embed_tt,
+            feature_maps_tt,
+            projection_mat_tt,
+            image_wh_tt,
+            spatial_shapes,
+            bs=bs,
+            num_anchor=num_anchor,
+        )
+
+    # Convert output to torch for comparison
+    tt_output_torch = ttnn.to_torch(tt_output)
+    # Trim padding if needed (TILE may pad)
+    if tt_output_torch.shape != pt_output.shape:
+        tt_output_torch = tt_output_torch[:bs, :num_anchor, :pt_output.shape[-1]]
+
+    # Full comparison
+    result = compare_tensors(
+        pt_output, tt_output_torch, name=f"DFA E2E Output (device-only, bs={bs})",
+    )
+
+    for fm_tt in feature_maps_tt:
+        ttnn.deallocate(fm_tt)
+
+    return result["pcc"]
+
+
+# ============================================================
+# Main
+# ============================================================
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="DeformableFeatureAggregation PCC Test (device-only)"
+    )
+    parser.add_argument(
+        "--ckpt", type=str, default=None,
+        help="Path to Sparse4D checkpoint (default: random weights)",
+    )
+    parser.add_argument(
+        "--skip-grid-sample", action="store_true",
+        help="Skip grid_sample-only test",
+    )
+    args = parser.parse_args()
+
+    print("=" * 65)
+    print("DeformableFeatureAggregation PCC Test: PyTorch vs TT-NN (device-only)")
+    print("=" * 65)
+
+    device = ttnn.open_device(device_id=0, l1_small_size=24576)
+    try:
+        compute_grid = device.compute_with_storage_grid_size()
+        print(
+            f"  Device: {device.arch()}, "
+            f"grid: {compute_grid.x}x{compute_grid.y}"
+        )
+
+        gs_pcc = None
+        if not args.skip_grid_sample:
+            gs_pcc = test_grid_sample_pcc(device)
+
+        # bs=1: standard inference batch
+        e2e_pcc_bs1 = test_e2e_pcc(device, args.ckpt, bs=1, num_anchor=900)
+
+        # bs=2: multi-batch to verify slice+concat rearrange logic
+        e2e_pcc_bs2 = test_e2e_pcc(device, args.ckpt, bs=2, num_anchor=900)
+
+        print(f"\n{'=' * 65}")
+        print("Final Summary:")
+        if gs_pcc is not None:
+            print(f"  grid_sample avg PCC:     {gs_pcc:.6f}")
+        print(f"  End-to-end DFA PCC bs=1: {e2e_pcc_bs1:.6f}")
+        print(f"  End-to-end DFA PCC bs=2: {e2e_pcc_bs2:.6f}")
+
+    except Exception as e:
+        import traceback
+        traceback.print_exc()
+        print(f"  FAILED: {str(e)[:100]}")
+
+    finally:
+        ttnn.close_device(device)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Implement 

Deformable feature aggregation block in Sparse4D

  - kps_generator: anchor → 3D key points (ttnn.slice, ttnn.exp, ttnn.linear, ttnn.sigmoid, yaw rotation via element-wise ops)
  - project_points: 3D → 2D per-camera projection (homogeneous coords, ttnn.matmul, perspective divide via ttnn.reciprocal, per-camera loop)
  - camera_encoder: projection_mat → camera embedding (ttnn.linear → ttnn.relu → ttnn.layer_norm × 2)
  - get_weights: instance_feature + anchor_embed + camera_embed → attention weights (ttnn.linear, ttnn.softmax over cams×levels×pts)
  - feature_sampling: ttnn.grid_sample per FPN level, per-camera slice + concat rearrange (no host-device transfer)
  - multi_view_level_fusion: group-wise weighted sum (ttnn.multiply, ttnn.sum)
  - output_proj: ttnn.linear + residual (add / cat mode)
  - device-only forward: no host-device transfer during forward pass
  - **bs>1 support: per-batch slice + concat for multi-batch inference** → should be optimized(#4)

## Related

#3 

## Test Metrics

  - grid_sample PCC: per-FPN-level ttnn.grid_sample vs torch.nn.functional.grid_sample
  - E2E DFA PCC (bs=1): full forward pass, TT-NN vs PyTorch fallback path (random weights)
  - E2E DFA PCC (bs=2): multi-batch verification
  - Metrics reported: PCC, MaxDiff, MeanDiff, RelErr, Allclose, sample values, top-5 worst diffs
  - Checkpoint support: --ckpt flag for pretrained weight testing

