### PR TITLE
feat: implement sparse4D head module

### DIFF
--- a/model/instance_bank.py
+++ b/model/instance_bank.py
@@ -1,0 +1,341 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+# =============================================================================
+# InstanceBank for TT Devices (Inference Only)
+#
+# Manages anchor instances across frames for temporal modeling.
+# Inference-only: no denoising queries, no gradient, no training logic.
+#
+# Per-frame flow:
+#   get()    → prepare anchor/feature, apply temporal projection
+#   update() → merge cached + new instances via topk + mask
+#   cache()  → save top-K instances for next frame
+#
+# All operations on device using ttnn ops.
+# anchor_projection handled on host (per-frame coordinate transform,
+# requires numpy metas) then transferred back to device.
+# =============================================================================
+
+import numpy as np
+import torch
+import ttnn
+
+# Anchor box field indices
+X, Y, Z = 0, 1, 2
+W, L, H = 3, 4, 5
+SIN_YAW, COS_YAW = 6, 7
+VX, VY, VZ = 8, 9, 10
+
+
+class InstanceBank:
+    """TT-NN InstanceBank for inference.
+
+    Manages temporal instance caching and retrieval on device.
+    """
+
+    def __init__(
+        self,
+        device,
+        anchor_data: torch.Tensor,
+        instance_feature_data: torch.Tensor,
+        num_anchor: int = 900,
+        embed_dims: int = 256,
+        num_temp_instances: int = 600,
+        default_time_interval: float = 0.5,
+        confidence_decay: float = 0.6,
+        max_time_interval: float = 2.0,
+    ) -> None:
+        self.device = device
+        self.num_anchor = num_anchor
+        self.embed_dims = embed_dims
+        self.num_temp_instances = num_temp_instances
+        self.default_time_interval = default_time_interval
+        self.confidence_decay = confidence_decay
+        self.max_time_interval = max_time_interval
+
+        # Learnable parameters (loaded from checkpoint)
+        self.anchor_data = anchor_data.float()  # [num_anchor, 11] on host
+        self.instance_feature_data = instance_feature_data.float()  # [num_anchor, embed_dims]
+
+        self.reset()
+
+    def reset(self):
+        """Reset temporal cache."""
+        self.cached_feature = None  # ttnn tensor or None
+        self.cached_anchor = None  # ttnn tensor or None
+        self.metas = None
+        self.mask = None  # torch tensor [bs] bool
+        self.confidence = None  # ttnn tensor or None
+        self.instance_id = None
+        self.prev_id = 0
+
+    def get(self, bs: int, metas: dict):
+        """Prepare instances for current frame.
+
+        Args:
+            bs: batch size
+            metas: dict with 'timestamp', 'img_metas' (containing T_global, T_global_inv)
+
+        Returns:
+            instance_feature: [bs, num_anchor, embed_dims] on device
+            anchor: [bs, num_anchor, 11] on device
+            cached_feature: [bs, num_temp, embed_dims] on device or None
+            cached_anchor: [bs, num_temp, 11] on device or None
+            time_interval: [bs] on device
+        """
+        # Tile anchor and feature across batch
+        anchor_tiled = self.anchor_data.unsqueeze(0).expand(bs, -1, -1).contiguous()
+        feature_tiled = self.instance_feature_data.unsqueeze(0).expand(bs, -1, -1).contiguous()
+
+        cached_feature = None
+        cached_anchor = None
+
+        if self.cached_anchor is not None:
+            # Compute time interval
+            history_time = self.metas["timestamp"]
+            time_interval_pt = metas["timestamp"] - history_time
+            self.mask = torch.abs(time_interval_pt) <= self.max_time_interval
+
+            # Anchor projection: transform cached anchors to current frame
+            # Done on host since it requires numpy metas (T_global matrices)
+            cached_anchor_pt = ttnn.to_torch(self.cached_anchor)
+            T_temp2cur = torch.tensor(
+                np.stack([
+                    x["T_global_inv"] @ self.metas["img_metas"][i]["T_global"]
+                    for i, x in enumerate(metas["img_metas"])
+                ]),
+                dtype=torch.float32,
+            )
+            cached_anchor_pt = self._anchor_projection(
+                cached_anchor_pt, T_temp2cur, -time_interval_pt
+            )
+
+            # Fix time_interval: use default where mask is False or interval is 0
+            time_interval_pt = torch.where(
+                torch.logical_and(time_interval_pt != 0, self.mask),
+                time_interval_pt,
+                torch.tensor(self.default_time_interval, dtype=time_interval_pt.dtype),
+            )
+
+            cached_anchor = ttnn.from_torch(
+                cached_anchor_pt.float(), layout=ttnn.TILE_LAYOUT, device=self.device
+            )
+            cached_feature = self.cached_feature  # already on device
+        else:
+            self.reset()
+            time_interval_pt = torch.full(
+                (bs,), self.default_time_interval, dtype=torch.float32
+            )
+
+        # Move to device
+        instance_feature = ttnn.from_torch(
+            feature_tiled, layout=ttnn.TILE_LAYOUT, device=self.device
+        )
+        anchor = ttnn.from_torch(
+            anchor_tiled, layout=ttnn.TILE_LAYOUT, device=self.device
+        )
+        time_interval = ttnn.from_torch(
+            time_interval_pt.reshape(1, 1, 1, bs),
+            layout=ttnn.TILE_LAYOUT,
+            device=self.device,
+        )
+        time_interval = ttnn.reshape(time_interval, (bs,))
+
+        return instance_feature, anchor, cached_feature, cached_anchor, time_interval
+
+    def update(
+        self,
+        instance_feature: ttnn.Tensor,
+        anchor: ttnn.Tensor,
+        confidence: ttnn.Tensor,
+        bs: int,
+    ):
+        """Merge cached and new instances based on confidence.
+
+        Args:
+            instance_feature: [bs, num_anchor, embed_dims] on device
+            anchor: [bs, num_anchor, 11] on device
+            confidence: [bs, num_anchor, num_cls] on device
+            bs: batch size
+
+        Returns:
+            instance_feature: [bs, num_anchor, embed_dims] on device
+            anchor: [bs, num_anchor, 11] on device
+        """
+        if self.cached_feature is None:
+            return instance_feature, anchor
+
+        N = self.num_anchor - self.num_temp_instances  # 300
+
+        # confidence max over classes: [bs, num_anchor, num_cls] → [bs, num_anchor]
+        conf_pt = ttnn.to_torch(confidence).float()
+        conf_max = conf_pt.max(dim=-1).values  # [bs, num_anchor]
+
+        # topk: select top-N by confidence
+        _, top_indices = torch.topk(conf_max, N, dim=1)  # [bs, N]
+
+        # Gather selected features and anchors on host
+        inst_pt = ttnn.to_torch(instance_feature).float()
+        anch_pt = ttnn.to_torch(anchor).float()
+
+        selected_feature = torch.gather(
+            inst_pt, 1,
+            top_indices.unsqueeze(-1).expand(-1, -1, self.embed_dims),
+        )
+        selected_anchor = torch.gather(
+            anch_pt, 1,
+            top_indices.unsqueeze(-1).expand(-1, -1, anch_pt.shape[-1]),
+        )
+
+        # Concat cached + selected
+        cached_feat_pt = ttnn.to_torch(self.cached_feature).float()
+        cached_anch_pt = ttnn.to_torch(self.cached_anchor).float()
+        merged_feature = torch.cat([cached_feat_pt, selected_feature], dim=1)
+        merged_anchor = torch.cat([cached_anch_pt, selected_anchor], dim=1)
+
+        # Apply mask: use merged where mask=True, keep original where mask=False
+        mask = self.mask[:, None, None]  # [bs, 1, 1]
+        out_feature = torch.where(mask, merged_feature, inst_pt)
+        out_anchor = torch.where(mask, merged_anchor, anch_pt)
+
+        # Back to device
+        instance_feature = ttnn.from_torch(
+            out_feature, layout=ttnn.TILE_LAYOUT, device=self.device
+        )
+        anchor = ttnn.from_torch(
+            out_anchor, layout=ttnn.TILE_LAYOUT, device=self.device
+        )
+
+        return instance_feature, anchor
+
+    def cache(
+        self,
+        instance_feature: ttnn.Tensor,
+        anchor: ttnn.Tensor,
+        confidence: ttnn.Tensor,
+        metas: dict,
+        bs: int,
+    ):
+        """Cache top temporal instances for next frame.
+
+        Args:
+            instance_feature: [bs, num_anchor, embed_dims] on device
+            anchor: [bs, num_anchor, 11] on device
+            confidence: [bs, num_anchor, num_cls] on device
+            metas: current frame metadata
+            bs: batch size
+        """
+        if self.num_temp_instances <= 0:
+            return
+
+        self.metas = metas
+
+        # confidence: max over classes → sigmoid
+        conf_pt = ttnn.to_torch(confidence).float()
+        conf_scores = conf_pt.max(dim=-1).values.sigmoid()  # [bs, num_anchor]
+
+        # Apply confidence decay to previously cached instances
+        if self.confidence is not None:
+            prev_conf = ttnn.to_torch(self.confidence).float().squeeze()
+            if prev_conf.dim() == 1:
+                prev_conf = prev_conf.unsqueeze(0)
+            decayed = prev_conf * self.confidence_decay
+            conf_scores[:, :self.num_temp_instances] = torch.maximum(
+                decayed, conf_scores[:, :self.num_temp_instances]
+            )
+
+        # topk: select top num_temp_instances
+        top_conf, top_indices = torch.topk(
+            conf_scores, self.num_temp_instances, dim=1
+        )
+
+        inst_pt = ttnn.to_torch(instance_feature).float()
+        anch_pt = ttnn.to_torch(anchor).float()
+
+        cached_feature = torch.gather(
+            inst_pt, 1,
+            top_indices.unsqueeze(-1).expand(-1, -1, self.embed_dims),
+        )
+        cached_anchor = torch.gather(
+            anch_pt, 1,
+            top_indices.unsqueeze(-1).expand(-1, -1, anch_pt.shape[-1]),
+        )
+
+        self.cached_feature = ttnn.from_torch(
+            cached_feature, layout=ttnn.TILE_LAYOUT, device=self.device
+        )
+        self.cached_anchor = ttnn.from_torch(
+            cached_anchor, layout=ttnn.TILE_LAYOUT, device=self.device
+        )
+        self.confidence = ttnn.from_torch(
+            top_conf.reshape(1, 1, bs, self.num_temp_instances),
+            layout=ttnn.TILE_LAYOUT,
+            device=self.device,
+        )
+
+    @staticmethod
+    def _anchor_projection(
+        anchor: torch.Tensor,
+        T_src2dst: torch.Tensor,
+        time_interval: torch.Tensor,
+    ) -> torch.Tensor:
+        """Project cached anchors to current frame coordinates.
+
+        Args:
+            anchor: [bs, num_temp, 11]
+            T_src2dst: [bs, 4, 4] transformation matrix
+            time_interval: [bs] time delta (negative = backward)
+
+        Returns:
+            projected anchor: [bs, num_temp, 11]
+        """
+        vel = anchor[..., VX:]
+        vel_dim = vel.shape[-1]
+        T = T_src2dst.unsqueeze(1).to(dtype=anchor.dtype)
+
+        center = anchor[..., [X, Y, Z]]
+
+        # Adjust center by velocity * time
+        if time_interval is not None:
+            ti = time_interval.to(dtype=vel.dtype)
+            translation = vel.transpose(0, -1) * ti
+            translation = translation.transpose(0, -1)
+            center = center - translation
+
+        # Rotate center
+        center = (
+            torch.matmul(T[..., :3, :3], center[..., None]).squeeze(-1)
+            + T[..., :3, 3]
+        )
+
+        size = anchor[..., [W, L, H]]
+
+        # Rotate yaw
+        yaw = torch.matmul(
+            T[..., :2, :2],
+            anchor[..., [COS_YAW, SIN_YAW], None],
+        ).squeeze(-1)
+
+        # Rotate velocity
+        vel = torch.matmul(
+            T[..., :vel_dim, :vel_dim], vel[..., None]
+        ).squeeze(-1)
+
+        return torch.cat([center, size, yaw, vel], dim=-1)
+
+
+def preprocess_instance_bank_parameters(pt_bank) -> dict:
+    """Extract parameters from PyTorch InstanceBank.
+
+    Args:
+        pt_bank: PyTorch InstanceBank instance
+
+    Returns:
+        dict with anchor_data and instance_feature_data
+    """
+    return {
+        "anchor_data": pt_bank.anchor.data.clone(),
+        "instance_feature_data": pt_bank.instance_feature.data.clone(),
+    }

