### PR TITLE
feat: implement multihaed_attention

### DIFF
--- a/model/multihead_attention.py
+++ b/model/multihead_attention.py
@@ -1,0 +1,206 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+# =============================================================================
+# MultiheadAttention for TT Devices
+#
+# Implements mmcv's MultiheadAttention wrapper around nn.MultiheadAttention
+# using ttnn ops. Used as "gnn" (self-attention) and "temp_gnn" (cross-attention)
+# in the Sparse4D decoder.
+#
+# Forward flow:
+#   1. Q/K/V linear projections (from in_proj_weight/bias)
+#   2. Multi-head reshape + transpose
+#   3. Scaled dot-product attention: softmax(QK^T / sqrt(d)) * V
+#   4. Output projection (out_proj)
+#   5. Residual connection: identity + output
+#
+# In Sparse4D with decouple_attn=True:
+#   - query = cat([instance_feature, anchor_embed], dim=-1)  [bs, N, 512]
+#   - key = cat([key, key_pos], dim=-1) or query             [bs, M, 512]
+#   - value = fc_before(value)                                [bs, M, 512]
+#   - output = fc_after(MHA(query, key, value))               [bs, N, 256]
+# =============================================================================
+
+import torch
+import ttnn
+
+
+class MultiheadAttention:
+    """TT-NN implementation of multi-head attention.
+
+    Mirrors mmcv.cnn.bricks.transformer.MultiheadAttention behavior:
+    - Wraps scaled dot-product attention with Q/K/V projections
+    - Supports both self-attention (key=None) and cross-attention
+    - Includes residual connection (identity + output)
+    - Dropout is skipped (inference only)
+    """
+
+    def __init__(
+        self,
+        device,
+        parameters: dict,
+        embed_dims: int = 512,
+        num_heads: int = 8,
+    ) -> None:
+        self.device = device
+        self.embed_dims = embed_dims
+        self.num_heads = num_heads
+        self.head_dim = embed_dims // num_heads
+
+        # Q, K, V projection weights (already transposed: [in, out] for ttnn.linear)
+        self.w_q = self._to_device(parameters["w_q"])
+        self.b_q = self._to_device_bias(parameters["b_q"])
+        self.w_k = self._to_device(parameters["w_k"])
+        self.b_k = self._to_device_bias(parameters["b_k"])
+        self.w_v = self._to_device(parameters["w_v"])
+        self.b_v = self._to_device_bias(parameters["b_v"])
+
+        # Output projection
+        self.w_out = self._to_device(parameters["w_out"])
+        self.b_out = self._to_device_bias(parameters["b_out"])
+
+        # Precompute scale factor on device
+        self.scale = ttnn.from_torch(
+            torch.full((1, 1, 1, 1), self.head_dim**-0.5),
+            layout=ttnn.TILE_LAYOUT,
+            device=self.device,
+        )
+
+    def _to_device(self, tensor: torch.Tensor) -> ttnn.Tensor:
+        if tensor.dim() == 1:
+            tensor = tensor.unsqueeze(0)
+        return ttnn.from_torch(
+            tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device
+        )
+
+    def _to_device_bias(self, tensor: torch.Tensor) -> ttnn.Tensor:
+        if tensor.dim() == 1:
+            tensor = tensor.reshape(1, 1, 1, -1)
+        return ttnn.from_torch(
+            tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device
+        )
+
+    def run(
+        self,
+        query: ttnn.Tensor,
+        key: ttnn.Tensor,
+        value: ttnn.Tensor,
+        bs: int,
+        num_queries: int,
+        num_keys: int,
+    ) -> ttnn.Tensor:
+        """Forward pass of multi-head attention.
+
+        Implements: identity + out_proj(softmax(QK^T/sqrt(d)) @ V)
+        where identity = query (residual connection).
+
+        Args:
+            query: [bs, num_queries, embed_dims] on device (TILE)
+            key: [bs, num_keys, embed_dims] on device (TILE)
+            value: [bs, num_keys, embed_dims] on device (TILE)
+            bs: batch size
+            num_queries: number of query tokens
+            num_keys: number of key/value tokens
+
+        Returns:
+            output: [bs, num_queries, embed_dims] on device (TILE)
+        """
+        # Save identity for residual
+        identity = query
+
+        # --- 1. Linear projections ---
+        q = ttnn.reshape(query, (1, 1, bs * num_queries, self.embed_dims))
+        q = ttnn.linear(q, self.w_q, bias=self.b_q)
+
+        k = ttnn.reshape(key, (1, 1, bs * num_keys, self.embed_dims))
+        k = ttnn.linear(k, self.w_k, bias=self.b_k)
+
+        v = ttnn.reshape(value, (1, 1, bs * num_keys, self.embed_dims))
+        v = ttnn.linear(v, self.w_v, bias=self.b_v)
+
+        # --- 2. Multi-head reshape ---
+        # [1, 1, bs*seq, embed] -> [bs, seq, num_heads, head_dim] -> [bs, num_heads, seq, head_dim]
+        q = ttnn.reshape(q, (bs, num_queries, self.num_heads, self.head_dim))
+        q = ttnn.permute(q, (0, 2, 1, 3))  # [bs, num_heads, num_queries, head_dim]
+
+        k = ttnn.reshape(k, (bs, num_keys, self.num_heads, self.head_dim))
+        k = ttnn.permute(k, (0, 2, 1, 3))  # [bs, num_heads, num_keys, head_dim]
+
+        v = ttnn.reshape(v, (bs, num_keys, self.num_heads, self.head_dim))
+        v = ttnn.permute(v, (0, 2, 1, 3))  # [bs, num_heads, num_keys, head_dim]
+
+        # --- 3. Scaled dot-product attention ---
+        # Q @ K^T -> [bs, num_heads, num_queries, num_keys]
+        k_t = ttnn.transpose(k, -2, -1)  # [bs, num_heads, head_dim, num_keys]
+        attn_weights = ttnn.matmul(q, k_t)
+        attn_weights = ttnn.multiply(attn_weights, self.scale)
+
+        # Softmax over keys dimension
+        attn_weights = ttnn.softmax(attn_weights, dim=-1)
+
+        # Attention output: [bs, num_heads, num_queries, head_dim]
+        attn_output = ttnn.matmul(attn_weights, v)
+
+        # --- 4. Reshape back ---
+        # [bs, num_heads, num_queries, head_dim] -> [bs, num_queries, num_heads, head_dim]
+        attn_output = ttnn.permute(attn_output, (0, 2, 1, 3))
+        attn_output = ttnn.reshape(
+            attn_output, (1, 1, bs * num_queries, self.embed_dims)
+        )
+
+        # --- 5. Output projection ---
+        output = ttnn.linear(attn_output, self.w_out, bias=self.b_out)
+
+        # --- 6. Residual connection ---
+        identity_flat = ttnn.reshape(
+            identity, (1, 1, bs * num_queries, self.embed_dims)
+        )
+        output = ttnn.add(output, identity_flat)
+        output = ttnn.reshape(output, (bs, num_queries, self.embed_dims))
+
+        return output
+
+
+def preprocess_mha_parameters(pt_mha_layer) -> dict:
+    """Extract parameters from mmcv MultiheadAttention.
+
+    mmcv's MultiheadAttention wraps nn.MultiheadAttention which stores:
+    - attn.in_proj_weight: [3*embed_dims, embed_dims]
+    - attn.in_proj_bias: [3*embed_dims]
+    - attn.out_proj.weight: [embed_dims, embed_dims]
+    - attn.out_proj.bias: [embed_dims]
+
+    We split in_proj into separate Q, K, V weights and transpose
+    for ttnn.linear (expects [in_features, out_features]).
+
+    Args:
+        pt_mha_layer: mmcv MultiheadAttention instance
+
+    Returns:
+        dict of torch tensors
+    """
+    params = {}
+    attn = pt_mha_layer.attn
+
+    # Split in_proj_weight [3*E, E] into Q, K, V each [E, E]
+    in_proj_weight = attn.in_proj_weight.data.clone()
+    w_q, w_k, w_v = in_proj_weight.chunk(3, dim=0)
+    # Transpose: nn.Linear [out, in] -> ttnn.linear [in, out]
+    params["w_q"] = w_q.t()
+    params["w_k"] = w_k.t()
+    params["w_v"] = w_v.t()
+
+    # Split in_proj_bias [3*E] into Q, K, V
+    in_proj_bias = attn.in_proj_bias.data.clone()
+    b_q, b_k, b_v = in_proj_bias.chunk(3, dim=0)
+    params["b_q"] = b_q
+    params["b_k"] = b_k
+    params["b_v"] = b_v
+
+    # Output projection
+    params["w_out"] = attn.out_proj.weight.data.clone().t()
+    params["b_out"] = attn.out_proj.bias.data.clone()
+
+    return params

