### PR TITLE
performance: optimized projection_mat, fusion

### DIFF
--- a/model/deformable_feature_aggregation.py
+++ b/model/deformable_feature_aggregation.py
@@ -621,44 +621,31 @@ class DeformableFeatureAggregation:
         bs: int,
         num_anchor: int,
     ) -> ttnn.Tensor:
-        """Weighted fusion on device.
+        """Weighted fusion on device via repeat_interleave + element-wise multiply + sum.
 
         Args:
             features: [bs*num_anchor, cams*levels*pts, embed_dims] on device
             weights: [bs*num_anchor, cams*levels*pts, num_groups] on device
 
         Returns:
-            output: [bs*num_anchor, embed_dims] on device
+            output: [1, 1, bs*num_anchor, embed_dims] on device
         """
         total_clp = self.num_cams * self.num_levels * self.num_pts
         n = bs * num_anchor  # 900
 
-        # Use matmul instead of multiply+sum(dim=1) for efficiency
-        # Original: features[n,clp,G,D] * weights[n,clp,G,1] → sum(dim=1) → [n,G,D]
-        # Matmul:   weights[n*G,1,clp] @ features[n*G,clp,D] → [n*G,1,D]
-        logger.debug(f"fusion: matmul approach, n={n}, clp={total_clp}, groups={self.num_groups}")
+        # Expand weights [n, clp, G] → [n, clp, embed_dims] by repeating each group value D times
+        # repeat_interleave on 2D: [n*clp, G] → [n*clp, G*D=embed_dims]
+        weights = ttnn.reshape(weights, (n * total_clp, self.num_groups))
+        weights = ttnn.repeat_interleave(weights, self.group_dims, dim=-1)
+        weights = ttnn.reshape(weights, (n, total_clp, self.embed_dims))
 
-        # features: [n, clp, embed_dims] → [n, clp, G, D] → [n, G, clp, D] → [n*G, clp, D]
-        features = ttnn.reshape(features, (n, total_clp, self.num_groups, self.group_dims))
-        features = ttnn.transpose(features, 1, 2)  # [n, G, clp, D]
-        features = ttnn.reshape(features, (n * self.num_groups, total_clp, self.group_dims))
-
-        # weights: [n, clp, G] → [n, G, clp] → [n*G, 1, clp]
-        weights = ttnn.transpose(weights, -2, -1)  # [n, G, clp]
-        weights = ttnn.reshape(weights, (n * self.num_groups, 1, total_clp))
-        logger.debug("fusion: reshape done")
-
-        # matmul: [n*G, 1, clp] @ [n*G, clp, D] = [n*G, 1, D]
-        summed = ttnn.matmul(weights, features, compute_kernel_config=self._hifi_compute_config)
-        ttnn.synchronize_device(self.device)
-        logger.debug("fusion: matmul done")
-        ttnn.deallocate(features)
+        # Element-wise multiply + sum over clp dimension
+        features = ttnn.multiply(features, weights)
         ttnn.deallocate(weights)
+        features = ttnn.sum(features, dim=1)
 
-        # Reshape: [n*G, 1, D] → [n, G, D] → [1, 1, n, embed_dims]
-        features = ttnn.reshape(summed, (n, self.num_groups, self.group_dims))
+        # Reshape: [n, 1, embed_dims] → [1, 1, n, embed_dims]
         features = ttnn.reshape(features, (1, 1, n, self.embed_dims))
-        logger.debug("fusion: final reshape done")
 
         return features
 

--- a/model/sparse4d_head.py
+++ b/model/sparse4d_head.py
@@ -315,7 +315,17 @@ class Sparse4DHead:
             temp_anchor_embed = None
             num_temp = 0
 
-        # 3. Decoder loop
+        # 3. Pre-allocate projection_mat and image_wh on device (reused across decoder loop)
+        proj_tt = ttnn.from_torch(
+            metas["projection_mat"].float(),
+            layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32,
+        )
+        wh_tt = ttnn.from_torch(
+            metas["image_wh"].float(),
+            layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32,
+        )
+
+        # 4. Decoder loop
         prediction = []
         classification = []
         quality = []
@@ -375,21 +385,11 @@ class Sparse4DHead:
 
             elif op == "deformable":
                 dfa = self.layers[i]
-                proj_tt = ttnn.from_torch(
-                    metas["projection_mat"].float(),
-                    layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32,
-                )
-                wh_tt = ttnn.from_torch(
-                    metas["image_wh"].float(),
-                    layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32,
-                )
                 instance_feature = dfa.run(
                     instance_feature, anchor, anchor_embed,
                     feature_maps, proj_tt, wh_tt,
                     self.spatial_shapes, bs=bs, num_anchor=num_anchor,
                 )
-                ttnn.deallocate(proj_tt)
-                ttnn.deallocate(wh_tt)
 
             elif op == "ffn":
                 ffn = self.layers[i]
@@ -455,7 +455,11 @@ class Sparse4DHead:
                 if op == "refine":
                     debug_intermediates[f"step_{i}_anchor"] = ttnn.to_torch(anchor)
 
-        # 4. Cache for next frame
+        # 5. Deallocate projection_mat and image_wh
+        ttnn.deallocate(proj_tt)
+        ttnn.deallocate(wh_tt)
+
+        # 6. Cache for next frame
         last_cls = classification[-1]
         if last_cls is not None:
             self.instance_bank.cache(


### PR DESCRIPTION
## Implement

- `sparse4d_head.py` use `projection_mat` in iteration. refactor this for projection_mat reused in iteration
- `DFA` use batch matmul in device. but use `repeat_interleave` befor multiply more efficient. 

before
reshape 4D → transpose → reshape 3D → batch matmul [900,312,256] → [900,312,8,32] → [900,8,312,32] → [7200,1,312]@[7200,312,32]

refactor
repeat_interleave → element-wise multiply → sum weights [900,312,8] → repeat_interleave → [900,312,256] features × weights → sum(dim=1) → [900,256]

## Related

#11 

## Test

- 6019 samples, avg **~0.87s/sample**
- dual-device mesh (batch=3 x 2), HiFi4+fp32_dest_acc

| Metric | Value | vs 이전 (3/26) |
|---|---|---|
| mAP | **0.2993** | +0.0024 |
| NDS | **0.3345** | +0.0019 |
| mATE | 0.7641 | -0.006 |
| mASE | 0.2760 | +0.001 |
| mAOE | 0.7614 | +0.003 |
| mAVE | 2.7261 | -0.033 |
| mAAE | 0.3496 | -0.005 |

### Per-class AP
| Class | AP | ATE | ASE | AOE | AVE | AAE |
|---|---|---|---|---|---|---|
| car | 0.504 | 0.538 | 0.151 | 0.302 | 4.991 | 0.409 |
| truck | 0.221 | 0.825 | 0.228 | 0.361 | 3.659 | 0.529 |
| bus | 0.287 | 0.928 | 0.224 | 0.377 | 4.535 | 0.396 |
| trailer | 0.093 | 1.162 | 0.235 | 0.905 | 1.121 | 0.298 |
| construction_vehicle | 0.029 | 1.089 | 0.500 | 1.342 | 0.747 | 0.525 |
| pedestrian | 0.381 | 0.697 | 0.296 | 1.151 | 1.334 | 0.262 |
| motorcycle | 0.276 | 0.696 | 0.247 | 0.915 | 3.360 | 0.179 |
| bicycle | 0.200 | 0.704 | 0.270 | 0.946 | 2.061 | 0.198 |
| traffic_cone | 0.514 | 0.461 | 0.314 | nan | nan | nan |
| barrier | 0.489 | 0.539 | 0.294 | 0.554 | nan | nan |