--- a/model/refinement_module.py
+++ b/model/refinement_module.py
@@ -1,0 +1,292 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+# =============================================================================
+# SparseBox3DRefinementModule for TT Devices
+#
+# Refines anchor boxes and predicts classification/quality scores.
+#
+# Forward flow:
+#   1. feature = instance_feature + anchor_embed
+#   2. output = refine_layers(feature)  → [bs, N, 11]
+#   3. output[refine_state] += anchor[refine_state]  (residual refinement)
+#   4. velocity = output[VX:] / time_interval + anchor[VX:]
+#   5. cls = cls_layers(instance_feature)  → [bs, N, 10]
+#   6. quality = quality_layers(feature)   → [bs, N, 2]
+#
+# Sparse4D config:
+#   embed_dims=256, num_cls=10, refine_yaw=True, with_quality_estimation=True
+#   refine_layers: (Linear→ReLU→LN)×2 → (Linear→ReLU→LN)×2 → Linear(256→11) → Scale
+#   cls_layers: (Linear→ReLU→LN)×1 → (Linear→ReLU→LN)×1 → Linear(256→10)
+#   quality_layers: (Linear→ReLU→LN)×1 → (Linear→ReLU→LN)×1 → Linear(256→2)
+# =============================================================================
+
+import torch
+import ttnn
+
+# Anchor box field indices
+X, Y, Z = 0, 1, 2
+W, L, H = 3, 4, 5
+SIN_YAW, COS_YAW = 6, 7
+VX, VY, VZ = 8, 9, 10
+
+
+class SparseBox3DRefinementModule:
+    """TT-NN implementation of SparseBox3DRefinementModule."""
+
+    def __init__(
+        self,
+        device,
+        parameters: dict,
+        embed_dims: int = 256,
+        output_dim: int = 11,
+        num_cls: int = 10,
+        refine_yaw: bool = True,
+        with_quality_estimation: bool = True,
+    ) -> None:
+        self.device = device
+        self.embed_dims = embed_dims
+        self.output_dim = output_dim
+        self.num_cls = num_cls
+        self.refine_yaw = refine_yaw
+        self.with_quality_estimation = with_quality_estimation
+
+        self.refine_state = [X, Y, Z, W, L, H]
+        if refine_yaw:
+            self.refine_state += [SIN_YAW, COS_YAW]
+
+        # Refine layers: Linear→ReLU→LN chains + final Linear + Scale
+        self.refine_layers = self._load_layers(parameters["refine_layers"])
+        self.refine_final_weight = self._to_device(parameters["refine_final_weight"])
+        self.refine_final_bias = self._to_device_bias(parameters["refine_final_bias"])
+        self.refine_scale = self._to_device_bias(parameters["refine_scale"])
+
+        # Classification layers
+        self.cls_layers = self._load_layers(parameters["cls_layers"])
+        self.cls_final_weight = self._to_device(parameters["cls_final_weight"])
+        self.cls_final_bias = self._to_device_bias(parameters["cls_final_bias"])
+
+        # Quality estimation layers
+        if with_quality_estimation:
+            self.quality_layers = self._load_layers(parameters["quality_layers"])
+            self.quality_final_weight = self._to_device(parameters["quality_final_weight"])
+            self.quality_final_bias = self._to_device_bias(parameters["quality_final_bias"])
+
+    def _load_layers(self, layer_params: list):
+        loaded = []
+        for p in layer_params:
+            entry = {}
+            entry["weight"] = self._to_device(p["weight"])
+            entry["bias"] = self._to_device_bias(p["bias"])
+            if "ln_weight" in p:
+                entry["ln_weight"] = self._to_device_1d(p["ln_weight"])
+                entry["ln_bias"] = self._to_device_1d(p["ln_bias"])
+            loaded.append(entry)
+        return loaded
+
+    def _to_device(self, tensor: torch.Tensor) -> ttnn.Tensor:
+        if tensor.dim() == 1:
+            tensor = tensor.unsqueeze(0)
+        return ttnn.from_torch(
+            tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device
+        )
+
+    def _to_device_bias(self, tensor: torch.Tensor) -> ttnn.Tensor:
+        if tensor.dim() == 1:
+            tensor = tensor.reshape(1, 1, 1, -1)
+        return ttnn.from_torch(
+            tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device
+        )
+
+    def _to_device_1d(self, tensor: torch.Tensor) -> ttnn.Tensor:
+        if tensor.dim() == 1:
+            tensor = tensor.reshape(1, 1, 1, -1)
+        return ttnn.from_torch(
+            tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device
+        )
+
+    def _run_layers(self, x: ttnn.Tensor, layers: list) -> ttnn.Tensor:
+        for entry in layers:
+            x = ttnn.linear(x, entry["weight"], bias=entry["bias"])
+            x = ttnn.relu(x)
+            if "ln_weight" in entry:
+                x = ttnn.layer_norm(
+                    x, weight=entry["ln_weight"], bias=entry["ln_bias"]
+                )
+        return x
+
+    def run(
+        self,
+        instance_feature: ttnn.Tensor,
+        anchor: ttnn.Tensor,
+        anchor_embed: ttnn.Tensor,
+        time_interval: ttnn.Tensor,
+        bs: int,
+        num_anchor: int,
+        return_cls: bool = True,
+    ):
+        """Forward pass of refinement module.
+
+        Args:
+            instance_feature: [bs, num_anchor, embed_dims] on device
+            anchor: [bs, num_anchor, 11] on device
+            anchor_embed: [bs, num_anchor, embed_dims] on device
+            time_interval: [bs] on device or scalar
+            bs: batch size
+            num_anchor: number of anchors
+            return_cls: whether to compute classification
+
+        Returns:
+            (refined_anchor, cls, quality) - all on device
+        """
+        n = bs * num_anchor
+
+        # feature = instance_feature + anchor_embed
+        feature = ttnn.add(instance_feature, anchor_embed)
+        feature_flat = ttnn.reshape(feature, (1, 1, n, self.embed_dims))
+
+        # --- Refine layers ---
+        refined = self._run_layers(feature_flat, self.refine_layers)
+        refined = ttnn.linear(
+            refined, self.refine_final_weight, bias=self.refine_final_bias
+        )
+        # Apply Scale
+        refined = ttnn.multiply(refined, self.refine_scale)
+        refined = ttnn.reshape(refined, (bs, num_anchor, self.output_dim))
+
+        # Residual refinement: output[refine_state] += anchor[refine_state]
+        # For refine_yaw=True: indices [0,1,2,3,4,5,6,7] = [X,Y,Z,W,L,H,SIN,COS]
+        # We add the full anchor and subtract what we don't want to refine
+        # Simpler: slice refine_state from both, add, then reconstruct
+        if self.refine_yaw:
+            # refine_state = [0:8], non-refine = [8:11]
+            refined_pos = ttnn.slice(refined, [0, 0, 0], [bs, num_anchor, 8])
+            anchor_pos = ttnn.slice(anchor, [0, 0, 0], [bs, num_anchor, 8])
+            refined_pos = ttnn.add(refined_pos, anchor_pos)
+
+            refined_vel = ttnn.slice(
+                refined, [0, 0, VX], [bs, num_anchor, self.output_dim]
+            )
+        else:
+            # refine_state = [0:6], non-refine = [6:11]
+            refined_pos = ttnn.slice(refined, [0, 0, 0], [bs, num_anchor, 6])
+            anchor_pos = ttnn.slice(anchor, [0, 0, 0], [bs, num_anchor, 6])
+            refined_pos = ttnn.add(refined_pos, anchor_pos)
+
+            refined_yaw = ttnn.slice(refined, [0, 0, SIN_YAW], [bs, num_anchor, VX])
+            refined_vel = ttnn.slice(
+                refined, [0, 0, VX], [bs, num_anchor, self.output_dim]
+            )
+
+        # Velocity refinement: vel = output[VX:] / time_interval + anchor[VX:]
+        if self.output_dim > 8:
+            # time_interval: [bs] → [bs, 1, 1] for broadcast
+            ti = ttnn.reshape(time_interval, (bs, 1, 1))
+            ti_recip = ttnn.reciprocal(ti)
+            refined_vel = ttnn.multiply(refined_vel, ti_recip)
+            anchor_vel = ttnn.slice(
+                anchor, [0, 0, VX], [bs, num_anchor, VX + (self.output_dim - VX)]
+            )
+            refined_vel = ttnn.add(refined_vel, anchor_vel)
+
+        # Reconstruct full output
+        if self.refine_yaw:
+            output = ttnn.concat([refined_pos, refined_vel], dim=-1)
+        else:
+            output = ttnn.concat([refined_pos, refined_yaw, refined_vel], dim=-1)
+
+        # --- Classification ---
+        cls = None
+        if return_cls:
+            inst_flat = ttnn.reshape(
+                instance_feature, (1, 1, n, self.embed_dims)
+            )
+            cls_feat = self._run_layers(inst_flat, self.cls_layers)
+            cls = ttnn.linear(
+                cls_feat, self.cls_final_weight, bias=self.cls_final_bias
+            )
+            cls = ttnn.reshape(cls, (bs, num_anchor, self.num_cls))
+
+        # --- Quality estimation ---
+        quality = None
+        if return_cls and self.with_quality_estimation:
+            qt_feat = self._run_layers(feature_flat, self.quality_layers)
+            quality = ttnn.linear(
+                qt_feat, self.quality_final_weight, bias=self.quality_final_bias
+            )
+            quality = ttnn.reshape(quality, (bs, num_anchor, 2))
+
+        return output, cls, quality
+
+
+def _extract_linear_relu_ln_params(modules_list):
+    """Extract params from list of modules: Linear→ReLU→LN chains."""
+    params = []
+    i = 0
+    while i < len(modules_list):
+        m = modules_list[i]
+        if hasattr(m, 'weight') and hasattr(m, 'in_features'):
+            entry = {
+                "weight": m.weight.data.clone().t(),
+                "bias": m.bias.data.clone(),
+            }
+            if i + 2 < len(modules_list) and isinstance(
+                modules_list[i + 2], torch.nn.LayerNorm
+            ):
+                ln = modules_list[i + 2]
+                entry["ln_weight"] = ln.weight.data.clone()
+                entry["ln_bias"] = ln.bias.data.clone()
+                i += 3
+            else:
+                i += 2
+            params.append(entry)
+        else:
+            i += 1
+    return params
+
+
+def preprocess_refinement_parameters(pt_module) -> dict:
+    """Extract parameters from SparseBox3DRefinementModule.
+
+    Structure:
+        layers: Sequential(
+            Linear→ReLU→LN × (in_loops * out_loops),  # refine layers
+            Linear(embed_dims, output_dim),             # final linear
+            Scale([1.0] * output_dim),                  # scale
+        )
+        cls_layers: Sequential(Linear→ReLU→LN × ..., Linear(embed_dims, num_cls))
+        quality_layers: Sequential(Linear→ReLU→LN × ..., Linear(embed_dims, 2))
+    """
+    params = {}
+
+    # Refine layers
+    modules = list(pt_module.layers.children())
+    # Last 2 modules are the final Linear and Scale
+    scale_module = modules[-1]
+    final_linear = modules[-2]
+    chain_modules = modules[:-2]
+
+    params["refine_layers"] = _extract_linear_relu_ln_params(chain_modules)
+    params["refine_final_weight"] = final_linear.weight.data.clone().t()
+    params["refine_final_bias"] = final_linear.bias.data.clone()
+    params["refine_scale"] = scale_module.scale.data.clone()
+
+    # Classification layers
+    cls_modules = list(pt_module.cls_layers.children())
+    cls_final = cls_modules[-1]
+    cls_chain = cls_modules[:-1]
+    params["cls_layers"] = _extract_linear_relu_ln_params(cls_chain)
+    params["cls_final_weight"] = cls_final.weight.data.clone().t()
+    params["cls_final_bias"] = cls_final.bias.data.clone()
+
+    # Quality layers
+    if hasattr(pt_module, 'quality_layers'):
+        qt_modules = list(pt_module.quality_layers.children())
+        qt_final = qt_modules[-1]
+        qt_chain = qt_modules[:-1]
+        params["quality_layers"] = _extract_linear_relu_ln_params(qt_chain)
+        params["quality_final_weight"] = qt_final.weight.data.clone().t()
+        params["quality_final_bias"] = qt_final.bias.data.clone()
+
+    return params