--- a/test/mha_pcc.py
+++ b/test/mha_pcc.py
@@ -1,0 +1,376 @@
+"""
+MultiheadAttention PCC Test: PyTorch vs TT-NN
+
+Compares the TT-NN MultiheadAttention against PyTorch's nn.MultiheadAttention
+for numerical accuracy.
+
+Tests:
+  1. Self-attention (gnn): query = key (900 anchors)
+  2. Cross-attention (temp_gnn): query (900) vs key (600 temporal anchors)
+  3. Full graph_model flow with decouple_attn (fc_before + MHA + fc_after)
+
+Usage:
+  python test/mha_pcc.py
+"""
+
+import os
+import sys
+
+TT_METAL_HOME = os.environ.get(
+    "TT_METAL_HOME", os.path.expanduser("~/project/tt-metal")
+)
+sys.path.insert(0, TT_METAL_HOME)
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import torch
+import torch.nn as nn
+import ttnn
+
+from model.multihead_attention import MultiheadAttention, preprocess_mha_parameters
+
+
+# ============================================================
+# Comparison Utilities
+# ============================================================
+
+def compute_pcc(a: torch.Tensor, b: torch.Tensor) -> float:
+    a = a.double().flatten()
+    b = b.double().flatten()
+    a = a - a.mean()
+    b = b - b.mean()
+    denom = a.norm() * b.norm()
+    if denom == 0:
+        return 1.0 if a.norm() == 0 and b.norm() == 0 else 0.0
+    return (torch.dot(a, b) / denom).item()
+
+
+def compare_tensors(
+    pt: torch.Tensor,
+    tt: torch.Tensor,
+    name: str,
+    atol: float = 1e-2,
+    rtol: float = 1e-2,
+    num_samples: int = 10,
+):
+    pt_f = pt.float()
+    tt_f = tt.float()
+    diff = (pt_f - tt_f).abs()
+
+    pcc = compute_pcc(pt, tt)
+    max_diff = diff.max().item()
+    mean_diff = diff.mean().item()
+    allclose = torch.allclose(pt_f, tt_f, atol=atol, rtol=rtol)
+
+    print(f"\n  --- {name} ---")
+    print(f"  Shape:     {list(pt.shape)}")
+    print(f"  PCC:       {pcc:.6f}")
+    print(f"  MaxDiff:   {max_diff:.6f}")
+    print(f"  MeanDiff:  {mean_diff:.6f}")
+    print(f"  Allclose:  {allclose}  (atol={atol}, rtol={rtol})")
+
+    pt_flat = pt_f.flatten()
+    tt_flat = tt_f.flatten()
+    n = min(num_samples, pt_flat.numel())
+    print(f"\n  Sample values (first {n}):")
+    print(f"  {'Index':<8} {'PyTorch':>12} {'TT-NN':>12} {'Diff':>12}")
+    print(f"  {'-'*7:<8} {'-'*11:>12} {'-'*11:>12} {'-'*11:>12}")
+    for i in range(n):
+        d = (pt_flat[i] - tt_flat[i]).abs().item()
+        print(f"  {i:<8} {pt_flat[i].item():>12.6f} {tt_flat[i].item():>12.6f} {d:>12.6f}")
+
+    diff_flat = diff.flatten()
+    _, worst_indices = diff_flat.topk(min(5, diff_flat.numel()))
+    print(f"\n  Top-5 worst diffs:")
+    print(f"  {'Index':<8} {'PyTorch':>12} {'TT-NN':>12} {'Diff':>12}")
+    print(f"  {'-'*7:<8} {'-'*11:>12} {'-'*11:>12} {'-'*11:>12}")
+    for idx in worst_indices:
+        i = idx.item()
+        d = diff_flat[i].item()
+        print(f"  {i:<8} {pt_flat[i].item():>12.6f} {tt_flat[i].item():>12.6f} {d:>12.6f}")
+
+    return {"pcc": pcc, "max_diff": max_diff, "mean_diff": mean_diff, "allclose": allclose}
+
+
+# ============================================================
+# PyTorch reference (standalone, no mmcv dependency)
+# ============================================================
+
+class _PTMultiheadAttention(nn.Module):
+    """Mimics mmcv MultiheadAttention behavior for testing."""
+
+    def __init__(self, embed_dims=512, num_heads=8, dropout=0.0):
+        super().__init__()
+        self.embed_dims = embed_dims
+        self.num_heads = num_heads
+        self.batch_first = True
+        self.attn = nn.MultiheadAttention(
+            embed_dims, num_heads, dropout=dropout, batch_first=False
+        )
+        self.proj_drop = nn.Dropout(0.0)
+
+    def forward(self, query, key=None, value=None, identity=None, **kwargs):
+        if key is None:
+            key = query
+        if value is None:
+            value = key
+        if identity is None:
+            identity = query
+
+        # mmcv batch_first: transpose to (seq, batch, dim)
+        query = query.transpose(0, 1)
+        key = key.transpose(0, 1)
+        value = value.transpose(0, 1)
+
+        out = self.attn(query=query, key=key, value=value)[0]
+
+        out = out.transpose(0, 1)
+        return identity + self.proj_drop(out)
+
+
+def preprocess_mha_parameters_from_pt(pt_mha: _PTMultiheadAttention) -> dict:
+    """Extract MHA parameters from standalone PyTorch model."""
+    params = {}
+    attn = pt_mha.attn
+
+    in_proj_weight = attn.in_proj_weight.data.clone()
+    w_q, w_k, w_v = in_proj_weight.chunk(3, dim=0)
+    params["w_q"] = w_q.t()
+    params["w_k"] = w_k.t()
+    params["w_v"] = w_v.t()
+
+    in_proj_bias = attn.in_proj_bias.data.clone()
+    b_q, b_k, b_v = in_proj_bias.chunk(3, dim=0)
+    params["b_q"] = b_q
+    params["b_k"] = b_k
+    params["b_v"] = b_v
+
+    params["w_out"] = attn.out_proj.weight.data.clone().t()
+    params["b_out"] = attn.out_proj.bias.data.clone()
+
+    return params
+
+
+# ============================================================
+# Test 1: Self-attention (gnn)
+# ============================================================
+
+def test_self_attention(device, bs=1, num_anchor=900, embed_dims=512, num_heads=8):
+    """Self-attention: query = key = value."""
+    print("\n" + "=" * 65)
+    print(f"  [Test 1] Self-attention (gnn), bs={bs}, anchors={num_anchor}")
+    print("=" * 65)
+
+    torch.manual_seed(42)
+
+    pt_mha = _PTMultiheadAttention(embed_dims, num_heads)
+    pt_mha.eval()
+
+    query = torch.randn(bs, num_anchor, embed_dims)
+
+    # PyTorch forward (self-attention: key=None, value=None)
+    with torch.no_grad():
+        pt_output = pt_mha(query)
+
+    # TT-NN forward
+    params = preprocess_mha_parameters_from_pt(pt_mha)
+    tt_mha = MultiheadAttention(device, params, embed_dims, num_heads)
+
+    query_tt = ttnn.from_torch(
+        query.float(), layout=ttnn.TILE_LAYOUT, device=device
+    )
+
+    tt_output = tt_mha.run(
+        query=query_tt,
+        key=query_tt,
+        value=query_tt,
+        bs=bs,
+        num_queries=num_anchor,
+        num_keys=num_anchor,
+    )
+
+    tt_output_torch = ttnn.to_torch(tt_output)
+    if tt_output_torch.shape != pt_output.shape:
+        tt_output_torch = tt_output_torch[:bs, :num_anchor, :embed_dims]
+
+    result = compare_tensors(pt_output, tt_output_torch, "Self-attention output")
+    return result["pcc"]
+
+
+# ============================================================
+# Test 2: Cross-attention (temp_gnn)
+# ============================================================
+
+def test_cross_attention(
+    device, bs=1, num_queries=900, num_keys=600,
+    embed_dims=512, num_heads=8,
+):
+    """Cross-attention: different query and key/value lengths."""
+    print("\n" + "=" * 65)
+    print(f"  [Test 2] Cross-attention (temp_gnn), bs={bs}, Q={num_queries}, K={num_keys}")
+    print("=" * 65)
+
+    torch.manual_seed(123)
+
+    pt_mha = _PTMultiheadAttention(embed_dims, num_heads)
+    pt_mha.eval()
+
+    query = torch.randn(bs, num_queries, embed_dims)
+    key = torch.randn(bs, num_keys, embed_dims)
+    value = torch.randn(bs, num_keys, embed_dims)
+
+    with torch.no_grad():
+        pt_output = pt_mha(query, key, value)
+
+    params = preprocess_mha_parameters_from_pt(pt_mha)
+    tt_mha = MultiheadAttention(device, params, embed_dims, num_heads)
+
+    query_tt = ttnn.from_torch(query.float(), layout=ttnn.TILE_LAYOUT, device=device)
+    key_tt = ttnn.from_torch(key.float(), layout=ttnn.TILE_LAYOUT, device=device)
+    value_tt = ttnn.from_torch(value.float(), layout=ttnn.TILE_LAYOUT, device=device)
+
+    tt_output = tt_mha.run(
+        query=query_tt,
+        key=key_tt,
+        value=value_tt,
+        bs=bs,
+        num_queries=num_queries,
+        num_keys=num_keys,
+    )
+
+    tt_output_torch = ttnn.to_torch(tt_output)
+    if tt_output_torch.shape != pt_output.shape:
+        tt_output_torch = tt_output_torch[:bs, :num_queries, :embed_dims]
+
+    result = compare_tensors(pt_output, tt_output_torch, "Cross-attention output")
+    return result["pcc"]
+
+
+# ============================================================
+# Test 3: Full graph_model flow (decouple_attn)
+# ============================================================
+
+def test_graph_model_flow(device, bs=1, num_anchor=900, embed_dims=256, num_heads=8):
+    """Full Sparse4D graph_model flow with decouple_attn=True.
+
+    Flow:
+      1. query = cat([instance_feature, anchor_embed], dim=-1)  [bs, N, 512]
+      2. value = fc_before(instance_feature)                    [bs, N, 512]
+      3. MHA self-attention (key=query)
+      4. output = fc_after(mha_output)                          [bs, N, 256]
+    """
+    print("\n" + "=" * 65)
+    print(f"  [Test 3] Full graph_model (decouple_attn), bs={bs}, anchors={num_anchor}")
+    print("=" * 65)
+
+    torch.manual_seed(456)
+    mha_embed = embed_dims * 2  # 512
+
+    # Build PyTorch modules
+    pt_mha = _PTMultiheadAttention(mha_embed, num_heads)
+    fc_before = nn.Linear(embed_dims, mha_embed, bias=False)
+    fc_after = nn.Linear(mha_embed, embed_dims, bias=False)
+    pt_mha.eval()
+    fc_before.eval()
+    fc_after.eval()
+
+    # Inputs
+    instance_feature = torch.randn(bs, num_anchor, embed_dims)
+    anchor_embed = torch.randn(bs, num_anchor, embed_dims)
+
+    # PyTorch forward
+    with torch.no_grad():
+        query = torch.cat([instance_feature, anchor_embed], dim=-1)  # [bs, N, 512]
+        value = fc_before(instance_feature)  # [bs, N, 512]
+        mha_out = pt_mha(query, key=None, value=value)  # [bs, N, 512]
+        pt_output = fc_after(mha_out)  # [bs, N, 256]
+
+    # TT-NN forward
+    mha_params = preprocess_mha_parameters_from_pt(pt_mha)
+    tt_mha = MultiheadAttention(device, mha_params, mha_embed, num_heads)
+
+    # fc_before/after weights on device
+    fc_before_w = ttnn.from_torch(
+        fc_before.weight.data.t().float(), layout=ttnn.TILE_LAYOUT, device=device
+    )
+    fc_after_w = ttnn.from_torch(
+        fc_after.weight.data.t().float(), layout=ttnn.TILE_LAYOUT, device=device
+    )
+
+    # Inputs on device
+    inst_tt = ttnn.from_torch(
+        instance_feature.float(), layout=ttnn.TILE_LAYOUT, device=device
+    )
+    anc_embed_tt = ttnn.from_torch(
+        anchor_embed.float(), layout=ttnn.TILE_LAYOUT, device=device
+    )
+
+    # Step 1: cat([instance_feature, anchor_embed])
+    query_tt = ttnn.concat([inst_tt, anc_embed_tt], dim=-1)  # [bs, N, 512]
+
+    # Step 2: fc_before(instance_feature)
+    inst_flat = ttnn.reshape(inst_tt, (1, 1, bs * num_anchor, embed_dims))
+    value_tt = ttnn.linear(inst_flat, fc_before_w)  # [1, 1, bs*N, 512]
+    value_tt = ttnn.reshape(value_tt, (bs, num_anchor, mha_embed))
+
+    # Step 3: MHA
+    mha_out_tt = tt_mha.run(
+        query=query_tt,
+        key=query_tt,
+        value=value_tt,
+        bs=bs,
+        num_queries=num_anchor,
+        num_keys=num_anchor,
+    )
+
+    # Step 4: fc_after
+    mha_out_flat = ttnn.reshape(mha_out_tt, (1, 1, bs * num_anchor, mha_embed))
+    output_tt = ttnn.linear(mha_out_flat, fc_after_w)  # [1, 1, bs*N, 256]
+    output_tt = ttnn.reshape(output_tt, (bs, num_anchor, embed_dims))
+
+    tt_output_torch = ttnn.to_torch(output_tt)
+    if tt_output_torch.shape != pt_output.shape:
+        tt_output_torch = tt_output_torch[:bs, :num_anchor, :embed_dims]
+
+    result = compare_tensors(pt_output, tt_output_torch, "graph_model output (decouple_attn)")
+    return result["pcc"]
+
+
+# ============================================================
+# Main
+# ============================================================
+
+def main():
+    print("=" * 65)
+    print("MultiheadAttention PCC Test: PyTorch vs TT-NN")
+    print("=" * 65)
+
+    device = ttnn.open_device(device_id=0, l1_small_size=24576)
+    try:
+        compute_grid = device.compute_with_storage_grid_size()
+        print(
+            f"  Device: {device.arch()}, "
+            f"grid: {compute_grid.x}x{compute_grid.y}"
+        )
+
+        pcc_self = test_self_attention(device, bs=1, num_anchor=900)
+        pcc_cross = test_cross_attention(device, bs=1, num_queries=900, num_keys=600)
+        pcc_graph = test_graph_model_flow(device, bs=1, num_anchor=900)
+
+        print(f"\n{'=' * 65}")
+        print("Final Summary:")
+        print(f"  Self-attention PCC:       {pcc_self:.6f}")
+        print(f"  Cross-attention PCC:      {pcc_cross:.6f}")
+        print(f"  graph_model flow PCC:     {pcc_graph:.6f}")
+        print(f"{'=' * 65}")
+
+    except Exception as e:
+        import traceback
+        traceback.print_exc()
+        print(f"  FAILED: {str(e)[:200]}")
+
+    finally:
+        ttnn.close_device(device)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Implement 

Multihead Attention block in Sparse4D

| Operation          | ttnn op                           |
|--------------------|-----------------------------------|
| Q/K/V Projection   | ttnn.linear(input, weight, bias)  |
| Head Splitting     | ttnn.reshape + ttnn.permute       |
| QK^T               | ttnn.matmul(Q, K^T)               |
| K Transpose        | ttnn.transpose(K, -2, -1)         |
| Scale              | ttnn.multiply(attn, scale_tensor) |
| Softmax            | ttnn.softmax(attn, dim=-1)        |
| attn @ V           | ttnn.matmul(attn, V)              |
| Out Projection     | ttnn.linear                       |
| Residual           | ttnn.add(output, identity)        |
| Dropout            | Omitted (no-op in inference)      |

## Related

#1 

## Test Metrics

  - self attention `pcc`, `Max diff`, `Mean diff`
  - cross attention `pcc`, `Max diff`, `Mean diff`
  - full graph module `pcc`, `Max diff`, `Mean diff`