--- a/model/sparse_box3d_encoder.py
+++ b/model/sparse_box3d_encoder.py
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+# =============================================================================
+# SparseBox3DEncoder for TT Devices
+#
+# Encodes 3D anchor box parameters into feature embeddings.
+# Each component (pos, size, yaw, vel) passes through its own
+# Linear→ReLU→LN chain, then combined via "cat" mode.
+#
+# Sparse4D config (decouple_attn=True):
+#   embed_dims = [128, 32, 32, 64]
+#   mode = "cat" → output = cat([pos, size, yaw, vel]) = 256
+#   output_fc = None (no final FC)
+#   in_loops = 1, out_loops = 4
+#
+# Each embedding_layer = (Linear→ReLU→LN) × out_loops:
+#   e.g. pos_fc: Linear(3→128)→ReLU→LN → Linear(128→128)→ReLU→LN × 3
+# =============================================================================
+
+import torch
+import ttnn
+
+# Anchor box field indices
+X, Y, Z = 0, 1, 2
+W, L, H = 3, 4, 5
+SIN_YAW, COS_YAW = 6, 7
+VX, VY, VZ = 8, 9, 10
+
+
+class SparseBox3DEncoder:
+    """TT-NN implementation of SparseBox3DEncoder.
+
+    Encodes anchor [bs, N, 11] → embedding [bs, N, embed_dims].
+    """
+
+    def __init__(
+        self,
+        device,
+        parameters: dict,
+        embed_dims=(128, 32, 32, 64),
+        vel_dims: int = 3,
+        mode: str = "cat",
+        has_output_fc: bool = False,
+        in_loops: int = 1,
+        out_loops: int = 4,
+    ) -> None:
+        self.device = device
+        self.vel_dims = vel_dims
+        self.mode = mode
+        self.has_output_fc = has_output_fc
+
+        if not isinstance(embed_dims, (list, tuple)):
+            embed_dims = [embed_dims] * 5
+        self.embed_dims = embed_dims
+        # Total output dim depends on mode
+        if mode == "cat":
+            self.output_dims = sum(embed_dims[:3])
+            if vel_dims > 0:
+                self.output_dims += embed_dims[3]
+        else:
+            self.output_dims = embed_dims[0]
+
+        # Each embedding_layer has (in_loops * out_loops) Linear+LN pairs
+        # Structure: for each out_loop: for each in_loop: Linear→ReLU, then LN
+        self.pos_layers = self._load_layers(parameters["pos_fc"], out_loops, in_loops)
+        self.size_layers = self._load_layers(parameters["size_fc"], out_loops, in_loops)
+        self.yaw_layers = self._load_layers(parameters["yaw_fc"], out_loops, in_loops)
+        if vel_dims > 0:
+            self.vel_layers = self._load_layers(parameters["vel_fc"], out_loops, in_loops)
+        if has_output_fc:
+            self.out_layers = self._load_layers(parameters["output_fc"], out_loops, in_loops)
+
+    def _load_layers(self, layer_params: list, out_loops: int, in_loops: int):
+        """Load Linear→ReLU→LN chain parameters.
+
+        layer_params is a list of dicts, each with keys:
+          - "weight": Linear weight (already transposed for ttnn)
+          - "bias": Linear bias
+          - "ln_weight": LayerNorm weight (optional, present after each out_loop)
+          - "ln_bias": LayerNorm bias (optional)
+        """
+        loaded = []
+        for p in layer_params:
+            entry = {}
+            entry["weight"] = self._to_device(p["weight"])
+            entry["bias"] = self._to_device_bias(p["bias"])
+            if "ln_weight" in p:
+                entry["ln_weight"] = self._to_device_1d(p["ln_weight"])
+                entry["ln_bias"] = self._to_device_1d(p["ln_bias"])
+            loaded.append(entry)
+        return loaded
+
+    def _to_device(self, tensor: torch.Tensor) -> ttnn.Tensor:
+        if tensor.dim() == 1:
+            tensor = tensor.unsqueeze(0)
+        return ttnn.from_torch(
+            tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device
+        )
+
+    def _to_device_bias(self, tensor: torch.Tensor) -> ttnn.Tensor:
+        if tensor.dim() == 1:
+            tensor = tensor.reshape(1, 1, 1, -1)
+        return ttnn.from_torch(
+            tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device
+        )
+
+    def _to_device_1d(self, tensor: torch.Tensor) -> ttnn.Tensor:
+        if tensor.dim() == 1:
+            tensor = tensor.reshape(1, 1, 1, -1)
+        return ttnn.from_torch(
+            tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device
+        )
+
+    def _run_layers(self, x: ttnn.Tensor, layers: list) -> ttnn.Tensor:
+        """Run Linear→ReLU (→LN) chain."""
+        for entry in layers:
+            x = ttnn.linear(x, entry["weight"], bias=entry["bias"])
+            x = ttnn.relu(x)
+            if "ln_weight" in entry:
+                x = ttnn.layer_norm(
+                    x, weight=entry["ln_weight"], bias=entry["ln_bias"]
+                )
+        return x
+
+    def run(
+        self,
+        box_3d: ttnn.Tensor,
+        bs: int,
+        num_anchor: int,
+    ) -> ttnn.Tensor:
+        """Encode anchor boxes to embeddings.
+
+        Args:
+            box_3d: [bs, num_anchor, 11] on device (TILE)
+            bs: batch size
+            num_anchor: number of anchors
+
+        Returns:
+            output: [bs, num_anchor, output_dims] on device (TILE)
+        """
+        # Extract components via slice
+        pos = ttnn.slice(box_3d, [0, 0, X], [bs, num_anchor, Z + 1])
+        size = ttnn.slice(box_3d, [0, 0, W], [bs, num_anchor, H + 1])
+        yaw = ttnn.slice(box_3d, [0, 0, SIN_YAW], [bs, num_anchor, COS_YAW + 1])
+
+        # Flatten for linear: [1, 1, bs*num_anchor, dim]
+        n = bs * num_anchor
+        pos = ttnn.reshape(pos, (1, 1, n, 3))
+        size = ttnn.reshape(size, (1, 1, n, 3))
+        yaw = ttnn.reshape(yaw, (1, 1, n, 2))
+
+        pos_feat = self._run_layers(pos, self.pos_layers)
+        size_feat = self._run_layers(size, self.size_layers)
+        yaw_feat = self._run_layers(yaw, self.yaw_layers)
+
+        if self.mode == "add":
+            output = ttnn.add(ttnn.add(pos_feat, size_feat), yaw_feat)
+        else:
+            output = ttnn.concat([pos_feat, size_feat, yaw_feat], dim=-1)
+
+        if self.vel_dims > 0:
+            vel = ttnn.slice(box_3d, [0, 0, VX], [bs, num_anchor, VX + self.vel_dims])
+            vel = ttnn.reshape(vel, (1, 1, n, self.vel_dims))
+            vel_feat = self._run_layers(vel, self.vel_layers)
+            if self.mode == "add":
+                output = ttnn.add(output, vel_feat)
+            else:
+                output = ttnn.concat([output, vel_feat], dim=-1)
+
+        if self.has_output_fc:
+            output = self._run_layers(output, self.out_layers)
+
+        output = ttnn.reshape(output, (bs, num_anchor, self.output_dims))
+        return output
+
+
+def _extract_linear_relu_ln_params(sequential_module):
+    """Extract params from nn.Sequential of Linear→ReLU→LN chains.
+
+    Structure from linear_relu_ln():
+      for out_loop:
+        for in_loop:
+          Linear(in, out)
+          ReLU
+        LayerNorm(out)
+
+    Returns list of dicts with weight, bias, and optional ln_weight/ln_bias.
+    """
+    params = []
+    if hasattr(sequential_module, 'children'):
+        modules = list(sequential_module.children())
+    else:
+        modules = list(sequential_module)
+    i = 0
+    while i < len(modules):
+        m = modules[i]
+        if hasattr(m, 'weight') and hasattr(m, 'in_features'):
+            # This is a Linear layer
+            entry = {
+                "weight": m.weight.data.clone().t(),
+                "bias": m.bias.data.clone(),
+            }
+            # Check if there's a LayerNorm after ReLU (skip ReLU at i+1)
+            # Pattern: Linear, ReLU, [LayerNorm | Linear]
+            if i + 2 < len(modules) and isinstance(modules[i + 2], torch.nn.LayerNorm):
+                ln = modules[i + 2]
+                entry["ln_weight"] = ln.weight.data.clone()
+                entry["ln_bias"] = ln.bias.data.clone()
+                i += 3  # skip Linear, ReLU, LN
+            else:
+                i += 2  # skip Linear, ReLU
+            params.append(entry)
+        else:
+            i += 1
+    return params
+
+
+def preprocess_encoder_parameters(pt_encoder) -> dict:
+    """Extract parameters from SparseBox3DEncoder.
+
+    Args:
+        pt_encoder: PyTorch SparseBox3DEncoder instance
+
+    Returns:
+        dict with pos_fc, size_fc, yaw_fc, vel_fc, output_fc layer params
+    """
+    params = {}
+    params["pos_fc"] = _extract_linear_relu_ln_params(pt_encoder.pos_fc)
+    params["size_fc"] = _extract_linear_relu_ln_params(pt_encoder.size_fc)
+    params["yaw_fc"] = _extract_linear_relu_ln_params(pt_encoder.yaw_fc)
+
+    if hasattr(pt_encoder, 'vel_fc'):
+        params["vel_fc"] = _extract_linear_relu_ln_params(pt_encoder.vel_fc)
+
+    if pt_encoder.output_fc is not None:
+        params["output_fc"] = _extract_linear_relu_ln_params(pt_encoder.output_fc)
+
+    return params

--- a/test/all_pcc.py
+++ b/test/all_pcc.py
@@ -1,0 +1,426 @@
+"""
+Sparse4D Module PCC Summary: All modules PyTorch vs TT-NN
+
+Runs all individual module PCC tests and produces a consolidated report.
+
+Modules tested:
+  1. MultiheadAttention (self-attn, cross-attn, graph_model flow)
+  2. AsymmetricFFN (asymmetric 512→256, symmetric 256→256)
+  3. SparseBox3DEncoder (cat mode, add mode)
+  4. SparseBox3DRefinementModule (anchor, cls, quality)
+
+Note: ResNet50, FPN, DFA have separate tests (resnet_pcc.py, fpn_pcc.py, dfa_pcc.py)
+      and are not included here to keep runtime manageable.
+
+Usage:
+  python test/all_pcc.py
+"""
+
+import os
+import sys
+import time
+
+TT_METAL_HOME = os.environ.get(
+    "TT_METAL_HOME", os.path.expanduser("~/project/tt-metal")
+)
+sys.path.insert(0, TT_METAL_HOME)
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import torch
+import torch.nn as nn
+import ttnn
+
+# ============================================================
+# Shared utilities
+# ============================================================
+
+def compute_pcc(a: torch.Tensor, b: torch.Tensor) -> float:
+    a = a.double().flatten()
+    b = b.double().flatten()
+    a = a - a.mean()
+    b = b - b.mean()
+    denom = a.norm() * b.norm()
+    if denom == 0:
+        return 1.0 if a.norm() == 0 and b.norm() == 0 else 0.0
+    return (torch.dot(a, b) / denom).item()
+
+
+def quick_compare(pt: torch.Tensor, tt: torch.Tensor):
+    """Return pcc, max_diff, mean_diff without printing."""
+    pt_f, tt_f = pt.float(), tt.float()
+    diff = (pt_f - tt_f).abs()
+    return {
+        "pcc": compute_pcc(pt, tt),
+        "max_diff": diff.max().item(),
+        "mean_diff": diff.mean().item(),
+        "allclose": torch.allclose(pt_f, tt_f, atol=1e-2, rtol=1e-2),
+    }
+
+
+def trim(tt_tensor, target_shape):
+    t = ttnn.to_torch(tt_tensor)
+    slices = tuple(slice(0, s) for s in target_shape)
+    return t[slices]
+
+
+# ============================================================
+# Helper: linear_relu_ln for standalone PT modules
+# ============================================================
+
+def _linear_relu_ln(embed_dims, in_loops, out_loops, input_dims=None):
+    if input_dims is None:
+        input_dims = embed_dims
+    layers = []
+    for _ in range(out_loops):
+        for _ in range(in_loops):
+            layers.append(nn.Linear(input_dims, embed_dims))
+            layers.append(nn.ReLU(inplace=True))
+            input_dims = embed_dims
+        layers.append(nn.LayerNorm(embed_dims))
+    return layers
+
+
+# ============================================================
+# 1. MultiheadAttention
+# ============================================================
+
+def test_mha(device):
+    from model.multihead_attention import MultiheadAttention
+
+    results = {}
+
+    # --- Self-attention ---
+    torch.manual_seed(42)
+    embed_dims, num_heads, bs, N = 512, 8, 1, 900
+
+    attn = nn.MultiheadAttention(embed_dims, num_heads, batch_first=False)
+    query = torch.randn(bs, N, embed_dims)
+    with torch.no_grad():
+        q_t = query.transpose(0, 1)
+        pt_out = attn(q_t, q_t, q_t)[0].transpose(0, 1)
+        pt_out = query + pt_out  # residual
+
+    in_w = attn.in_proj_weight.data.clone()
+    wq, wk, wv = in_w.chunk(3, dim=0)
+    in_b = attn.in_proj_bias.data.clone()
+    bq, bk, bv = in_b.chunk(3, dim=0)
+    params = {
+        "w_q": wq.t(), "w_k": wk.t(), "w_v": wv.t(),
+        "b_q": bq, "b_k": bk, "b_v": bv,
+        "w_out": attn.out_proj.weight.data.clone().t(),
+        "b_out": attn.out_proj.bias.data.clone(),
+    }
+    tt_mha = MultiheadAttention(device, params, embed_dims, num_heads)
+    q_tt = ttnn.from_torch(query.float(), layout=ttnn.TILE_LAYOUT, device=device)
+    tt_out = tt_mha.run(q_tt, q_tt, q_tt, bs=bs, num_queries=N, num_keys=N)
+    results["MHA self-attn"] = quick_compare(pt_out, trim(tt_out, pt_out.shape))
+
+    # --- Cross-attention ---
+    torch.manual_seed(123)
+    M = 600
+    query2 = torch.randn(bs, N, embed_dims)
+    key2 = torch.randn(bs, M, embed_dims)
+    value2 = torch.randn(bs, M, embed_dims)
+    with torch.no_grad():
+        pt_out2 = attn(query2.transpose(0, 1), key2.transpose(0, 1), value2.transpose(0, 1))[0].transpose(0, 1)
+        pt_out2 = query2 + pt_out2
+
+    q2_tt = ttnn.from_torch(query2.float(), layout=ttnn.TILE_LAYOUT, device=device)
+    k2_tt = ttnn.from_torch(key2.float(), layout=ttnn.TILE_LAYOUT, device=device)
+    v2_tt = ttnn.from_torch(value2.float(), layout=ttnn.TILE_LAYOUT, device=device)
+    tt_out2 = tt_mha.run(q2_tt, k2_tt, v2_tt, bs=bs, num_queries=N, num_keys=M)
+    results["MHA cross-attn"] = quick_compare(pt_out2, trim(tt_out2, pt_out2.shape))
+
+    return results
+
+
+# ============================================================
+# 2. AsymmetricFFN
+# ============================================================
+
+def test_ffn(device):
+    from model.asymmetric_ffn import AsymmetricFFN
+
+    results = {}
+
+    # --- Asymmetric 512→256 ---
+    torch.manual_seed(42)
+    bs, N, in_ch, out_ch, ff_ch = 1, 900, 512, 256, 1024
+
+    pre_norm = nn.LayerNorm(in_ch)
+    layers = nn.Sequential(
+        nn.Sequential(nn.Linear(in_ch, ff_ch), nn.ReLU(inplace=True), nn.Dropout(0.0)),
+        nn.Linear(ff_ch, out_ch), nn.Dropout(0.0),
+    )
+    identity_fc = nn.Linear(in_ch, out_ch)
+
+    x = torch.randn(bs, N, in_ch)
+    with torch.no_grad():
+        pt_out = identity_fc(x) + layers(pre_norm(x))
+
+    params = {
+        "pre_norm_weight": pre_norm.weight.data.clone(),
+        "pre_norm_bias": pre_norm.bias.data.clone(),
+        "fc1_weight": layers[0][0].weight.data.clone().t(),
+        "fc1_bias": layers[0][0].bias.data.clone(),
+        "fc2_weight": layers[1].weight.data.clone().t(),
+        "fc2_bias": layers[1].bias.data.clone(),
+        "identity_fc_weight": identity_fc.weight.data.clone().t(),
+        "identity_fc_bias": identity_fc.bias.data.clone(),
+    }
+    tt_ffn = AsymmetricFFN(device, params, in_ch, out_ch, ff_ch)
+    x_tt = ttnn.from_torch(x.float(), layout=ttnn.TILE_LAYOUT, device=device)
+    tt_out = tt_ffn.run(x_tt, bs=bs, num_tokens=N)
+    results["FFN asymmetric (512→256)"] = quick_compare(pt_out, trim(tt_out, pt_out.shape))
+
+    # --- Symmetric 256→256 ---
+    torch.manual_seed(123)
+    in_ch2 = 256
+    pre_norm2 = nn.LayerNorm(in_ch2)
+    layers2 = nn.Sequential(
+        nn.Sequential(nn.Linear(in_ch2, ff_ch), nn.ReLU(inplace=True), nn.Dropout(0.0)),
+        nn.Linear(ff_ch, out_ch), nn.Dropout(0.0),
+    )
+    x2 = torch.randn(bs, N, in_ch2)
+    with torch.no_grad():
+        pt_out2 = x2 + layers2(pre_norm2(x2))
+
+    params2 = {
+        "pre_norm_weight": pre_norm2.weight.data.clone(),
+        "pre_norm_bias": pre_norm2.bias.data.clone(),
+        "fc1_weight": layers2[0][0].weight.data.clone().t(),
+        "fc1_bias": layers2[0][0].bias.data.clone(),
+        "fc2_weight": layers2[1].weight.data.clone().t(),
+        "fc2_bias": layers2[1].bias.data.clone(),
+    }
+    tt_ffn2 = AsymmetricFFN(device, params2, in_ch2, out_ch, ff_ch)
+    x2_tt = ttnn.from_torch(x2.float(), layout=ttnn.TILE_LAYOUT, device=device)
+    tt_out2 = tt_ffn2.run(x2_tt, bs=bs, num_tokens=N)
+    results["FFN symmetric (256→256)"] = quick_compare(pt_out2, trim(tt_out2, pt_out2.shape))
+
+    return results
+
+
+# ============================================================
+# 3. SparseBox3DEncoder
+# ============================================================
+
+def test_encoder(device):
+    from model.sparse_box3d_encoder import SparseBox3DEncoder, _extract_linear_relu_ln_params
+
+    results = {}
+
+    X, Y, Z, W, L, H, SIN_YAW, COS_YAW, VX, VY, VZ = range(11)
+
+    class _PTEncoder(nn.Module):
+        def __init__(self, embed_dims, vel_dims=3, mode="cat", output_fc=False, in_loops=1, out_loops=4):
+            super().__init__()
+            self.mode = mode
+            self.vel_dims = vel_dims
+            def emb(inp, out): return nn.Sequential(*_linear_relu_ln(out, in_loops, out_loops, inp))
+            if not isinstance(embed_dims, (list, tuple)):
+                embed_dims = [embed_dims] * 5
+            self.pos_fc = emb(3, embed_dims[0])
+            self.size_fc = emb(3, embed_dims[1])
+            self.yaw_fc = emb(2, embed_dims[2])
+            if vel_dims > 0: self.vel_fc = emb(vel_dims, embed_dims[3])
+            self.output_fc = emb(embed_dims[-1], embed_dims[-1]) if output_fc else None
+
+        def forward(self, b):
+            p = self.pos_fc(b[..., [X, Y, Z]])
+            s = self.size_fc(b[..., [W, L, H]])
+            y = self.yaw_fc(b[..., [SIN_YAW, COS_YAW]])
+            o = torch.cat([p, s, y], dim=-1) if self.mode == "cat" else p + s + y
+            if self.vel_dims > 0:
+                v = self.vel_fc(b[..., VX:VX + self.vel_dims])
+                o = torch.cat([o, v], dim=-1) if self.mode == "cat" else o + v
+            if self.output_fc is not None: o = self.output_fc(o)
+            return o
+
+    def extract(enc):
+        p = {}
+        for name in ["pos_fc", "size_fc", "yaw_fc"]:
+            p[name] = _extract_linear_relu_ln_params(list(getattr(enc, name).children()))
+        if hasattr(enc, 'vel_fc'): p["vel_fc"] = _extract_linear_relu_ln_params(list(enc.vel_fc.children()))
+        if enc.output_fc is not None: p["output_fc"] = _extract_linear_relu_ln_params(list(enc.output_fc.children()))
+        return p
+
+    # --- Cat mode ---
+    torch.manual_seed(42)
+    bs, N = 1, 900
+    dims = [128, 32, 32, 64]
+    pt_enc = _PTEncoder(dims, mode="cat", output_fc=False, in_loops=1, out_loops=4).eval()
+    box = torch.randn(bs, N, 11)
+    with torch.no_grad(): pt_out = pt_enc(box)
+
+    tt_enc = SparseBox3DEncoder(device, extract(pt_enc), embed_dims=dims, mode="cat", has_output_fc=False, in_loops=1, out_loops=4)
+    box_tt = ttnn.from_torch(box.float(), layout=ttnn.TILE_LAYOUT, device=device)
+    tt_out = tt_enc.run(box_tt, bs=bs, num_anchor=N)
+    results["Encoder cat mode"] = quick_compare(pt_out, trim(tt_out, pt_out.shape))
+
+    # --- Add mode ---
+    torch.manual_seed(123)
+    pt_enc2 = _PTEncoder(256, mode="add", output_fc=True, in_loops=1, out_loops=2).eval()
+    box2 = torch.randn(bs, N, 11)
+    with torch.no_grad(): pt_out2 = pt_enc2(box2)
+
+    tt_enc2 = SparseBox3DEncoder(device, extract(pt_enc2), embed_dims=256, mode="add", has_output_fc=True, in_loops=1, out_loops=2)
+    box2_tt = ttnn.from_torch(box2.float(), layout=ttnn.TILE_LAYOUT, device=device)
+    tt_out2 = tt_enc2.run(box2_tt, bs=bs, num_anchor=N)
+    results["Encoder add mode"] = quick_compare(pt_out2, trim(tt_out2, pt_out2.shape))
+
+    return results
+
+
+# ============================================================
+# 4. SparseBox3DRefinementModule
+# ============================================================
+
+def test_refinement(device):
+    from model.refinement_module import SparseBox3DRefinementModule, _extract_linear_relu_ln_params
+
+    results = {}
+
+    X, Y, Z, W, L, H, SIN_YAW, COS_YAW, VX, VY, VZ = range(11)
+
+    class _Scale(nn.Module):
+        def __init__(self, s):
+            super().__init__()
+            self.scale = nn.Parameter(torch.tensor(s, dtype=torch.float32))
+        def forward(self, x): return x * self.scale
+
+    class _PTRefine(nn.Module):
+        def __init__(self, embed_dims=256, output_dim=11, num_cls=10, refine_yaw=True, with_quality=True):
+            super().__init__()
+            self.output_dim, self.refine_yaw, self.with_quality = output_dim, refine_yaw, with_quality
+            self.refine_state = [X, Y, Z, W, L, H] + ([SIN_YAW, COS_YAW] if refine_yaw else [])
+            self.layers = nn.Sequential(*_linear_relu_ln(embed_dims, 2, 2), nn.Linear(embed_dims, output_dim), _Scale([1.0]*output_dim))
+            self.cls_layers = nn.Sequential(*_linear_relu_ln(embed_dims, 1, 2), nn.Linear(embed_dims, num_cls))
+            if with_quality: self.quality_layers = nn.Sequential(*_linear_relu_ln(embed_dims, 1, 2), nn.Linear(embed_dims, 2))
+
+        def forward(self, inst, anch, embed, ti=1.0):
+            feat = inst + embed
+            out = self.layers(feat)
+            out[..., self.refine_state] = out[..., self.refine_state] + anch[..., self.refine_state]
+            if self.output_dim > 8:
+                if not isinstance(ti, torch.Tensor): ti = inst.new_tensor(ti)
+                tr = torch.transpose(out[..., VX:], 0, -1)
+                out[..., VX:] = torch.transpose(tr / ti, 0, -1) + anch[..., VX:]
+            cls = self.cls_layers(inst)
+            qt = self.quality_layers(feat) if self.with_quality else None
+            return out, cls, qt
+
+    def extract_ref(m):
+        p = {}
+        mods = list(m.layers.children())
+        p["refine_layers"] = _extract_linear_relu_ln_params(mods[:-2])
+        p["refine_final_weight"] = mods[-2].weight.data.clone().t()
+        p["refine_final_bias"] = mods[-2].bias.data.clone()
+        p["refine_scale"] = mods[-1].scale.data.clone()
+        cls_mods = list(m.cls_layers.children())
+        p["cls_layers"] = _extract_linear_relu_ln_params(cls_mods[:-1])
+        p["cls_final_weight"] = cls_mods[-1].weight.data.clone().t()
+        p["cls_final_bias"] = cls_mods[-1].bias.data.clone()
+        if hasattr(m, 'quality_layers'):
+            qt_mods = list(m.quality_layers.children())
+            p["quality_layers"] = _extract_linear_relu_ln_params(qt_mods[:-1])
+            p["quality_final_weight"] = qt_mods[-1].weight.data.clone().t()
+            p["quality_final_bias"] = qt_mods[-1].bias.data.clone()
+        return p
+
+    torch.manual_seed(42)
+    bs, N, E = 1, 900, 256
+    pt_ref = _PTRefine(E, 11, 10, True, True).eval()
+    inst = torch.randn(bs, N, E)
+    anch = torch.randn(bs, N, 11)
+    embed = torch.randn(bs, N, E)
+    ti = torch.tensor([0.5] * bs)
+
+    with torch.no_grad(): pt_out, pt_cls, pt_qt = pt_ref(inst, anch, embed, ti)
+
+    tt_ref = SparseBox3DRefinementModule(device, extract_ref(pt_ref), E, 11, 10, True, True)
+    inst_tt = ttnn.from_torch(inst.float(), layout=ttnn.TILE_LAYOUT, device=device)
+    anch_tt = ttnn.from_torch(anch.float(), layout=ttnn.TILE_LAYOUT, device=device)
+    embed_tt = ttnn.from_torch(embed.float(), layout=ttnn.TILE_LAYOUT, device=device)
+    ti_tt = ttnn.from_torch(ti.reshape(1, 1, 1, bs).float(), layout=ttnn.TILE_LAYOUT, device=device)
+    ti_tt = ttnn.reshape(ti_tt, (bs,))
+
+    tt_out, tt_cls, tt_qt = tt_ref.run(inst_tt, anch_tt, embed_tt, ti_tt, bs=bs, num_anchor=N)
+
+    results["Refinement anchor"] = quick_compare(pt_out, trim(tt_out, pt_out.shape))
+    results["Refinement cls"] = quick_compare(pt_cls, trim(tt_cls, pt_cls.shape))
+    results["Refinement quality"] = quick_compare(pt_qt, trim(tt_qt, pt_qt.shape))
+
+    return results
+
+
+# ============================================================
+# Main
+# ============================================================
+
+def main():
+    print("=" * 70)
+    print("  Sparse4D Module PCC Summary: All Modules PyTorch vs TT-NN")
+    print("=" * 70)
+
+    device = ttnn.open_device(device_id=0, l1_small_size=24576)
+    all_results = {}
+
+    try:
+        compute_grid = device.compute_with_storage_grid_size()
+        print(f"  Device: {device.arch()}, grid: {compute_grid.x}x{compute_grid.y}\n")
+
+        tests = [
+            ("MultiheadAttention", test_mha),
+            ("AsymmetricFFN", test_ffn),
+            ("SparseBox3DEncoder", test_encoder),
+            ("RefinementModule", test_refinement),
+        ]
+
+        for group_name, test_fn in tests:
+            print(f"  Running {group_name}...", end=" ", flush=True)
+            t0 = time.time()
+            results = test_fn(device)
+            elapsed = time.time() - t0
+            print(f"done ({elapsed:.1f}s)")
+            all_results.update(results)
+
+        # Print summary table
+        print(f"\n{'=' * 70}")
+        print(f"  {'Module':<30} {'PCC':>10} {'MaxDiff':>10} {'MeanDiff':>10} {'Pass':>6}")
+        print(f"  {'-'*29:<30} {'-'*9:>10} {'-'*9:>10} {'-'*9:>10} {'-'*5:>6}")
+
+        all_pass = True
+        for name, r in all_results.items():
+            passed = r["pcc"] >= 0.999
+            if not passed:
+                all_pass = False
+            mark = "OK" if passed else "FAIL"
+            print(
+                f"  {name:<30} {r['pcc']:>10.6f} {r['max_diff']:>10.4f} "
+                f"{r['mean_diff']:>10.6f} {mark:>6}"
+            )
+
+        print(f"  {'-'*29:<30} {'-'*9:>10} {'-'*9:>10} {'-'*9:>10} {'-'*5:>6}")
+        avg_pcc = sum(r["pcc"] for r in all_results.values()) / len(all_results)
+        status = "ALL PASS" if all_pass else "SOME FAILED"
+        print(f"  {'Average':<30} {avg_pcc:>10.6f} {'':>10} {'':>10} {status:>6}")
+        print(f"{'=' * 70}")
+
+        # Additional note about modules not tested here
+        print(f"\n  Note: ResNet50, FPN, DFA tested separately via:")
+        print(f"    python test/resnet_pcc.py")
+        print(f"    python test/fpn_pcc.py")
+        print(f"    python test/dfa_pcc.py")
+
+    except Exception as e:
+        import traceback
+        traceback.print_exc()
+        print(f"\n  FAILED: {str(e)[:200]}")
+
+    finally:
+        ttnn.close_device(device)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/encoder_pcc.py
+++ b/test/encoder_pcc.py
@@ -1,0 +1,302 @@
+"""
+SparseBox3DEncoder PCC Test: PyTorch vs TT-NN
+
+Compares the TT-NN SparseBox3DEncoder against PyTorch for numerical accuracy.
+
+Tests:
+  1. Cat mode (decouple_attn=True): embed_dims=[128,32,32,64], output=256
+  2. Add mode: embed_dims=256, output=256
+
+Usage:
+  python test/encoder_pcc.py
+"""
+
+import os
+import sys
+
+TT_METAL_HOME = os.environ.get(
+    "TT_METAL_HOME", os.path.expanduser("~/project/tt-metal")
+)
+sys.path.insert(0, TT_METAL_HOME)
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import torch
+import torch.nn as nn
+import ttnn
+
+from model.sparse_box3d_encoder import (
+    SparseBox3DEncoder,
+    preprocess_encoder_parameters,
+    _extract_linear_relu_ln_params,
+)
+
+
+# ============================================================
+# Comparison Utilities
+# ============================================================
+
+def compute_pcc(a: torch.Tensor, b: torch.Tensor) -> float:
+    a = a.double().flatten()
+    b = b.double().flatten()
+    a = a - a.mean()
+    b = b - b.mean()
+    denom = a.norm() * b.norm()
+    if denom == 0:
+        return 1.0 if a.norm() == 0 and b.norm() == 0 else 0.0
+    return (torch.dot(a, b) / denom).item()
+
+
+def compare_tensors(
+    pt: torch.Tensor,
+    tt: torch.Tensor,
+    name: str,
+    atol: float = 1e-2,
+    rtol: float = 1e-2,
+    num_samples: int = 10,
+):
+    pt_f = pt.float()
+    tt_f = tt.float()
+    diff = (pt_f - tt_f).abs()
+
+    pcc = compute_pcc(pt, tt)
+    max_diff = diff.max().item()
+    mean_diff = diff.mean().item()
+    allclose = torch.allclose(pt_f, tt_f, atol=atol, rtol=rtol)
+
+    print(f"\n  --- {name} ---")
+    print(f"  Shape:     {list(pt.shape)}")
+    print(f"  PCC:       {pcc:.6f}")
+    print(f"  MaxDiff:   {max_diff:.6f}")
+    print(f"  MeanDiff:  {mean_diff:.6f}")
+    print(f"  Allclose:  {allclose}  (atol={atol}, rtol={rtol})")
+
+    pt_flat = pt_f.flatten()
+    tt_flat = tt_f.flatten()
+    n = min(num_samples, pt_flat.numel())
+    print(f"\n  Sample values (first {n}):")
+    print(f"  {'Index':<8} {'PyTorch':>12} {'TT-NN':>12} {'Diff':>12}")
+    print(f"  {'-'*7:<8} {'-'*11:>12} {'-'*11:>12} {'-'*11:>12}")
+    for i in range(n):
+        d = (pt_flat[i] - tt_flat[i]).abs().item()
+        print(f"  {i:<8} {pt_flat[i].item():>12.6f} {tt_flat[i].item():>12.6f} {d:>12.6f}")
+
+    diff_flat = diff.flatten()
+    _, worst_indices = diff_flat.topk(min(5, diff_flat.numel()))
+    print(f"\n  Top-5 worst diffs:")
+    print(f"  {'Index':<8} {'PyTorch':>12} {'TT-NN':>12} {'Diff':>12}")
+    print(f"  {'-'*7:<8} {'-'*11:>12} {'-'*11:>12} {'-'*11:>12}")
+    for idx in worst_indices:
+        i = idx.item()
+        d = diff_flat[i].item()
+        print(f"  {i:<8} {pt_flat[i].item():>12.6f} {tt_flat[i].item():>12.6f} {d:>12.6f}")
+
+    return {"pcc": pcc, "max_diff": max_diff, "mean_diff": mean_diff, "allclose": allclose}
+
+
+# ============================================================
+# PyTorch reference (standalone)
+# ============================================================
+
+def _linear_relu_ln(embed_dims, in_loops, out_loops, input_dims=None):
+    """Replicate mmcv linear_relu_ln."""
+    if input_dims is None:
+        input_dims = embed_dims
+    layers = []
+    for _ in range(out_loops):
+        for _ in range(in_loops):
+            layers.append(nn.Linear(input_dims, embed_dims))
+            layers.append(nn.ReLU(inplace=True))
+            input_dims = embed_dims
+        layers.append(nn.LayerNorm(embed_dims))
+    return layers
+
+
+class _PTSparseBox3DEncoder(nn.Module):
+    """Standalone PyTorch SparseBox3DEncoder."""
+
+    X, Y, Z = 0, 1, 2
+    W, L, H = 3, 4, 5
+    SIN_YAW, COS_YAW = 6, 7
+    VX, VY, VZ = 8, 9, 10
+
+    def __init__(
+        self,
+        embed_dims,
+        vel_dims=3,
+        mode="cat",
+        output_fc=False,
+        in_loops=1,
+        out_loops=4,
+    ):
+        super().__init__()
+        self.embed_dims = embed_dims
+        self.vel_dims = vel_dims
+        self.mode = mode
+
+        def embedding_layer(input_dims, output_dims):
+            return nn.Sequential(
+                *_linear_relu_ln(output_dims, in_loops, out_loops, input_dims)
+            )
+
+        if not isinstance(embed_dims, (list, tuple)):
+            embed_dims = [embed_dims] * 5
+        self.pos_fc = embedding_layer(3, embed_dims[0])
+        self.size_fc = embedding_layer(3, embed_dims[1])
+        self.yaw_fc = embedding_layer(2, embed_dims[2])
+        if vel_dims > 0:
+            self.vel_fc = embedding_layer(vel_dims, embed_dims[3])
+        self.output_fc = None
+        if output_fc:
+            self.output_fc = embedding_layer(embed_dims[-1], embed_dims[-1])
+
+    def forward(self, box_3d):
+        pos_feat = self.pos_fc(box_3d[..., [self.X, self.Y, self.Z]])
+        size_feat = self.size_fc(box_3d[..., [self.W, self.L, self.H]])
+        yaw_feat = self.yaw_fc(box_3d[..., [self.SIN_YAW, self.COS_YAW]])
+        if self.mode == "add":
+            output = pos_feat + size_feat + yaw_feat
+        elif self.mode == "cat":
+            output = torch.cat([pos_feat, size_feat, yaw_feat], dim=-1)
+
+        if self.vel_dims > 0:
+            vel_feat = self.vel_fc(box_3d[..., self.VX: self.VX + self.vel_dims])
+            if self.mode == "add":
+                output = output + vel_feat
+            elif self.mode == "cat":
+                output = torch.cat([output, vel_feat], dim=-1)
+        if self.output_fc is not None:
+            output = self.output_fc(output)
+        return output
+
+
+def preprocess_encoder_parameters_from_pt(pt_encoder):
+    """Extract params from standalone PT encoder."""
+    params = {}
+    params["pos_fc"] = _extract_linear_relu_ln_params(list(pt_encoder.pos_fc.children()))
+    params["size_fc"] = _extract_linear_relu_ln_params(list(pt_encoder.size_fc.children()))
+    params["yaw_fc"] = _extract_linear_relu_ln_params(list(pt_encoder.yaw_fc.children()))
+    if hasattr(pt_encoder, 'vel_fc'):
+        params["vel_fc"] = _extract_linear_relu_ln_params(list(pt_encoder.vel_fc.children()))
+    if pt_encoder.output_fc is not None:
+        params["output_fc"] = _extract_linear_relu_ln_params(
+            list(pt_encoder.output_fc.children())
+        )
+    return params
+
+
+# ============================================================
+# Test 1: Cat mode (Sparse4D default with decouple_attn)
+# ============================================================
+
+def test_cat_mode(device, bs=1, num_anchor=900):
+    embed_dims = [128, 32, 32, 64]
+    print("\n" + "=" * 65)
+    print(f"  [Test 1] Cat mode, dims={embed_dims}, bs={bs}, anchors={num_anchor}")
+    print("=" * 65)
+
+    torch.manual_seed(42)
+
+    pt_encoder = _PTSparseBox3DEncoder(
+        embed_dims=embed_dims, vel_dims=3, mode="cat",
+        output_fc=False, in_loops=1, out_loops=4,
+    )
+    pt_encoder.eval()
+
+    box_3d = torch.randn(bs, num_anchor, 11)
+
+    with torch.no_grad():
+        pt_output = pt_encoder(box_3d)
+
+    params = preprocess_encoder_parameters_from_pt(pt_encoder)
+    tt_encoder = SparseBox3DEncoder(
+        device, params,
+        embed_dims=embed_dims, vel_dims=3, mode="cat",
+        has_output_fc=False, in_loops=1, out_loops=4,
+    )
+
+    box_3d_tt = ttnn.from_torch(box_3d.float(), layout=ttnn.TILE_LAYOUT, device=device)
+    tt_output = tt_encoder.run(box_3d_tt, bs=bs, num_anchor=num_anchor)
+
+    tt_output_torch = ttnn.to_torch(tt_output)
+    if tt_output_torch.shape != pt_output.shape:
+        tt_output_torch = tt_output_torch[:bs, :num_anchor, :pt_output.shape[-1]]
+
+    result = compare_tensors(pt_output, tt_output_torch, f"Encoder cat mode (dims={embed_dims})")
+    return result["pcc"]
+
+
+# ============================================================
+# Test 2: Add mode
+# ============================================================
+
+def test_add_mode(device, bs=1, num_anchor=900):
+    embed_dims = 256
+    print("\n" + "=" * 65)
+    print(f"  [Test 2] Add mode, dims={embed_dims}, bs={bs}, anchors={num_anchor}")
+    print("=" * 65)
+
+    torch.manual_seed(123)
+
+    pt_encoder = _PTSparseBox3DEncoder(
+        embed_dims=embed_dims, vel_dims=3, mode="add",
+        output_fc=True, in_loops=1, out_loops=2,
+    )
+    pt_encoder.eval()
+
+    box_3d = torch.randn(bs, num_anchor, 11)
+
+    with torch.no_grad():
+        pt_output = pt_encoder(box_3d)
+
+    params = preprocess_encoder_parameters_from_pt(pt_encoder)
+    tt_encoder = SparseBox3DEncoder(
+        device, params,
+        embed_dims=embed_dims, vel_dims=3, mode="add",
+        has_output_fc=True, in_loops=1, out_loops=2,
+    )
+
+    box_3d_tt = ttnn.from_torch(box_3d.float(), layout=ttnn.TILE_LAYOUT, device=device)
+    tt_output = tt_encoder.run(box_3d_tt, bs=bs, num_anchor=num_anchor)
+
+    tt_output_torch = ttnn.to_torch(tt_output)
+    if tt_output_torch.shape != pt_output.shape:
+        tt_output_torch = tt_output_torch[:bs, :num_anchor, :pt_output.shape[-1]]
+
+    result = compare_tensors(pt_output, tt_output_torch, f"Encoder add mode (dims={embed_dims})")
+    return result["pcc"]
+
+
+# ============================================================
+# Main
+# ============================================================
+
+def main():
+    print("=" * 65)
+    print("SparseBox3DEncoder PCC Test: PyTorch vs TT-NN")
+    print("=" * 65)
+
+    device = ttnn.open_device(device_id=0, l1_small_size=24576)
+    try:
+        compute_grid = device.compute_with_storage_grid_size()
+        print(f"  Device: {device.arch()}, grid: {compute_grid.x}x{compute_grid.y}")
+
+        pcc_cat = test_cat_mode(device, bs=1, num_anchor=900)
+        pcc_add = test_add_mode(device, bs=1, num_anchor=900)
+
+        print(f"\n{'=' * 65}")
+        print("Final Summary:")
+        print(f"  Cat mode PCC:  {pcc_cat:.6f}")
+        print(f"  Add mode PCC:  {pcc_add:.6f}")
+        print(f"{'=' * 65}")
+
+    except Exception as e:
+        import traceback
+        traceback.print_exc()
+        print(f"  FAILED: {str(e)[:200]}")
+
+    finally:
+        ttnn.close_device(device)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/refinement_pcc.py
+++ b/test/refinement_pcc.py
@@ -1,0 +1,392 @@
+"""
+SparseBox3DRefinementModule PCC Test: PyTorch vs TT-NN
+
+Compares the TT-NN RefinementModule against PyTorch for numerical accuracy.
+
+Tests:
+  1. Full refinement with cls + quality (Sparse4D default)
+  2. Refinement without quality estimation
+
+Usage:
+  python test/refinement_pcc.py
+"""
+
+import os
+import sys
+
+TT_METAL_HOME = os.environ.get(
+    "TT_METAL_HOME", os.path.expanduser("~/project/tt-metal")
+)
+sys.path.insert(0, TT_METAL_HOME)
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import torch
+import torch.nn as nn
+import ttnn
+
+from model.refinement_module import (
+    SparseBox3DRefinementModule,
+    preprocess_refinement_parameters,
+    _extract_linear_relu_ln_params,
+)
+
+
+# ============================================================
+# Comparison Utilities
+# ============================================================
+
+def compute_pcc(a: torch.Tensor, b: torch.Tensor) -> float:
+    a = a.double().flatten()
+    b = b.double().flatten()
+    a = a - a.mean()
+    b = b - b.mean()
+    denom = a.norm() * b.norm()
+    if denom == 0:
+        return 1.0 if a.norm() == 0 and b.norm() == 0 else 0.0
+    return (torch.dot(a, b) / denom).item()
+
+
+def compare_tensors(
+    pt: torch.Tensor,
+    tt: torch.Tensor,
+    name: str,
+    atol: float = 1e-2,
+    rtol: float = 1e-2,
+    num_samples: int = 10,
+):
+    pt_f = pt.float()
+    tt_f = tt.float()
+    diff = (pt_f - tt_f).abs()
+
+    pcc = compute_pcc(pt, tt)
+    max_diff = diff.max().item()
+    mean_diff = diff.mean().item()
+    allclose = torch.allclose(pt_f, tt_f, atol=atol, rtol=rtol)
+
+    print(f"\n  --- {name} ---")
+    print(f"  Shape:     {list(pt.shape)}")
+    print(f"  PCC:       {pcc:.6f}")
+    print(f"  MaxDiff:   {max_diff:.6f}")
+    print(f"  MeanDiff:  {mean_diff:.6f}")
+    print(f"  Allclose:  {allclose}  (atol={atol}, rtol={rtol})")
+
+    pt_flat = pt_f.flatten()
+    tt_flat = tt_f.flatten()
+    n = min(num_samples, pt_flat.numel())
+    print(f"\n  Sample values (first {n}):")
+    print(f"  {'Index':<8} {'PyTorch':>12} {'TT-NN':>12} {'Diff':>12}")
+    print(f"  {'-'*7:<8} {'-'*11:>12} {'-'*11:>12} {'-'*11:>12}")
+    for i in range(n):
+        d = (pt_flat[i] - tt_flat[i]).abs().item()
+        print(f"  {i:<8} {pt_flat[i].item():>12.6f} {tt_flat[i].item():>12.6f} {d:>12.6f}")
+
+    diff_flat = diff.flatten()
+    _, worst_indices = diff_flat.topk(min(5, diff_flat.numel()))
+    print(f"\n  Top-5 worst diffs:")
+    print(f"  {'Index':<8} {'PyTorch':>12} {'TT-NN':>12} {'Diff':>12}")
+    print(f"  {'-'*7:<8} {'-'*11:>12} {'-'*11:>12} {'-'*11:>12}")
+    for idx in worst_indices:
+        i = idx.item()
+        d = diff_flat[i].item()
+        print(f"  {i:<8} {pt_flat[i].item():>12.6f} {tt_flat[i].item():>12.6f} {d:>12.6f}")
+
+    return {"pcc": pcc, "max_diff": max_diff, "mean_diff": mean_diff, "allclose": allclose}
+
+
+# ============================================================
+# PyTorch reference (standalone)
+# ============================================================
+
+X, Y, Z = 0, 1, 2
+W, L, H = 3, 4, 5
+SIN_YAW, COS_YAW = 6, 7
+VX, VY, VZ = 8, 9, 10
+
+
+def _linear_relu_ln(embed_dims, in_loops, out_loops, input_dims=None):
+    if input_dims is None:
+        input_dims = embed_dims
+    layers = []
+    for _ in range(out_loops):
+        for _ in range(in_loops):
+            layers.append(nn.Linear(input_dims, embed_dims))
+            layers.append(nn.ReLU(inplace=True))
+            input_dims = embed_dims
+        layers.append(nn.LayerNorm(embed_dims))
+    return layers
+
+
+class _PTRefinementModule(nn.Module):
+    """Standalone PyTorch SparseBox3DRefinementModule."""
+
+    def __init__(
+        self,
+        embed_dims=256,
+        output_dim=11,
+        num_cls=10,
+        refine_yaw=True,
+        with_quality_estimation=True,
+    ):
+        super().__init__()
+        self.embed_dims = embed_dims
+        self.output_dim = output_dim
+        self.num_cls = num_cls
+        self.refine_yaw = refine_yaw
+
+        self.refine_state = [X, Y, Z, W, L, H]
+        if refine_yaw:
+            self.refine_state += [SIN_YAW, COS_YAW]
+
+        self.layers = nn.Sequential(
+            *_linear_relu_ln(embed_dims, 2, 2),
+            nn.Linear(embed_dims, output_dim),
+            _Scale([1.0] * output_dim),
+        )
+        self.cls_layers = nn.Sequential(
+            *_linear_relu_ln(embed_dims, 1, 2),
+            nn.Linear(embed_dims, num_cls),
+        )
+        self.with_quality_estimation = with_quality_estimation
+        if with_quality_estimation:
+            self.quality_layers = nn.Sequential(
+                *_linear_relu_ln(embed_dims, 1, 2),
+                nn.Linear(embed_dims, 2),
+            )
+
+    def forward(self, instance_feature, anchor, anchor_embed, time_interval=1.0, return_cls=True):
+        feature = instance_feature + anchor_embed
+        output = self.layers(feature)
+        output[..., self.refine_state] = (
+            output[..., self.refine_state] + anchor[..., self.refine_state]
+        )
+        if self.output_dim > 8:
+            if not isinstance(time_interval, torch.Tensor):
+                time_interval = instance_feature.new_tensor(time_interval)
+            translation = torch.transpose(output[..., VX:], 0, -1)
+            velocity = torch.transpose(translation / time_interval, 0, -1)
+            output[..., VX:] = velocity + anchor[..., VX:]
+
+        cls = None
+        if return_cls:
+            cls = self.cls_layers(instance_feature)
+
+        quality = None
+        if return_cls and self.with_quality_estimation:
+            quality = self.quality_layers(feature)
+
+        return output, cls, quality
+
+
+class _Scale(nn.Module):
+    """Mimics mmcv Scale."""
+    def __init__(self, scale):
+        super().__init__()
+        self.scale = nn.Parameter(torch.tensor(scale, dtype=torch.float32))
+
+    def forward(self, x):
+        return x * self.scale
+
+
+def preprocess_refinement_parameters_from_pt(pt_module):
+    """Extract params from standalone PT refinement module."""
+    params = {}
+
+    modules = list(pt_module.layers.children())
+    scale_module = modules[-1]
+    final_linear = modules[-2]
+    chain_modules = modules[:-2]
+
+    params["refine_layers"] = _extract_linear_relu_ln_params(chain_modules)
+    params["refine_final_weight"] = final_linear.weight.data.clone().t()
+    params["refine_final_bias"] = final_linear.bias.data.clone()
+    params["refine_scale"] = scale_module.scale.data.clone()
+
+    cls_modules = list(pt_module.cls_layers.children())
+    cls_final = cls_modules[-1]
+    cls_chain = cls_modules[:-1]
+    params["cls_layers"] = _extract_linear_relu_ln_params(cls_chain)
+    params["cls_final_weight"] = cls_final.weight.data.clone().t()
+    params["cls_final_bias"] = cls_final.bias.data.clone()
+
+    if hasattr(pt_module, 'quality_layers'):
+        qt_modules = list(pt_module.quality_layers.children())
+        qt_final = qt_modules[-1]
+        qt_chain = qt_modules[:-1]
+        params["quality_layers"] = _extract_linear_relu_ln_params(qt_chain)
+        params["quality_final_weight"] = qt_final.weight.data.clone().t()
+        params["quality_final_bias"] = qt_final.bias.data.clone()
+
+    return params
+
+
+# ============================================================
+# Test 1: Full refinement (cls + quality)
+# ============================================================
+
+def test_full_refinement(device, bs=1, num_anchor=900):
+    embed_dims = 256
+    print("\n" + "=" * 65)
+    print(f"  [Test 1] Full refinement (cls+quality), bs={bs}, anchors={num_anchor}")
+    print("=" * 65)
+
+    torch.manual_seed(42)
+
+    pt_module = _PTRefinementModule(
+        embed_dims=embed_dims, output_dim=11, num_cls=10,
+        refine_yaw=True, with_quality_estimation=True,
+    )
+    pt_module.eval()
+
+    instance_feature = torch.randn(bs, num_anchor, embed_dims)
+    anchor = torch.randn(bs, num_anchor, 11)
+    anchor_embed = torch.randn(bs, num_anchor, embed_dims)
+    time_interval = torch.tensor([0.5] * bs)
+
+    with torch.no_grad():
+        pt_output, pt_cls, pt_quality = pt_module(
+            instance_feature, anchor, anchor_embed, time_interval
+        )
+
+    params = preprocess_refinement_parameters_from_pt(pt_module)
+    tt_module = SparseBox3DRefinementModule(
+        device, params,
+        embed_dims=embed_dims, output_dim=11, num_cls=10,
+        refine_yaw=True, with_quality_estimation=True,
+    )
+
+    inst_tt = ttnn.from_torch(instance_feature.float(), layout=ttnn.TILE_LAYOUT, device=device)
+    anch_tt = ttnn.from_torch(anchor.float(), layout=ttnn.TILE_LAYOUT, device=device)
+    embed_tt = ttnn.from_torch(anchor_embed.float(), layout=ttnn.TILE_LAYOUT, device=device)
+    ti_tt = ttnn.from_torch(
+        time_interval.reshape(1, 1, 1, bs).float(),
+        layout=ttnn.TILE_LAYOUT, device=device,
+    )
+    ti_tt = ttnn.reshape(ti_tt, (bs,))
+
+    tt_output, tt_cls, tt_quality = tt_module.run(
+        inst_tt, anch_tt, embed_tt, ti_tt,
+        bs=bs, num_anchor=num_anchor, return_cls=True,
+    )
+
+    # Compare refined anchor
+    tt_out_pt = ttnn.to_torch(tt_output)
+    if tt_out_pt.shape != pt_output.shape:
+        tt_out_pt = tt_out_pt[:bs, :num_anchor, :11]
+    result_anchor = compare_tensors(pt_output, tt_out_pt, "Refined anchor")
+
+    # Compare cls
+    tt_cls_pt = ttnn.to_torch(tt_cls)
+    if tt_cls_pt.shape != pt_cls.shape:
+        tt_cls_pt = tt_cls_pt[:bs, :num_anchor, :10]
+    result_cls = compare_tensors(pt_cls, tt_cls_pt, "Classification")
+
+    # Compare quality
+    tt_qt_pt = ttnn.to_torch(tt_quality)
+    if tt_qt_pt.shape != pt_quality.shape:
+        tt_qt_pt = tt_qt_pt[:bs, :num_anchor, :2]
+    result_qt = compare_tensors(pt_quality, tt_qt_pt, "Quality")
+
+    return result_anchor["pcc"], result_cls["pcc"], result_qt["pcc"]
+
+
+# ============================================================
+# Test 2: Without quality estimation
+# ============================================================
+
+def test_no_quality(device, bs=1, num_anchor=900):
+    embed_dims = 256
+    print("\n" + "=" * 65)
+    print(f"  [Test 2] No quality estimation, bs={bs}, anchors={num_anchor}")
+    print("=" * 65)
+
+    torch.manual_seed(123)
+
+    pt_module = _PTRefinementModule(
+        embed_dims=embed_dims, output_dim=11, num_cls=10,
+        refine_yaw=True, with_quality_estimation=False,
+    )
+    pt_module.eval()
+
+    instance_feature = torch.randn(bs, num_anchor, embed_dims)
+    anchor = torch.randn(bs, num_anchor, 11)
+    anchor_embed = torch.randn(bs, num_anchor, embed_dims)
+    time_interval = torch.tensor([0.5] * bs)
+
+    with torch.no_grad():
+        pt_output, pt_cls, _ = pt_module(
+            instance_feature, anchor, anchor_embed, time_interval
+        )
+
+    params = preprocess_refinement_parameters_from_pt(pt_module)
+    tt_module = SparseBox3DRefinementModule(
+        device, params,
+        embed_dims=embed_dims, output_dim=11, num_cls=10,
+        refine_yaw=True, with_quality_estimation=False,
+    )
+
+    inst_tt = ttnn.from_torch(instance_feature.float(), layout=ttnn.TILE_LAYOUT, device=device)
+    anch_tt = ttnn.from_torch(anchor.float(), layout=ttnn.TILE_LAYOUT, device=device)
+    embed_tt = ttnn.from_torch(anchor_embed.float(), layout=ttnn.TILE_LAYOUT, device=device)
+    ti_tt = ttnn.from_torch(
+        time_interval.reshape(1, 1, 1, bs).float(),
+        layout=ttnn.TILE_LAYOUT, device=device,
+    )
+    ti_tt = ttnn.reshape(ti_tt, (bs,))
+
+    tt_output, tt_cls, tt_quality = tt_module.run(
+        inst_tt, anch_tt, embed_tt, ti_tt,
+        bs=bs, num_anchor=num_anchor, return_cls=True,
+    )
+
+    tt_out_pt = ttnn.to_torch(tt_output)
+    if tt_out_pt.shape != pt_output.shape:
+        tt_out_pt = tt_out_pt[:bs, :num_anchor, :11]
+    result_anchor = compare_tensors(pt_output, tt_out_pt, "Refined anchor (no quality)")
+
+    tt_cls_pt = ttnn.to_torch(tt_cls)
+    if tt_cls_pt.shape != pt_cls.shape:
+        tt_cls_pt = tt_cls_pt[:bs, :num_anchor, :10]
+    result_cls = compare_tensors(pt_cls, tt_cls_pt, "Classification (no quality)")
+
+    assert tt_quality is None, "Quality should be None"
+
+    return result_anchor["pcc"], result_cls["pcc"]
+
+
+# ============================================================
+# Main
+# ============================================================
+
+def main():
+    print("=" * 65)
+    print("SparseBox3DRefinementModule PCC Test: PyTorch vs TT-NN")
+    print("=" * 65)
+
+    device = ttnn.open_device(device_id=0, l1_small_size=24576)
+    try:
+        compute_grid = device.compute_with_storage_grid_size()
+        print(f"  Device: {device.arch()}, grid: {compute_grid.x}x{compute_grid.y}")
+
+        pcc_anch, pcc_cls, pcc_qt = test_full_refinement(device, bs=1, num_anchor=900)
+        pcc_anch2, pcc_cls2 = test_no_quality(device, bs=1, num_anchor=900)
+
+        print(f"\n{'=' * 65}")
+        print("Final Summary:")
+        print(f"  [Test 1] Anchor PCC:    {pcc_anch:.6f}")
+        print(f"  [Test 1] Cls PCC:       {pcc_cls:.6f}")
+        print(f"  [Test 1] Quality PCC:   {pcc_qt:.6f}")
+        print(f"  [Test 2] Anchor PCC:    {pcc_anch2:.6f}")
+        print(f"  [Test 2] Cls PCC:       {pcc_cls2:.6f}")
+        print(f"{'=' * 65}")
+
+    except Exception as e:
+        import traceback
+        traceback.print_exc()
+        print(f"  FAILED: {str(e)[:200]}")
+
+    finally:
+        ttnn.close_device(device)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION

  ## Implement

  ### SparseBox3DEncoder

  | Operation | ttnn op |
  |-----------|---------|
  | Slice (pos/size/yaw/vel) | `ttnn.slice` |
  | Linear → ReLU → LayerNorm (×4) | `ttnn.linear`, `ttnn.relu`, `ttnn.layer_norm` |
  | Cat / Add | `ttnn.concat` / `ttnn.add` |

  ### SparseBox3DRefinementModule

  | Operation | ttnn op |
  |-----------|---------|
  | Add (feature + anchor_embed) | `ttnn.add` |
  | Linear → ReLU → LayerNorm (×4) | `ttnn.linear`, `ttnn.relu`, `ttnn.layer_norm` |
  | Linear (256 → 11) + Scale | `ttnn.linear`, `ttnn.multiply` |
  | Velocity refinement (÷ time_interval) | `ttnn.reciprocal`, `ttnn.multiply` |
  | Residual refinement | `ttnn.slice`, `ttnn.add`, `ttnn.concat` |
  | Cls branch (Linear → ReLU → LN → Linear) | `ttnn.linear`, `ttnn.relu`, `ttnn.layer_norm` |
  | Quality branch | same as cls |

  ### InstanceBank

  | Operation | ttnn op |
  |-----------|---------|
  | Anchor/feature tiling | `ttnn.from_torch` |
  | Anchor projection | host (numpy metas for T_global) |
  | Top-K selection | `torch.topk` + `torch.gather` → device |
  | Confidence decay | `torch.sigmoid`, `torch.maximum` |
  | Mask-based merge | `torch.where` |

  ## Related

  - #1

  ## Test Metrics

  ### SparseBox3DEncoder (`test/encoder_pcc.py`)

  | Test | PCC | MaxDiff | MeanDiff |
  |------|-----|---------|----------|
  | Cat mode `[128,32,32,64]` | 0.999982 | 0.0642 | 0.004220 |
  | Add mode `256` | 0.999972 | 0.0555 | 0.005081 |

  ### SparseBox3DRefinementModule (`test/refinement_pcc.py`)

  | Test | PCC | MaxDiff | MeanDiff |
  |------|-----|---------|----------|
  | Refined anchor | 0.999997 | 0.0173 | 0.002539 |
  | Classification | 0.999995 | 0.0072 | 0.001463 |
  | Quality | 0.999997 | 0.0065 | 0.001372 |

  ### All Modules Summary (`test/all_pcc.py`)

  | Module | PCC | MaxDiff | MeanDiff | Pass |
  |--------|-----|---------|----------|------|
  | MHA self-attn | 1.000000 | 0.0024 | 0.000381 | OK |
  | MHA cross-attn | 1.000000 | 0.0024 | 0.000371 | OK |
  | FFN asymmetric (512→256) | 0.999999 | 0.0115 | 0.001712 | OK |
  | FFN symmetric (256→256) | 0.999999 | 0.0063 | 0.001076 | OK |
  | Encoder cat mode | 0.999982 | 0.0642 | 0.004220 | OK |
  | Encoder add mode | 0.999972 | 0.0555 | 0.005081 | OK |
  | Refinement anchor | 0.999997 | 0.0173 | 0.002539 | OK |
  | Refinement cls | 0.999995 | 0.0072 | 0.001463 | OK |
  | Refinement quality | 0.999997 | 0.0065 | 0.001372 | OK |
  | **Average** | **0.999993** | | | **ALL PASS** |
