### PR TITLE
Feat: implement mesh modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ debug/
 
 # Documents
 *.pdf
+
+# AI
+.claude/
+logs/

--- a/model/asymmetric_ffn.py
+++ b/model/asymmetric_ffn.py
@@ -35,14 +35,16 @@ class AsymmetricFFN:
         in_channels: int = 512,
         embed_dims: int = 256,
         feedforward_channels: int = 1024,
+        mesh_device=None,
     ) -> None:
-        self.device = device
+        self.device = mesh_device if mesh_device is not None else device
+        self._mesh_device = mesh_device
         self.in_channels = in_channels
         self.embed_dims = embed_dims
         self.feedforward_channels = feedforward_channels
         self._hifi_compute_config = ttnn.init_device_compute_kernel_config(
-            device.arch(), math_fidelity=ttnn.MathFidelity.HiFi4,
-            fp32_dest_acc_en=True, packer_l1_acc=False, math_approx_mode=False,
+            device.arch(), math_fidelity=ttnn.MathFidelity.HiFi2,
+            fp32_dest_acc_en=False, packer_l1_acc=False, math_approx_mode=False,
         )
 
         # pre_norm: LayerNorm(in_channels)
@@ -68,23 +70,26 @@ class AsymmetricFFN:
     def _to_device(self, tensor: torch.Tensor) -> ttnn.Tensor:
         if tensor.dim() == 1:
             tensor = tensor.unsqueeze(0)
-        return ttnn.from_torch(
-            tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32
-        )
+        kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
+        if self._mesh_device is not None:
+            kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+        return ttnn.from_torch(tensor.float(), **kwargs)
 
     def _to_device_bias(self, tensor: torch.Tensor) -> ttnn.Tensor:
         if tensor.dim() == 1:
             tensor = tensor.reshape(1, 1, 1, -1)
-        return ttnn.from_torch(
-            tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32
-        )
+        kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
+        if self._mesh_device is not None:
+            kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+        return ttnn.from_torch(tensor.float(), **kwargs)
 
     def _to_device_1d(self, tensor: torch.Tensor) -> ttnn.Tensor:
         if tensor.dim() == 1:
             tensor = tensor.reshape(1, 1, 1, -1)
-        return ttnn.from_torch(
-            tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32
-        )
+        kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
+        if self._mesh_device is not None:
+            kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+        return ttnn.from_torch(tensor.float(), **kwargs)
 
     def run(
         self,
@@ -102,53 +107,26 @@ class AsymmetricFFN:
         Returns:
             output: [bs, num_tokens, embed_dims] on device (TILE)
         """
-        # Flatten for linear ops: [1, 1, bs*num_tokens, in_channels]
         x_flat = ttnn.reshape(x, (1, 1, bs * num_tokens, self.in_channels))
+        normed = ttnn.layer_norm(x_flat, weight=self.pre_norm_weight, bias=self.pre_norm_bias,
+                                  epsilon=1e-5, compute_kernel_config=self._hifi_compute_config)
 
-        # --- 1. Pre-norm (LayerNorm) ---
-        normed = ttnn.layer_norm(
-            x_flat, weight=self.pre_norm_weight, bias=self.pre_norm_bias,
-            epsilon=1e-5,
-            compute_kernel_config=self._hifi_compute_config,
-        )
-
-        # --- 2. Identity path (use normed input, matching mmcv AsymmetricFFN) ---
-        # mmcv default: identity=None → identity = pre_norm(x), then identity_fc(identity)
         if self.has_identity_fc:
-            identity = ttnn.linear(
-                normed, self.identity_fc_weight, bias=self.identity_fc_bias,
-                compute_kernel_config=self._hifi_compute_config,
-            )
+            identity = ttnn.linear(normed, self.identity_fc_weight, bias=self.identity_fc_bias,
+                                    compute_kernel_config=self._hifi_compute_config)
         else:
             identity = normed
 
-        # --- 3. Linear(in_channels → feedforward_channels) + ReLU ---
         fc1_out = ttnn.linear(normed, self.fc1_weight, bias=self.fc1_bias, compute_kernel_config=self._hifi_compute_config)
-        # Only deallocate normed if identity doesn't alias it (asymmetric case)
         if self.has_identity_fc:
             ttnn.deallocate(normed)
-
         relu_out = ttnn.relu(fc1_out)
-
-        # --- 4. Linear(feedforward_channels → embed_dims) ---
         projected = ttnn.linear(relu_out, self.fc2_weight, bias=self.fc2_bias, compute_kernel_config=self._hifi_compute_config)
+        ttnn.deallocate(fc1_out); ttnn.deallocate(relu_out)
 
-        # Sync + deallocate large intermediates (1024-dim tensors)
-        ttnn.synchronize_device(self.device)
-        ttnn.deallocate(fc1_out)
-        ttnn.deallocate(relu_out)
-
-        # --- 5. Residual ---
         output = ttnn.add(identity, projected)
-
-        # Sync + deallocate
-        ttnn.synchronize_device(self.device)
-        ttnn.deallocate(projected)
-        ttnn.deallocate(identity)
-
-        output = ttnn.reshape(output, (bs, num_tokens, self.embed_dims))
-
-        return output
+        ttnn.deallocate(projected); ttnn.deallocate(identity)
+        return ttnn.reshape(output, (bs, num_tokens, self.embed_dims))
 
 def preprocess_ffn_parameters(pt_ffn_layer) -> dict:
     """Extract parameters from mmcv AsymmetricFFN.

--- a/model/deformable_feature_aggregation.py
+++ b/model/deformable_feature_aggregation.py
@@ -45,8 +45,10 @@ class DeformableFeatureAggregation:
         num_learnable_pts: int = 6,
         use_camera_embed: bool = True,
         residual_mode: str = "cat",
+        mesh_device=None,
     ) -> None:
-        self.device = device
+        self.device = mesh_device if mesh_device is not None else device
+        self._mesh_device = mesh_device
         self.embed_dims = embed_dims
         self.num_groups = num_groups
         self.group_dims = embed_dims // num_groups  # 32
@@ -61,25 +63,19 @@ class DeformableFeatureAggregation:
         # HiFi compute config for precision-sensitive operations
         self._hifi_compute_config = ttnn.init_device_compute_kernel_config(
             device.arch(),
-            math_fidelity=ttnn.MathFidelity.HiFi4,
-            fp32_dest_acc_en=True,
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            fp32_dest_acc_en=False,
             packer_l1_acc=False,
             math_approx_mode=False,
         )
 
         # Pre-allocate scalar constants on device (reused per camera in _project_points)
-        self._scalar_two = ttnn.from_torch(
-            torch.full((1, 1, 1), 2.0),
-            layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.float32,
-        )
-        self._scalar_one = ttnn.from_torch(
-            torch.full((1, 1, 1), 1.0),
-            layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.float32,
-        )
-        self._scalar_half = ttnn.from_torch(
-            torch.full((1, 1, 1), 0.5),
-            layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.float32,
-        )
+        _skw = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
+        if self._mesh_device is not None:
+            _skw["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+        self._scalar_two = ttnn.from_torch(torch.full((1, 1, 1), 2.0), **_skw)
+        self._scalar_one = ttnn.from_torch(torch.full((1, 1, 1), 1.0), **_skw)
+        self._scalar_half = ttnn.from_torch(torch.full((1, 1, 1), 0.5), **_skw)
 
         # --- Move all parameters to TT device ---
         # Note: PyTorch nn.Linear stores weight as [out, in],
@@ -129,25 +125,28 @@ class DeformableFeatureAggregation:
         """Move weight tensor to device in TILE layout."""
         if tensor.dim() == 1:
             tensor = tensor.unsqueeze(0)
-        if tensor.dim() == 2:
-            # Pad to tile-aligned if needed
-            pass
-        t = ttnn.from_torch(tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32)
-        return t
+        kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
+        if self._mesh_device is not None:
+            kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+        return ttnn.from_torch(tensor.float(), **kwargs)
 
     def _to_device_bias(self, tensor: torch.Tensor) -> ttnn.Tensor:
         """Move bias tensor to device as [1, 1, 1, N] in TILE layout."""
         if tensor.dim() == 1:
             tensor = tensor.reshape(1, 1, 1, -1)
-        t = ttnn.from_torch(tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32)
-        return t
+        kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
+        if self._mesh_device is not None:
+            kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+        return ttnn.from_torch(tensor.float(), **kwargs)
 
     def _to_device_1d(self, tensor: torch.Tensor) -> ttnn.Tensor:
         """Move 1D tensor (LayerNorm weight/bias) to device as [1, 1, 1, N]."""
         if tensor.dim() == 1:
             tensor = tensor.reshape(1, 1, 1, -1)
-        t = ttnn.from_torch(tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32)
-        return t
+        kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
+        if self._mesh_device is not None:
+            kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+        return ttnn.from_torch(tensor.float(), **kwargs)
 
     def _kps_generator(
         self,
@@ -172,7 +171,6 @@ class DeformableFeatureAggregation:
             anchor, [0, 0, W], [bs, num_anchor, H + 1]
         )  # [bs, num_anchor, 3]
         size = ttnn.exp(size_wlh)  # [bs, num_anchor, 3]
-        ttnn.synchronize_device(self.device)
         ttnn.deallocate(size_wlh)
         logger.debug("_kps_generator: slice+exp done")
 
@@ -182,7 +180,6 @@ class DeformableFeatureAggregation:
         # Fixed key points: fix_scale [7, 3] * size [bs*num_anchor, 1, 3]
         fix_scale_3d = ttnn.reshape(self.fix_scale, (1, 7, 3))
         fix_kps = ttnn.multiply(fix_scale_3d, size_3d)  # [bs*num_anchor, 7, 3]
-        ttnn.synchronize_device(self.device)
         logger.debug("_kps_generator: fix_kps done")
 
         # Learnable key points
@@ -193,7 +190,6 @@ class DeformableFeatureAggregation:
             inst_flat, self.learnable_fc_weight, bias=self.learnable_fc_bias,
             compute_kernel_config=self._hifi_compute_config,
         )  # [1, 1, bs*num_anchor, 18]
-        ttnn.synchronize_device(self.device)
         logger.debug("_kps_generator: learnable linear done")
 
         learnable = ttnn.reshape(
@@ -202,22 +198,26 @@ class DeformableFeatureAggregation:
         learnable = ttnn.sigmoid(learnable)
         learnable = ttnn.subtract(learnable, self._scalar_half)  # sigmoid - 0.5
         learnable_kps = ttnn.multiply(learnable, size_3d)  # [bs*num_anchor, 6, 3]
-        ttnn.synchronize_device(self.device)
         ttnn.deallocate(learnable)
         # Note: size_3d is a reshape (view) of size, don't deallocate separately
         logger.debug("_kps_generator: learnable_kps done")
 
         # Concat fixed + learnable: [bs*num_anchor, 13, 3]
         key_points = ttnn.concat([fix_kps, learnable_kps], dim=1)
-        ttnn.synchronize_device(self.device)
         ttnn.deallocate(fix_kps)
         ttnn.deallocate(learnable_kps)
         logger.debug("_kps_generator: concat done")
 
         # --- Host fallback for rotation + translation (small tensors, avoids TILE hang) ---
-        key_points_torch = ttnn.to_torch(key_points)  # [bs*num_anchor, 13, 3]
-        ttnn.deallocate(key_points)
-        anchor_torch = ttnn.to_torch(anchor)  # [bs, num_anchor, 11]
+        if self._mesh_device is not None:
+            _composer = ttnn.ConcatMeshToTensor(self._mesh_device, dim=0)
+            key_points_torch = ttnn.to_torch(key_points, mesh_composer=_composer)[:bs * num_anchor]
+            ttnn.deallocate(key_points)
+            anchor_torch = ttnn.to_torch(anchor, mesh_composer=_composer)[:bs]
+        else:
+            key_points_torch = ttnn.to_torch(key_points)  # [bs*num_anchor, 13, 3]
+            ttnn.deallocate(key_points)
+            anchor_torch = ttnn.to_torch(anchor)  # [bs, num_anchor, 11]
 
         cos_yaw = anchor_torch[:, :, COS_YAW].reshape(bs * num_anchor, 1)  # [900, 1]
         sin_yaw = anchor_torch[:, :, SIN_YAW].reshape(bs * num_anchor, 1)  # [900, 1]
@@ -237,12 +237,12 @@ class DeformableFeatureAggregation:
 
         # Reshape to [bs, num_anchor*num_pts, 3] and send back to device
         key_points_torch = key_points_torch.reshape(bs, num_anchor * self.num_pts, 3)
-        key_points = ttnn.from_torch(
-            key_points_torch.float(),
-            layout=ttnn.TILE_LAYOUT,
-            device=self.device,
-            dtype=ttnn.float32,
-        )
+        # Use float32 for key_points (feeds into projection → grid_sample)
+        _kw_f32 = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32)
+        if self._mesh_device is not None:
+            _kw_f32["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+        key_points = ttnn.from_torch(key_points_torch.float(), **_kw_f32)
+        del key_points_torch, anchor_torch
         logger.debug("_kps_generator: rotation+translate (host) done")
 
         return key_points
@@ -268,12 +268,11 @@ class DeformableFeatureAggregation:
         n_pts_total = num_anchor * self.num_pts
 
         # Append ones for homogeneous: [bs, n_pts_total, 4]
-        ones = ttnn.from_torch(
-            torch.ones(bs, n_pts_total, 1),
-            layout=ttnn.TILE_LAYOUT,
-            device=self.device,
-            dtype=ttnn.float32,
-        )
+        # Use float32 for projection (grid_sample requires float32 grid)
+        _kw_f32 = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32)
+        if self._mesh_device is not None:
+            _kw_f32["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+        ones = ttnn.from_torch(torch.ones(bs, n_pts_total, 1), **_kw_f32)
         pts_homo = ttnn.concat([key_points, ones], dim=-1)  # [bs, n_pts_total, 4]
 
         # Per-camera projection via loop (avoid 6D tensor)
@@ -289,7 +288,6 @@ class DeformableFeatureAggregation:
 
             proj_t = ttnn.transpose(proj, -2, -1)
             projected = ttnn.matmul(pts_homo, proj_t, compute_kernel_config=self._hifi_compute_config)
-            ttnn.synchronize_device(self.device)
             ttnn.deallocate(proj)
             ttnn.deallocate(proj_t)
             logger.debug(f"DFA _project_points: cam {cam_idx} matmul done")
@@ -299,7 +297,6 @@ class DeformableFeatureAggregation:
             z_clamped = ttnn.clamp(z, min=1e-5)
             z_recip = ttnn.reciprocal(z_clamped)
             xy_div = ttnn.multiply(xy, z_recip)
-            ttnn.synchronize_device(self.device)
             ttnn.deallocate(projected)
             ttnn.deallocate(xy)
             ttnn.deallocate(z)
@@ -315,7 +312,6 @@ class DeformableFeatureAggregation:
 
             xy_scaled = ttnn.multiply(xy_norm, self._scalar_two)
             xy_grid = ttnn.subtract(xy_scaled, self._scalar_one)
-            ttnn.synchronize_device(self.device)
             ttnn.deallocate(xy_div)
             ttnn.deallocate(wh_recip)
             ttnn.deallocate(xy_norm)
@@ -348,7 +344,6 @@ class DeformableFeatureAggregation:
             for s in interleaved:
                 ttnn.deallocate(s)
 
-        ttnn.synchronize_device(self.device)
         ttnn.deallocate(pts_homo)
         ttnn.deallocate(ones)
         for p in all_cam_points:
@@ -391,7 +386,6 @@ class DeformableFeatureAggregation:
         x = ttnn.relu(x)
         relu_out = x
         x = ttnn.layer_norm(x, weight=self.cam_ln2_weight, bias=self.cam_ln2_bias, epsilon=1e-5, compute_kernel_config=self._hifi_compute_config)
-        ttnn.synchronize_device(self.device)
         ttnn.deallocate(relu_in)
         ttnn.deallocate(relu_out)
 
@@ -406,6 +400,7 @@ class DeformableFeatureAggregation:
         projection_mat: ttnn.Tensor,
         bs: int,
         num_anchor: int,
+        return_logits: bool = False,
     ) -> ttnn.Tensor:
         """Compute attention weights on device.
 
@@ -426,7 +421,6 @@ class DeformableFeatureAggregation:
                 camera_embed, (bs, 1, self.num_cams, self.embed_dims)
             )
             feature = ttnn.add(feat_exp, cam_exp)
-            ttnn.synchronize_device(self.device)
             ttnn.deallocate(camera_embed)
             feature = ttnn.reshape(
                 feature, (1, 1, bs * num_anchor * self.num_cams, self.embed_dims)
@@ -438,7 +432,6 @@ class DeformableFeatureAggregation:
             feature, self.weights_fc_weight, bias=self.weights_fc_bias,
             compute_kernel_config=self._hifi_compute_config,
         )
-        ttnn.synchronize_device(self.device)
 
         ttnn.deallocate(feature)
 
@@ -456,6 +449,9 @@ class DeformableFeatureAggregation:
             weights = ttnn.reshape(
                 weights, (bs * num_anchor, total_clp, self.num_groups)
             )
+
+        if return_logits:
+            return weights  # pre-softmax logits
 
         weights = ttnn.softmax(weights, dim=1, numeric_stable=True,
                                compute_kernel_config=self._hifi_compute_config)
@@ -485,34 +481,28 @@ class DeformableFeatureAggregation:
         """
         n_batch = bs * self.num_cams
 
-        # 1. grid_sample_lerp per level (lerp-based bilinear, device-only)
+        # Pre-convert grid once (reused across all levels)
+        grid = ttnn.to_layout(points_2d, ttnn.ROW_MAJOR_LAYOUT)
+        grid = ttnn.to_memory_config(grid, ttnn.DRAM_MEMORY_CONFIG)
+        if grid.dtype != ttnn.float32:
+            grid = ttnn.typecast(grid, ttnn.float32)
+
+        # 1. grid_sample_lerp per level
         all_level_features = []
         for level_idx, fm_tt in enumerate(feature_maps):
             h, w = spatial_shapes[level_idx]
-            logger.debug(f"==== DFA grid_sample_lerp level {level_idx}: spatial={h}x{w}")
 
             # Reshape feature map: [1, 1, N*H*W, C] -> [N, H, W, C] (NHWC)
             fm = ttnn.to_memory_config(fm_tt, ttnn.DRAM_MEMORY_CONFIG)
             fm = ttnn.to_layout(fm, ttnn.ROW_MAJOR_LAYOUT)
             fm = ttnn.reshape(fm, (n_batch, h, w, self.embed_dims))
 
-            # Grid: [bs*num_cams, num_anchor, num_pts, 2] — use float32 for precision
-            grid = ttnn.to_layout(points_2d, ttnn.ROW_MAJOR_LAYOUT)
-            grid = ttnn.to_memory_config(grid, ttnn.DRAM_MEMORY_CONFIG)
-            if grid.dtype != ttnn.float32:
-                grid = ttnn.typecast(grid, ttnn.float32)
-
-            sampled = ttnn.grid_sample_lerp(
-                fm, grid,
-                padding_mode="zeros",
-                align_corners=False,
-            )
-            # [bs*num_cams, num_anchor, num_pts, embed_dims]
-
+            sampled = ttnn.grid_sample_lerp(fm, grid, padding_mode="zeros", align_corners=False)
             sampled = ttnn.to_layout(sampled, ttnn.TILE_LAYOUT)
             sampled = ttnn.to_memory_config(sampled, ttnn.DRAM_MEMORY_CONFIG)
-
             all_level_features.append(sampled)
+
+        ttnn.deallocate(grid)
 
         # 2. Rearrange via slice + concat (no host transfer)
         #
@@ -681,7 +671,6 @@ class DeformableFeatureAggregation:
         # 1. Generate 3D key points
         logger.debug("DFA run: _kps_generator start")
         key_points = self._kps_generator(anchor, instance_feature, bs, num_anchor)
-        ttnn.synchronize_device(self.device)
         logger.debug("DFA run: _kps_generator done")
         # [bs, num_anchor*num_pts, 3]
 
@@ -712,12 +701,28 @@ class DeformableFeatureAggregation:
         logger.debug("DFA run: _multi_view_level_fusion done")
         ttnn.deallocate(points_2d)
 
+        # In mesh SPMD mode: each device has partial fusion (3 cams).
+        # Combine via host (all_reduce hangs on N300).
+        if self._mesh_device is not None:
+            logger.debug("DFA run: mesh combine start")
+            composer = ttnn.ConcatMeshToTensor(self._mesh_device, dim=0)
+            partials = ttnn.to_torch(features, mesh_composer=composer).float()
+            combined = partials[:1] + partials[1:]
+            del partials
+            ttnn.deallocate(features)
+            features = ttnn.from_torch(
+                combined, layout=ttnn.TILE_LAYOUT, device=self._mesh_device,
+                dtype=ttnn.bfloat16,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self._mesh_device),
+            )
+            del combined
+            logger.debug("DFA run: mesh combine done")
+
         logger.debug("DFA run: output_proj start")
         output = ttnn.linear(
             features, self.output_proj_weight, bias=self.output_proj_bias,
             compute_kernel_config=self._hifi_compute_config,
         )
-        ttnn.synchronize_device(self.device)
         ttnn.deallocate(features)
         logger.debug("DFA run: output_proj done")
 

--- a/model/instance_bank.py
+++ b/model/instance_bank.py
@@ -46,8 +46,10 @@ class InstanceBank:
         default_time_interval: float = 0.5,
         confidence_decay: float = 0.6,
         max_time_interval: float = 2.0,
+        mesh_device=None,
     ) -> None:
-        self.device = device
+        self.device = mesh_device if mesh_device is not None else device
+        self._mesh_device = mesh_device
         self.num_anchor = num_anchor
         self.embed_dims = embed_dims
         self.num_temp_instances = num_temp_instances
@@ -60,6 +62,19 @@ class InstanceBank:
         self.instance_feature_data = instance_feature_data.float()  # [num_anchor, embed_dims]
 
         self.reset()
+
+    def _to_dev(self, tensor: torch.Tensor) -> ttnn.Tensor:
+        """Helper: from_torch with mesh_mapper if mesh mode."""
+        kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
+        if self._mesh_device is not None:
+            kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+        return ttnn.from_torch(tensor.float(), **kwargs)
+
+    def _from_dev(self, tensor: ttnn.Tensor) -> torch.Tensor:
+        """Helper: to_torch with mesh_composer if mesh mode."""
+        if self._mesh_device is not None:
+            return ttnn.to_torch(tensor, mesh_composer=ttnn.ConcatMeshToTensor(self._mesh_device, dim=0)).float()[:1]
+        return ttnn.to_torch(tensor).float()
 
     def reset(self):
         """Reset temporal cache."""
@@ -100,7 +115,7 @@ class InstanceBank:
 
             # Anchor projection: transform cached anchors to current frame
             # Done on host since it requires numpy metas (T_global matrices)
-            cached_anchor_pt = ttnn.to_torch(self.cached_anchor)
+            cached_anchor_pt = self._from_dev(self.cached_anchor)
             T_temp2cur = torch.tensor(
                 np.stack([
                     x["T_global_inv"] @ self.metas["img_metas"][i]["T_global"]
@@ -119,9 +134,7 @@ class InstanceBank:
                 torch.tensor(self.default_time_interval, dtype=time_interval_pt.dtype),
             )
 
-            cached_anchor = ttnn.from_torch(
-                cached_anchor_pt.float(), layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32
-            )
+            cached_anchor = self._to_dev(cached_anchor_pt)
             cached_feature = self.cached_feature  # already on device
         else:
             self.reset()
@@ -130,18 +143,9 @@ class InstanceBank:
             )
 
         # Move to device
-        instance_feature = ttnn.from_torch(
-            feature_tiled, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32
-        )
-        anchor = ttnn.from_torch(
-            anchor_tiled, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32
-        )
-        time_interval = ttnn.from_torch(
-            time_interval_pt.reshape(1, 1, 1, bs),
-            layout=ttnn.TILE_LAYOUT,
-            device=self.device,
-            dtype=ttnn.float32,
-        )
+        instance_feature = self._to_dev(feature_tiled)
+        anchor = self._to_dev(anchor_tiled)
+        time_interval = self._to_dev(time_interval_pt.reshape(1, 1, 1, bs))
         time_interval = ttnn.reshape(time_interval, (bs,))
 
         return instance_feature, anchor, cached_feature, cached_anchor, time_interval
@@ -171,15 +175,15 @@ class InstanceBank:
         N = self.num_anchor - self.num_temp_instances  # 300
 
         # confidence max over classes: [bs, num_anchor, num_cls] → [bs, num_anchor]
-        conf_pt = ttnn.to_torch(confidence).float()
+        conf_pt = self._from_dev(confidence)
         conf_max = conf_pt.max(dim=-1).values  # [bs, num_anchor]
 
         # topk: select top-N by confidence
         _, top_indices = torch.topk(conf_max, N, dim=1)  # [bs, N]
 
         # Gather selected features and anchors on host
-        inst_pt = ttnn.to_torch(instance_feature).float()
-        anch_pt = ttnn.to_torch(anchor).float()
+        inst_pt = self._from_dev(instance_feature)
+        anch_pt = self._from_dev(anchor)
 
         selected_feature = torch.gather(
             inst_pt, 1,
@@ -191,8 +195,8 @@ class InstanceBank:
         )
 
         # Concat cached + selected
-        cached_feat_pt = ttnn.to_torch(self.cached_feature).float()
-        cached_anch_pt = ttnn.to_torch(self.cached_anchor).float()
+        cached_feat_pt = self._from_dev(self.cached_feature)
+        cached_anch_pt = self._from_dev(self.cached_anchor)
         merged_feature = torch.cat([cached_feat_pt, selected_feature], dim=1)
         merged_anchor = torch.cat([cached_anch_pt, selected_anchor], dim=1)
 
@@ -202,12 +206,8 @@ class InstanceBank:
         out_anchor = torch.where(mask, merged_anchor, anch_pt)
 
         # Back to device
-        instance_feature = ttnn.from_torch(
-            out_feature, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32
-        )
-        anchor = ttnn.from_torch(
-            out_anchor, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32
-        )
+        instance_feature = self._to_dev(out_feature)
+        anchor = self._to_dev(out_anchor)
 
         return instance_feature, anchor
 
@@ -234,12 +234,12 @@ class InstanceBank:
         self.metas = metas
 
         # confidence: max over classes → sigmoid
-        conf_pt = ttnn.to_torch(confidence).float()
+        conf_pt = self._from_dev(confidence)
         conf_scores = conf_pt.max(dim=-1).values.sigmoid()  # [bs, num_anchor]
 
         # Apply confidence decay to previously cached instances
         if self.confidence is not None:
-            prev_conf = ttnn.to_torch(self.confidence).float().squeeze()
+            prev_conf = self._from_dev(self.confidence).squeeze()
             if prev_conf.dim() == 1:
                 prev_conf = prev_conf.unsqueeze(0)
             decayed = prev_conf * self.confidence_decay
@@ -252,8 +252,8 @@ class InstanceBank:
             conf_scores, self.num_temp_instances, dim=1
         )
 
-        inst_pt = ttnn.to_torch(instance_feature).float()
-        anch_pt = ttnn.to_torch(anchor).float()
+        inst_pt = self._from_dev(instance_feature)
+        anch_pt = self._from_dev(anchor)
 
         cached_feature = torch.gather(
             inst_pt, 1,
@@ -264,18 +264,9 @@ class InstanceBank:
             top_indices.unsqueeze(-1).expand(-1, -1, anch_pt.shape[-1]),
         )
 
-        self.cached_feature = ttnn.from_torch(
-            cached_feature, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32
-        )
-        self.cached_anchor = ttnn.from_torch(
-            cached_anchor, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32
-        )
-        self.confidence = ttnn.from_torch(
-            top_conf.reshape(1, 1, bs, self.num_temp_instances),
-            layout=ttnn.TILE_LAYOUT,
-            device=self.device,
-            dtype=ttnn.float32,
-        )
+        self.cached_feature = self._to_dev(cached_feature)
+        self.cached_anchor = self._to_dev(cached_anchor)
+        self.confidence = self._to_dev(top_conf.reshape(1, 1, bs, self.num_temp_instances))
 
     @staticmethod
     def _anchor_projection(

--- a/model/mesh_dfa.py
+++ b/model/mesh_dfa.py
@@ -1,0 +1,335 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+DFA Camera Parallel Runner using 2 independent submeshes.
+No mesh device, no all_gather, no fabric.
+Each submesh processes 3 cameras independently.
+Results combined on host.
+"""
+
+import torch
+import ttnn
+from typing import List, Tuple
+from loguru import logger
+
+from model.deformable_feature_aggregation import DeformableFeatureAggregation
+
+
+class MeshDFARunner:
+    """Camera-parallel DFA using 2 submeshes (no mesh device needed)."""
+
+    def __init__(self, dfa0: DeformableFeatureAggregation, dev1, parameters, model_config, mesh_device=None):
+        """
+        Args:
+            dfa0: DFA instance on submesh0 (already constructed)
+            dev1: submesh1 device
+            parameters: DFA layer parameters (torch tensors)
+            model_config: model config dict
+            mesh_device: mesh device for all_gather_async (optional)
+        """
+        self.dfa0 = dfa0
+        self.dev1 = dev1
+        self.mesh_device = mesh_device
+
+        # Create semaphores for all_gather_async if mesh device available
+        if mesh_device is not None:
+            core_range = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0,0), ttnn.CoreCoord(7,7))})
+            self._ag_sem1 = ttnn.create_global_semaphore(mesh_device, core_range, 0)
+            self._ag_sem2 = ttnn.create_global_semaphore(mesh_device, core_range, 0)
+        self.embed_dims = dfa0.embed_dims
+        self.num_groups = dfa0.num_groups
+        self.group_dims = dfa0.group_dims
+        self.num_levels = dfa0.num_levels
+        self.num_cams_per_dev = 3
+        self.num_pts = dfa0.num_pts
+        self.residual_mode = dfa0.residual_mode
+
+        # Build DFA on dev1 (same weights, different device)
+        self.dfa1 = DeformableFeatureAggregation(
+            device=dev1,
+            parameters=parameters,
+            model_config=model_config,
+            embed_dims=dfa0.embed_dims,
+            num_groups=dfa0.num_groups,
+            num_levels=dfa0.num_levels,
+            num_cams=3,  # only 3 cameras per device
+            num_pts=dfa0.num_pts,
+            num_learnable_pts=dfa0.num_learnable_pts,
+            use_camera_embed=True,
+            residual_mode="add",  # we handle residual ourselves
+        )
+
+        # Cache KPS weights on host (avoid repeated device reads)
+        self._kps_fix_scale = ttnn.to_torch(dfa0.fix_scale).float().reshape(1, 7, 3)
+        self._kps_lfc_w = ttnn.to_torch(dfa0.learnable_fc_weight).float()
+        self._kps_lfc_b = ttnn.to_torch(dfa0.learnable_fc_bias).float().squeeze()
+
+    def _kps_host(self, dfa, anchor_pt, inst_pt, bs, num_anchor):
+        """KPS generator entirely on host (no device ops)."""
+        import torch.nn.functional as F
+        size = torch.exp(anchor_pt[:, :, 3:6]).reshape(bs * num_anchor, 1, 3)
+        fix_kps = self._kps_fix_scale * size
+        inst_flat = inst_pt.reshape(1, 1, bs * num_anchor, dfa.embed_dims)
+        learnable = F.linear(inst_flat, self._kps_lfc_w.t(), self._kps_lfc_b)
+        learnable = learnable.reshape(bs * num_anchor, dfa.num_learnable_pts, 3)
+        learnable = torch.sigmoid(learnable) - 0.5
+        learnable_kps = learnable * size
+
+        kp = torch.cat([fix_kps, learnable_kps], dim=1)
+        cos_yaw = anchor_pt[:, :, 7].reshape(bs * num_anchor, 1)
+        sin_yaw = anchor_pt[:, :, 6].reshape(bs * num_anchor, 1)
+        rot_x = cos_yaw * kp[:,:,0] - sin_yaw * kp[:,:,1]
+        rot_y = sin_yaw * kp[:,:,0] + cos_yaw * kp[:,:,1]
+        kp = torch.stack([rot_x, rot_y, kp[:,:,2]], dim=-1)
+        center = anchor_pt[:, :, 0:3].reshape(bs * num_anchor, 1, 3)
+        kp = (kp + center).reshape(bs, num_anchor * dfa.num_pts, 3)
+        return kp
+
+    def _project_host(self, kp_host, proj_host, wh_host, bs, num_anchor, num_pts):
+        """Project 3D→2D entirely on host for all 6 cameras."""
+        n_pts = num_anchor * num_pts
+        ones = torch.ones(bs, n_pts, 1)
+        pts_homo = torch.cat([kp_host, ones], dim=-1)  # [bs, n_pts, 4]
+
+        all_cams = []
+        for cam in range(6):
+            proj = proj_host[:, cam, :, :]  # [bs, 4, 4]
+            proj_t = proj.transpose(-2, -1)
+            projected = torch.matmul(pts_homo, proj_t)  # [bs, n_pts, 4]
+            xy = projected[:, :, :2]
+            z = projected[:, :, 2:3].clamp(min=1e-5)
+            xy_div = xy / z
+            wh = wh_host[:, cam, :].unsqueeze(1)  # [bs, 1, 2]
+            xy_norm = xy_div / wh
+            xy_grid = xy_norm * 2.0 - 1.0
+            xy_grid = xy_grid.reshape(bs, num_anchor, num_pts, 2)
+            all_cams.append(xy_grid)
+
+        # [6, bs, num_anchor, num_pts, 2] → [6*bs, num_anchor, num_pts, 2] for bs=1 → [6, 900, 13, 2]
+        return torch.cat(all_cams, dim=0)  # [6, num_anchor, num_pts, 2]
+
+    def _with_3cam(self, dfa, method_name, *args, **kwargs):
+        """Call a DFA method with num_cams temporarily set to 3."""
+        orig = dfa.num_cams
+        dfa.num_cams = 3
+        try:
+            return getattr(dfa, method_name)(*args, **kwargs)
+        finally:
+            dfa.num_cams = orig
+
+    def _get_weights_3cam(self, dfa, instance_feature, anchor_embed, proj, bs, num_anchor, return_logits=False):
+        orig = dfa.num_cams
+        dfa.num_cams = 3
+        try:
+            return dfa._get_weights(instance_feature, anchor_embed, proj, bs, num_anchor, return_logits=return_logits)
+        finally:
+            dfa.num_cams = orig
+
+    def _feature_sampling_3cam(self, dfa, feature_maps, points_2d, spatial_shapes, bs, num_anchor):
+        orig = dfa.num_cams
+        dfa.num_cams = 3
+        try:
+            return dfa._feature_sampling(feature_maps, points_2d, spatial_shapes, bs, num_anchor)
+        finally:
+            dfa.num_cams = orig
+
+    def _fusion_3cam(self, dfa, features, weights, bs, num_anchor):
+        orig = dfa.num_cams
+        dfa.num_cams = 3
+        try:
+            return dfa._multi_view_level_fusion(features, weights, bs, num_anchor)
+        finally:
+            dfa.num_cams = orig
+
+    def _project_3cam(self, dfa, key_points, projection_mat, image_wh, bs, num_anchor):
+        """Project 3D→2D for 3 cameras (reuses DFA's _project_points logic)."""
+        # Temporarily override num_cams
+        orig_cams = dfa.num_cams
+        dfa.num_cams = 3
+        try:
+            result = dfa._project_points(key_points, projection_mat, image_wh, bs, num_anchor)
+        finally:
+            dfa.num_cams = orig_cams
+        return result
+
+    def run(self, instance_feature, anchor, anchor_embed,
+            feature_maps_dev0, feature_maps_dev1,
+            projection_mat, image_wh, spatial_shapes, bs=1, num_anchor=900,
+            feature_maps_mesh=None):
+        """
+        Camera-parallel DFA: 3 cameras on each submesh.
+
+        All non-feature_map inputs are on submesh0.
+        feature_maps_dev0: list of 4 tensors on submesh0 (cam 0-2)
+        feature_maps_dev1: list of 4 tensors on submesh1 (cam 3-5)
+        """
+        dfa0 = self.dfa0
+        dfa1 = self.dfa1
+        n = bs * num_anchor
+
+        # === 1-3. KPS + Projection on HOST (avoid triple host roundtrip) ===
+        # Read inputs to host once
+        anchor_pt = ttnn.to_torch(anchor).float()
+        inst_pt = ttnn.to_torch(instance_feature).float()
+        ae_pt = ttnn.to_torch(anchor_embed).float()
+
+        # Cache proj/wh host tensors (same within a frame)
+        if not hasattr(self, '_proj_host_cache') or self._proj_host_cache is None:
+            self._proj_host_cache = ttnn.to_torch(projection_mat).float()
+            self._wh_host_cache = ttnn.to_torch(image_wh).float()
+            # Also cache device tensors for weights computation
+            proj0 = self._proj_host_cache[:, :3, :, :].contiguous()
+            proj1 = self._proj_host_cache[:, 3:, :, :].contiguous()
+            wh0 = self._wh_host_cache[:, :3, :].contiguous()
+            wh1 = self._wh_host_cache[:, 3:, :].contiguous()
+            self._proj_dev0_cache = ttnn.from_torch(proj0, layout=ttnn.TILE_LAYOUT, device=dfa0.device, dtype=ttnn.float32)
+            self._proj_dev1_cache = ttnn.from_torch(proj1, layout=ttnn.TILE_LAYOUT, device=self.dev1, dtype=ttnn.float32)
+            self._wh_dev0_cache = ttnn.from_torch(wh0, layout=ttnn.TILE_LAYOUT, device=dfa0.device, dtype=ttnn.float32)
+            self._wh_dev1_cache = ttnn.from_torch(wh1, layout=ttnn.TILE_LAYOUT, device=self.dev1, dtype=ttnn.float32)
+
+        # KPS on host
+        kp_host = self._kps_host(dfa0, anchor_pt, inst_pt, bs, num_anchor)
+
+        # Projection on host (3D→2D for all 6 cameras)
+        pts2d_host = self._project_host(kp_host, self._proj_host_cache, self._wh_host_cache, bs, num_anchor, dfa0.num_pts)
+
+        # Split 2D points: cam 0-2 → dev0, cam 3-5 → dev1
+        pts2d_0 = pts2d_host[:3].contiguous()  # [3, 900, 13, 2]
+        pts2d_1 = pts2d_host[3:].contiguous()
+        points_2d_dev0 = ttnn.from_torch(pts2d_0, layout=ttnn.TILE_LAYOUT, device=dfa0.device, dtype=ttnn.float32)
+        points_2d_dev1 = ttnn.from_torch(pts2d_1, layout=ttnn.TILE_LAYOUT, device=self.dev1, dtype=ttnn.float32)
+
+        # Transfer inst/ae to dev1
+        inst_dev1 = ttnn.from_torch(inst_pt, layout=ttnn.TILE_LAYOUT, device=self.dev1, dtype=ttnn.float32)
+        ae_dev1 = ttnn.from_torch(ae_pt, layout=ttnn.TILE_LAYOUT, device=self.dev1, dtype=ttnn.float32)
+
+        # === 4. Get weights on both submeshes (per-3-cam softmax on device) ===
+        proj_dev0 = self._proj_dev0_cache
+        proj_dev1 = self._proj_dev1_cache
+        weights_dev0 = self._get_weights_3cam(dfa0, instance_feature, anchor_embed, proj_dev0, bs, num_anchor)
+        weights_dev1 = self._get_weights_3cam(dfa1, inst_dev1, ae_dev1, proj_dev1, bs, num_anchor)
+
+
+        # === 5-7. Sampling + Fusion + Combine ===
+        if feature_maps_mesh is not None and self.mesh_device is not None and False:  # disabled
+            # MESH SPMD path: grid_sample on mesh → fusion → all_gather_async
+            # Create mesh grid from host points_2d
+            pts2d_mesh = ttnn.from_torch(
+                pts2d_host, layout=ttnn.TILE_LAYOUT, device=self.mesh_device, dtype=ttnn.float32,
+                mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=0))
+
+            # Grid_sample on mesh SPMD (each device processes 3 cameras)
+            grid = ttnn.to_layout(pts2d_mesh, ttnn.ROW_MAJOR_LAYOUT)
+            grid = ttnn.to_memory_config(grid, ttnn.DRAM_MEMORY_CONFIG)
+            if grid.dtype != ttnn.float32:
+                grid = ttnn.typecast(grid, ttnn.float32)
+
+            all_level = []
+            for lvl, fm in enumerate(feature_maps_mesh):
+                h, w = spatial_shapes[lvl]
+                s = ttnn.grid_sample_lerp(fm, grid, padding_mode="zeros", align_corners=False)
+                s = ttnn.to_layout(s, ttnn.TILE_LAYOUT)
+                s = ttnn.to_memory_config(s, ttnn.DRAM_MEMORY_CONFIG)
+                all_level.append(s)
+            ttnn.deallocate(grid); ttnn.deallocate(pts2d_mesh)
+
+            # Rearrange (same as DFA._feature_sampling but with num_cams=3 per device)
+            chunks = []
+            for cam in range(3):
+                for lvl in range(self.num_levels):
+                    chunks.append(ttnn.slice(all_level[lvl], [cam,0,0,0],
+                        [cam+1, num_anchor, self.num_pts, self.embed_dims]))
+            features_mesh = ttnn.concat(chunks, dim=2)
+            for c in chunks: ttnn.deallocate(c)
+            for s in all_level: ttnn.deallocate(s)
+            features_mesh = ttnn.reshape(features_mesh, (num_anchor, 3*self.num_levels*self.num_pts, self.embed_dims))
+
+            # Create mesh weights from submesh weights
+            w0_host = ttnn.to_torch(weights_dev0).float()
+            w1_host = ttnn.to_torch(weights_dev1).float()
+            w_stacked = torch.cat([w0_host, w1_host], dim=0)
+            weights_mesh = ttnn.from_torch(w_stacked, layout=ttnn.TILE_LAYOUT, device=self.mesh_device,
+                                            dtype=ttnn.float32, mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=0))
+
+            # Fusion on mesh SPMD
+            half_clp = 3 * self.num_levels * self.num_pts
+            wf = ttnn.reshape(weights_mesh, (n * half_clp, self.num_groups))
+            we = ttnn.repeat_interleave(wf, self.group_dims, dim=-1)
+            ttnn.deallocate(wf); ttnn.deallocate(weights_mesh)
+            we = ttnn.reshape(we, (n, half_clp, self.embed_dims))
+            result = ttnn.multiply(features_mesh, we)
+            ttnn.deallocate(we); ttnn.deallocate(features_mesh)
+            partial = ttnn.sum(result, dim=1)
+            partial = ttnn.reshape(partial, (1, 1, n, self.embed_dims))
+
+            # all_gather_async → both devices get full result
+            partial = ttnn.to_memory_config(partial, ttnn.DRAM_MEMORY_CONFIG)
+            gathered = ttnn.experimental.all_gather_async(partial, dim=2,
+                multi_device_global_semaphore=[self._ag_sem1, self._ag_sem2],
+                num_links=1, topology=ttnn.Topology.Linear)
+            ttnn.deallocate(partial)
+            # gathered: [1, 1, 1800, 256] on each device. Sum halves.
+            p0 = ttnn.slice(gathered, [0, 0, 0, 0], [1, 1, n, self.embed_dims])
+            p1 = ttnn.slice(gathered, [0, 0, n, 0], [1, 1, 2*n, self.embed_dims])
+            fused_mesh = ttnn.add(p0, p1)
+            ttnn.deallocate(gathered); ttnn.deallocate(p0); ttnn.deallocate(p1)
+
+            # Get result to submesh0
+            combined_host = ttnn.to_torch(fused_mesh, mesh_composer=ttnn.ConcatMeshToTensor(self.mesh_device, dim=0)).float()[:1]
+            combined = ttnn.from_torch(combined_host, layout=ttnn.TILE_LAYOUT, device=dfa0.device, dtype=ttnn.float32)
+            ttnn.deallocate(fused_mesh)
+        else:
+            # Submesh path (fallback)
+            features_dev0 = self._feature_sampling_3cam(dfa0, feature_maps_dev0, points_2d_dev0, spatial_shapes, bs, num_anchor)
+            features_dev1 = self._feature_sampling_3cam(dfa1, feature_maps_dev1, points_2d_dev1, spatial_shapes, bs, num_anchor)
+            fused_dev0 = self._fusion_3cam(dfa0, features_dev0, weights_dev0, bs, num_anchor)
+            fused_dev1 = self._fusion_3cam(dfa1, features_dev1, weights_dev1, bs, num_anchor)
+
+            # === Linearity trick: output_proj(A+B) = output_proj(A) + output_proj(B) ===
+            # Dispatch output_proj on dev0 while reading dev1 result
+            out_dev0 = ttnn.linear(fused_dev0, dfa0.output_proj_weight, bias=dfa0.output_proj_bias,
+                                    compute_kernel_config=dfa0._hifi_compute_config)
+            # Meanwhile, read dev1 fused result to host (to_torch syncs dev1)
+            f1_host = ttnn.to_torch(fused_dev1).float()
+
+        # Deallocate temporaries
+        ttnn.deallocate(inst_dev1); ttnn.deallocate(ae_dev1)
+        ttnn.deallocate(points_2d_dev1); ttnn.deallocate(weights_dev1)
+        ttnn.deallocate(points_2d_dev0); ttnn.deallocate(weights_dev0)
+        if feature_maps_mesh is None:
+            try:
+                ttnn.deallocate(features_dev1); ttnn.deallocate(fused_dev1)
+                ttnn.deallocate(features_dev0); ttnn.deallocate(fused_dev0)
+            except Exception:
+                pass
+
+        # === 8. Output projection dev1 on host + combine + residual ===
+        if not hasattr(self, '_op_w_host'):
+            self._op_w_host = ttnn.to_torch(dfa0.output_proj_weight).float()
+            self._op_b_host = ttnn.to_torch(dfa0.output_proj_bias).float().squeeze()
+        # Host output_proj for dev1 partial (small: [1,1,900,256] × [256,256])
+        out1_host = torch.nn.functional.linear(f1_host, self._op_w_host.t(), self._op_b_host)
+        out1_dev0 = ttnn.from_torch(out1_host.contiguous(), layout=ttnn.TILE_LAYOUT, device=dfa0.device, dtype=ttnn.float32)
+
+        # Combine: out_dev0 already has bias, out1 needs no additional bias (bias applied once)
+        # Actually: linear(A,W,b) + linear(B,W,b) = linear(A+B,W,b) + b → double bias!
+        # Fix: host linear without bias, add bias once on device
+        # Rewrite: linear(A,W,b) on dev0 already correct for A part.
+        # For B: linear(B,W,0) on host, then add to dev0 result.
+        out1_host_nobias = torch.nn.functional.linear(f1_host, self._op_w_host.t())
+        out1_dev0 = ttnn.from_torch(out1_host_nobias.contiguous(), layout=ttnn.TILE_LAYOUT, device=dfa0.device, dtype=ttnn.float32)
+        output = ttnn.add(out_dev0, out1_dev0)
+        ttnn.deallocate(out1_dev0); ttnn.deallocate(out_dev0)
+
+        inst_flat = ttnn.reshape(instance_feature, (1, 1, n, self.embed_dims))
+        if output.dtype != inst_flat.dtype:
+            output = ttnn.typecast(output, inst_flat.dtype)
+        if self.residual_mode == "cat":
+            output = ttnn.concat([output, inst_flat], dim=-1)
+            output = ttnn.reshape(output, (bs, num_anchor, 2 * self.embed_dims))
+        elif self.residual_mode == "add":
+            output = ttnn.add(output, inst_flat)
+            output = ttnn.reshape(output, (bs, num_anchor, self.embed_dims))
+
+        return output

--- a/model/multihead_attention.py
+++ b/model/multihead_attention.py
@@ -44,14 +44,16 @@ class MultiheadAttention:
         parameters: dict,
         embed_dims: int = 512,
         num_heads: int = 8,
+        mesh_device=None,
     ) -> None:
-        self.device = device
+        self.device = mesh_device if mesh_device is not None else device
+        self._mesh_device = mesh_device
         self.embed_dims = embed_dims
         self.num_heads = num_heads
         self.head_dim = embed_dims // num_heads
         self._hifi_compute_config = ttnn.init_device_compute_kernel_config(
-            device.arch(), math_fidelity=ttnn.MathFidelity.HiFi4,
-            fp32_dest_acc_en=True, packer_l1_acc=False, math_approx_mode=False,
+            device.arch(), math_fidelity=ttnn.MathFidelity.HiFi2,
+            fp32_dest_acc_en=False, packer_l1_acc=False, math_approx_mode=False,
         )
 
         # Q, K, V projection weights (already transposed: [in, out] for ttnn.linear)
@@ -67,28 +69,23 @@ class MultiheadAttention:
         self.b_out = self._to_device_bias(parameters["b_out"])
 
         # Precompute scale factor on device
-        self.scale = ttnn.from_torch(
-            torch.full((1, 1, 1, 1), self.head_dim**-0.5),
-            layout=ttnn.TILE_LAYOUT,
-            device=self.device,
-            dtype=ttnn.float32,
-        )
+        self.scale = self._to_device_bias(torch.full((1,), self.head_dim**-0.5))
 
     def _to_device(self, tensor: torch.Tensor) -> ttnn.Tensor:
         if tensor.dim() == 1:
             tensor = tensor.unsqueeze(0)
-        return ttnn.from_torch(
-            tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device,
-            dtype=ttnn.float32,
-        )
+        kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
+        if self._mesh_device is not None:
+            kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+        return ttnn.from_torch(tensor.float(), **kwargs)
 
     def _to_device_bias(self, tensor: torch.Tensor) -> ttnn.Tensor:
         if tensor.dim() == 1:
             tensor = tensor.reshape(1, 1, 1, -1)
-        return ttnn.from_torch(
-            tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device,
-            dtype=ttnn.float32,
-        )
+        kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
+        if self._mesh_device is not None:
+            kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+        return ttnn.from_torch(tensor.float(), **kwargs)
 
     def run(
         self,
@@ -130,73 +127,36 @@ class MultiheadAttention:
         q_flat = ttnn.reshape(query, (1, 1, bs * num_queries, self.embed_dims))
         logger.debug(f"MHA: Q linear start, q={q_flat.shape}")
         q = ttnn.linear(q_flat, self.w_q, bias=self.b_q, compute_kernel_config=self._hifi_compute_config)
-        ttnn.synchronize_device(self.device)
-        logger.debug("MHA: Q linear done")
-
-        logger.debug("MHA: K reshape start")
         k_flat = ttnn.reshape(key, (1, 1, bs * num_keys, self.embed_dims))
-        logger.debug(f"MHA: K linear start, k={k_flat.shape}")
         k = ttnn.linear(k_flat, self.w_k, bias=self.b_k, compute_kernel_config=self._hifi_compute_config)
-        ttnn.synchronize_device(self.device)
-        logger.debug("MHA: K linear done")
-
-        logger.debug("MHA: V reshape start")
         v_flat = ttnn.reshape(value, (1, 1, bs * num_keys, self.embed_dims))
-        logger.debug(f"MHA: V linear start, v={v_flat.shape}")
         v = ttnn.linear(v_flat, self.w_v, bias=self.b_v, compute_kernel_config=self._hifi_compute_config)
-        ttnn.synchronize_device(self.device)
-        logger.debug("MHA: V linear done")
 
-        # --- 2. Multi-head reshape ---
-        logger.debug("MHA: multi-head reshape start")
+        # Multi-head reshape + permute
         q = ttnn.reshape(q, (bs, num_queries, self.num_heads, self.head_dim))
         q = ttnn.permute(q, (0, 2, 1, 3))
-
         k = ttnn.reshape(k, (bs, num_keys, self.num_heads, self.head_dim))
         k = ttnn.permute(k, (0, 2, 1, 3))
-
         v = ttnn.reshape(v, (bs, num_keys, self.num_heads, self.head_dim))
         v = ttnn.permute(v, (0, 2, 1, 3))
-        ttnn.synchronize_device(self.device)
-        logger.debug("MHA: multi-head reshape done")
 
-        # --- 3. Scaled dot-product attention ---
-        logger.debug(f"MHA: matmul q@k_t start, q={q.shape}, k={k.shape}")
+        # Scaled dot-product attention
         k_t = ttnn.transpose(k, -2, -1)
         attn_weights = ttnn.matmul(q, k_t, compute_kernel_config=self._hifi_compute_config)
-        ttnn.synchronize_device(self.device)
-        ttnn.deallocate(q)
-        ttnn.deallocate(k)
-        ttnn.deallocate(k_t)
-        logger.debug("MHA: matmul q@k_t done")
+        ttnn.deallocate(q); ttnn.deallocate(k); ttnn.deallocate(k_t)
 
         attn_weights = ttnn.multiply(attn_weights, self.scale)
         attn_weights = ttnn.softmax(attn_weights, dim=-1, numeric_stable=True,
                                     compute_kernel_config=self._hifi_compute_config)
-        ttnn.synchronize_device(self.device)
-
-        logger.debug("MHA: softmax done")
 
         attn_output = ttnn.matmul(attn_weights, v, compute_kernel_config=self._hifi_compute_config)
-        ttnn.synchronize_device(self.device)
-        ttnn.deallocate(attn_weights)
-        ttnn.deallocate(v)
+        ttnn.deallocate(attn_weights); ttnn.deallocate(v)
 
-        logger.debug("MHA: matmul attn@v done")
-
-        # --- 4. Reshape back ---
+        # Reshape back + output projection
         attn_output = ttnn.permute(attn_output, (0, 2, 1, 3))
-        attn_output = ttnn.reshape(
-            attn_output, (1, 1, bs * num_queries, self.embed_dims)
-        )
-
-        # --- 5. Output projection ---
-        logger.debug("MHA: output projection start")
+        attn_output = ttnn.reshape(attn_output, (1, 1, bs * num_queries, self.embed_dims))
         output = ttnn.linear(attn_output, self.w_out, bias=self.b_out, compute_kernel_config=self._hifi_compute_config)
-        ttnn.synchronize_device(self.device)
         ttnn.deallocate(attn_output)
-
-        logger.debug("MHA: output projection done")
 
         # --- 6. Residual connection ---
         identity_flat = ttnn.reshape(

--- a/model/refinement_module.py
+++ b/model/refinement_module.py
@@ -44,12 +44,14 @@ class SparseBox3DRefinementModule:
         num_cls: int = 10,
         refine_yaw: bool = True,
         with_quality_estimation: bool = True,
+        mesh_device=None,
     ) -> None:
-        self.device = device
+        self.device = mesh_device if mesh_device is not None else device
+        self._mesh_device = mesh_device
         self.embed_dims = embed_dims
         self._hifi_compute_config = ttnn.init_device_compute_kernel_config(
-            device.arch(), math_fidelity=ttnn.MathFidelity.HiFi4,
-            fp32_dest_acc_en=True, packer_l1_acc=False, math_approx_mode=False,
+            device.arch(), math_fidelity=ttnn.MathFidelity.HiFi2,
+            fp32_dest_acc_en=False, packer_l1_acc=False, math_approx_mode=False,
         )
         self.output_dim = output_dim
         self.num_cls = num_cls
@@ -92,23 +94,26 @@ class SparseBox3DRefinementModule:
     def _to_device(self, tensor: torch.Tensor) -> ttnn.Tensor:
         if tensor.dim() == 1:
             tensor = tensor.unsqueeze(0)
-        return ttnn.from_torch(
-            tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32
-        )
+        kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
+        if self._mesh_device is not None:
+            kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+        return ttnn.from_torch(tensor.float(), **kwargs)
 
     def _to_device_bias(self, tensor: torch.Tensor) -> ttnn.Tensor:
         if tensor.dim() == 1:
             tensor = tensor.reshape(1, 1, 1, -1)
-        return ttnn.from_torch(
-            tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32
-        )
+        kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
+        if self._mesh_device is not None:
+            kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+        return ttnn.from_torch(tensor.float(), **kwargs)
 
     def _to_device_1d(self, tensor: torch.Tensor) -> ttnn.Tensor:
         if tensor.dim() == 1:
             tensor = tensor.reshape(1, 1, 1, -1)
-        return ttnn.from_torch(
-            tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32
-        )
+        kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
+        if self._mesh_device is not None:
+            kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+        return ttnn.from_torch(tensor.float(), **kwargs)
 
     def _run_layers(self, x: ttnn.Tensor, layers: list) -> ttnn.Tensor:
         for idx, entry in enumerate(layers):
@@ -123,11 +128,9 @@ class SparseBox3DRefinementModule:
                     epsilon=1e-5,
                     compute_kernel_config=self._hifi_compute_config,
                 )
-                ttnn.synchronize_device(self.device)
                 ttnn.deallocate(relu_in)
                 ttnn.deallocate(relu_out)
             else:
-                ttnn.synchronize_device(self.device)
                 ttnn.deallocate(relu_in)
             # Deallocate previous layer output (skip idx=0: caller owns input)
             if idx > 0:
@@ -175,7 +178,6 @@ class SparseBox3DRefinementModule:
         # Apply Scale
         refined_pre_scale = refined
         refined = ttnn.multiply(refined, self.refine_scale)
-        ttnn.synchronize_device(self.device)
         ttnn.deallocate(refined_pre_scale)
         refined = ttnn.reshape(refined, (bs, num_anchor, self.output_dim))
 
@@ -226,7 +228,7 @@ class SparseBox3DRefinementModule:
             output = ttnn.concat([refined_pos, refined_vel], dim=-1)
         else:
             output = ttnn.concat([refined_pos, refined_yaw, refined_vel], dim=-1)
-        ttnn.synchronize_device(self.device)
+
         ttnn.deallocate(refined_pos)
         ttnn.deallocate(refined_vel)
         if not self.refine_yaw:
@@ -252,7 +254,7 @@ class SparseBox3DRefinementModule:
                         cls_feat, weight=entry["ln_weight"], bias=entry["ln_bias"],
                         compute_kernel_config=self._hifi_compute_config,
                     )
-                    ttnn.synchronize_device(self.device)
+            
                     ttnn.deallocate(relu_in)
                     ttnn.deallocate(relu_out)
                 if layer_idx > 0:
@@ -262,7 +264,7 @@ class SparseBox3DRefinementModule:
                 cls_feat, self.cls_final_weight, bias=self.cls_final_bias,
                 compute_kernel_config=self._hifi_compute_config,
             )
-            ttnn.synchronize_device(self.device)
+    
             ttnn.deallocate(cls_feat)
 
             cls = ttnn.reshape(cls, (bs, num_anchor, self.num_cls))
@@ -275,7 +277,7 @@ class SparseBox3DRefinementModule:
                 qt_feat, self.quality_final_weight, bias=self.quality_final_bias,
                 compute_kernel_config=self._hifi_compute_config,
             )
-            ttnn.synchronize_device(self.device)
+    
             ttnn.deallocate(qt_feat)
             quality = ttnn.reshape(quality, (bs, num_anchor, 2))
 

--- a/model/resnet_bottleneck.py
+++ b/model/resnet_bottleneck.py
@@ -91,8 +91,8 @@ def preprocess_resnet50_parameters(
     # Conv1 + BN1
     weight, bias = fold_bn_into_conv(model.conv1, model.bn1)
     parameters["conv1"] = {
-        "weight": ttnn.from_torch(weight, dtype=ttnn.float32),
-        "bias": ttnn.from_torch(bias.reshape(1, 1, 1, -1), dtype=ttnn.float32),
+        "weight": ttnn.from_torch(weight, dtype=ttnn.bfloat16),
+        "bias": ttnn.from_torch(bias.reshape(1, 1, 1, -1), dtype=ttnn.bfloat16),
     }
 
     # Layers 1-4
@@ -109,8 +109,8 @@ def preprocess_resnet50_parameters(
                 bn = getattr(block, bn_name)
                 w, b = fold_bn_into_conv(conv, bn)
                 block_params[conv_name] = {
-                    "weight": ttnn.from_torch(w, dtype=ttnn.float32),
-                    "bias": ttnn.from_torch(b.reshape(1, 1, 1, -1), dtype=ttnn.float32),
+                    "weight": ttnn.from_torch(w, dtype=ttnn.bfloat16),
+                    "bias": ttnn.from_torch(b.reshape(1, 1, 1, -1), dtype=ttnn.bfloat16),
                 }
 
             # Downsample path (if present)
@@ -119,8 +119,8 @@ def preprocess_resnet50_parameters(
                 ds_bn = block.downsample[1]
                 w, b = fold_bn_into_conv(ds_conv, ds_bn)
                 block_params["downsample"] = {
-                    "weight": ttnn.from_torch(w, dtype=ttnn.float32),
-                    "bias": ttnn.from_torch(b.reshape(1, 1, 1, -1), dtype=ttnn.float32),
+                    "weight": ttnn.from_torch(w, dtype=ttnn.bfloat16),
+                    "bias": ttnn.from_torch(b.reshape(1, 1, 1, -1), dtype=ttnn.bfloat16),
                 }
 
             layer_params[block_idx] = block_params
@@ -203,7 +203,7 @@ class Conv2dOp:
         input_width: int,
         groups: int = 1,
         activation=None,
-        weights_dtype=ttnn.float32,
+        weights_dtype=ttnn.bfloat16,
         activation_dtype=ttnn.bfloat16,
         shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         deallocate_activation: bool = False,
@@ -580,7 +580,7 @@ class TtResNetBottleneck:
             act_block_h_override=64,
             deallocate_activation=True,
             math_fidelity=ttnn.MathFidelity.HiFi4 if batch_size <= 3 else ttnn.MathFidelity.LoFi,
-            fp32_dest_acc_en=True,
+            fp32_dest_acc_en=True if batch_size <= 3 else False,
             math_approx_mode=False,
         )
         self.conv1.disable_slice()  # conv1 doesn't need L1 slicing
@@ -612,7 +612,7 @@ class TtResNetBottleneck:
             use_fp32_acc = (batch_size <= 3)
 
             # HiFi4 when fp32 acc is available, HiFi2 otherwise
-            fidelity = ttnn.MathFidelity.HiFi4 if use_fp32_acc else ttnn.MathFidelity.HiFi2
+            fidelity = ttnn.MathFidelity.HiFi4 if (batch_size <= 3) else ttnn.MathFidelity.HiFi2
 
             layer = ResLayer(
                 params=params[f"layer{i + 1}"],
@@ -627,7 +627,7 @@ class TtResNetBottleneck:
                 conv3_block_sharded=use_block_shard,
                 downsample_block_sharded=use_block_shard,
                 math_fidelity=fidelity,
-                fp32_dest_acc_en=use_fp32_acc,
+                fp32_dest_acc_en=True if (batch_size <= 3) else False,
             )
             self.res_layers.append(layer)
             inplanes = planes * Bottleneck.expansion

--- a/model/sparse4d.py
+++ b/model/sparse4d.py
@@ -183,6 +183,7 @@ class Sparse4DInference:
         self._fpn_dev1 = None       # second FPN on submesh 1
         self._submesh0 = None
         self._submesh1 = None
+        self._mesh_device = None
 
     @classmethod
     def from_pytorch(
@@ -423,19 +424,16 @@ class Sparse4DInference:
         Returns:
             dict with 'prediction', 'classification', 'quality'
         """
-        # Mesh parallel mode: backbone+FPN on 2 submeshes in parallel
+        # Mesh parallel mode: backbone+FPN on 2 submeshes, features as mesh tensors
         if self.mesh_parallel_mode:
             feature_maps = self._extract_features_mesh_parallel(images)
         elif self.dual_device_mode:
             feature_maps = self._extract_features_dual_device(images)
         else:
-            # 1. Preprocess & send to device(s)
             input_tensor = self.preprocess_images(images)
-            # 2. Backbone + FPN
             feature_maps = self.extract_features(input_tensor)
 
-        # 3. Head decoder (always on single device)
-        logger.debug("Running Sparse4DHead...")
+        # 3. Head decoder
         outputs = self.head.forward(feature_maps, metas, bs=bs)
 
         return outputs
@@ -534,99 +532,82 @@ class Sparse4DInference:
         return fpn_combined
 
     def _extract_features_mesh_parallel(self, images: torch.Tensor) -> list:
-        """Run backbone+FPN on 2 submeshes in parallel within same process.
+        """Run backbone+FPN on mesh device SPMD (batch=3 per device).
 
-        Submesh 0 (device 0): cam0-2, batch=3
-        Submesh 1 (device 1): cam3-5, batch=3
-
-        Both backbones are dispatched before synchronizing, achieving
-        true parallel execution on 2 chips. No process spawn needed.
+        Input [6, 3, 256, 704] → ShardTensorToMesh(dim=0) → each device gets [3, 3, 256, 704]
+        Backbone + FPN run identically on both devices (SPMD).
+        Output: mesh tensors with 3 cameras per device (already sharded).
 
         Args:
             images: [bs, 6, 3, 256, 704] normalized images
 
         Returns:
-            list of FPN feature maps [p2, p3, p4, p5] on submesh 0 (float32)
+            list of FPN feature maps as mesh tensors (sharded by camera)
         """
         imgs_flat = images.reshape(self.num_cams, 3, 256, 704)
 
-        # Prepare inputs for both submeshes
-        imgs0 = imgs_flat[:3].permute(0, 2, 3, 1).contiguous().reshape(1, 1, 3 * 256 * 704, 3)
-        imgs1 = imgs_flat[3:].permute(0, 2, 3, 1).contiguous().reshape(1, 1, 3 * 256 * 704, 3)
+        # NHWC + flatten: [6, 256, 704, 3] → [1, 1, 6*256*704, 3]
+        # But we need to shard so each device gets 3 cams.
+        # Shard as [2, 1, 3*256*704, 3] along dim=0 → each device gets [1, 1, 3*H*W, 3]
+        imgs_nhwc = imgs_flat.permute(0, 2, 3, 1).contiguous()  # [6, 256, 704, 3]
+        # Split into 2 halves: [3, 256, 704, 3] each, flatten to [1, 1, 3*H*W, 3]
+        imgs_flat_0 = imgs_nhwc[:3].reshape(1, 1, 3 * 256 * 704, 3)
+        imgs_flat_1 = imgs_nhwc[3:].reshape(1, 1, 3 * 256 * 704, 3)
+        # Stack along dim=0 for ShardTensorToMesh
+        imgs_stacked = torch.cat([imgs_flat_0, imgs_flat_1], dim=0)  # [2, 1, 3*H*W, 3]
 
-        tt_x0 = ttnn.from_torch(
-            imgs0.float(), layout=ttnn.ROW_MAJOR_LAYOUT,
-            device=self._submesh0, dtype=self.activation_dtype,
+        tt_input = ttnn.from_torch(
+            imgs_stacked.float(),
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=self._mesh_device,
+            dtype=self.activation_dtype,
+            mesh_mapper=ttnn.ShardTensorToMesh(self._mesh_device, dim=0),
         )
-        tt_x1 = ttnn.from_torch(
-            imgs1.float(), layout=ttnn.ROW_MAJOR_LAYOUT,
-            device=self._submesh1, dtype=self.activation_dtype,
-        )
 
-        # Dispatch backbone on both submeshes (parallel)
-        logger.debug("Mesh parallel: dispatching backbone on 2 submeshes...")
-        bb_features_0 = self.backbone(tt_x0)
-        bb_features_1 = self._backbone_dev1(tt_x1)
-
-        # Sync both
-        ttnn.synchronize_device(self._submesh0)
-        ttnn.synchronize_device(self._submesh1)
-        logger.debug("Mesh parallel: backbone done on both submeshes")
+        # Backbone SPMD: each device processes its 3 cameras
+        logger.debug("Mesh SPMD: backbone start")
+        backbone_features = self.backbone(tt_input)
+        logger.debug("Mesh SPMD: backbone done")
 
         # Upcast if needed
-        bb_features_0 = [
+        backbone_features = [
             ttnn.typecast(f, self.activation_dtype)
             if f.dtype != self.activation_dtype and f.dtype == ttnn.bfloat8_b
             else f
-            for f in bb_features_0
-        ]
-        bb_features_1 = [
-            ttnn.typecast(f, self.activation_dtype)
-            if f.dtype != self.activation_dtype and f.dtype == ttnn.bfloat8_b
-            else f
-            for f in bb_features_1
+            for f in backbone_features
         ]
 
-        # FPN on both submeshes (parallel)
-        logger.debug("Mesh parallel: dispatching FPN on 2 submeshes...")
-        fpn_features_0 = self.fpn.run(bb_features_0, self._submesh0)
-        fpn_features_1 = self._fpn_dev1.run(bb_features_1, self._submesh1)
-        ttnn.synchronize_device(self._submesh0)
-        ttnn.synchronize_device(self._submesh1)
-        logger.debug("Mesh parallel: FPN done on both submeshes")
-
-        # Gather FPN results to host and concat
-        fpn_combined = []
-        for level_idx in range(4):
-            f0_torch = ttnn.to_torch(fpn_features_0[level_idx]).float()
-            f1_torch = ttnn.to_torch(fpn_features_1[level_idx]).float()
-            ttnn.deallocate(fpn_features_0[level_idx])
-            ttnn.deallocate(fpn_features_1[level_idx])
-            combined = torch.cat([f0_torch, f1_torch], dim=2)  # [1,1,6*H*W,256]
-            f_tt = ttnn.from_torch(
-                combined,
-                layout=ttnn.ROW_MAJOR_LAYOUT,
-                device=self._submesh0,
-                dtype=ttnn.float32,
-            )
-            fpn_combined.append(f_tt)
+        # FPN SPMD
+        logger.debug("Mesh SPMD: FPN start")
+        fpn_features = self.fpn.run(backbone_features, self._mesh_device)
+        logger.debug("Mesh SPMD: FPN done")
 
         # Deallocate backbone features
-        for bf in bb_features_0 + bb_features_1:
+        for bf in backbone_features:
             try:
                 ttnn.deallocate(bf)
             except Exception:
                 pass
 
-        logger.debug("Mesh parallel: FPN features combined on submesh 0")
-        return fpn_combined
+        # Pre-reshape for DFA grid_sample: [1,1,3*H*W,256] → [3, H, W, 256]
+        for level_idx in range(4):
+            h, w = SPATIAL_SHAPES[level_idx]
+            f = fpn_features[level_idx]
+            f = ttnn.to_memory_config(f, ttnn.DRAM_MEMORY_CONFIG)
+            f = ttnn.to_layout(f, ttnn.ROW_MAJOR_LAYOUT)
+            f = ttnn.reshape(f, (3, h, w, 256))
+            if f.dtype != ttnn.bfloat16:
+                f = ttnn.typecast(f, ttnn.bfloat16)
+            fpn_features[level_idx] = f
+
+        logger.debug("Mesh SPMD: FPN features reshaped for DFA")
+        return fpn_features
 
     def reset(self):
         """Reset temporal state (call at start of new sequence)."""
         self.head.instance_bank.reset()
 
-    @staticmethod
-    def post_process(outputs: dict, score_threshold: float = 0.3):
+    def post_process(self, outputs: dict, score_threshold: float = 0.3):
         """Decode predictions to 3D bounding boxes.
 
         Args:
@@ -645,8 +626,13 @@ class Sparse4DInference:
 
         # To host
         if hasattr(prediction, 'dtype') and hasattr(ttnn, 'to_torch'):
-            pred = ttnn.to_torch(prediction).float()
-            cls = ttnn.to_torch(classification).float()
+            if self._mesh_device is not None:
+                composer = ttnn.ConcatMeshToTensor(self._mesh_device, dim=0)
+                pred = ttnn.to_torch(prediction, mesh_composer=composer).float()[:1]
+                cls = ttnn.to_torch(classification, mesh_composer=composer).float()[:1]
+            else:
+                pred = ttnn.to_torch(prediction).float()
+                cls = ttnn.to_torch(classification).float()
         else:
             pred = prediction.float()
             cls = classification.float()

--- a/model/sparse4d_head.py
+++ b/model/sparse4d_head.py
@@ -67,12 +67,14 @@ class Sparse4DHead:
         num_learnable_pts: int = 6,
         decouple_attn: bool = True,
         spatial_shapes: list = None,
+        mesh_device=None,
     ) -> None:
-        self.device = device
+        self.device = mesh_device if mesh_device is not None else device
+        self._mesh_device = mesh_device
         self.embed_dims = embed_dims
         self._hifi_compute_config = ttnn.init_device_compute_kernel_config(
-            device.arch(), math_fidelity=ttnn.MathFidelity.HiFi4,
-            fp32_dest_acc_en=True, packer_l1_acc=False, math_approx_mode=False,
+            device.arch(), math_fidelity=ttnn.MathFidelity.HiFi2,
+            fp32_dest_acc_en=False, packer_l1_acc=False, math_approx_mode=False,
         )
         self.num_decoder = num_decoder
         self.num_single_frame_decoder = num_single_frame_decoder
@@ -88,11 +90,14 @@ class Sparse4DHead:
         self.layers = []
         for i, op in enumerate(operation_order):
             layer_params = parameters["layers"][i]
+            # In mesh SPMD mode, DFA uses num_cams=3 (each device processes 3 cameras)
+            dfa_num_cams = 3 if mesh_device is not None else num_cams
+
             if layer_params is None:
                 self.layers.append(None)
             elif op in ("gnn", "temp_gnn"):
                 self.layers.append(
-                    MultiheadAttention(device, layer_params, mha_embed, num_groups)
+                    MultiheadAttention(device, layer_params, mha_embed, num_groups, mesh_device=mesh_device)
                 )
             elif op == "norm":
                 self.layers.append({
@@ -108,11 +113,12 @@ class Sparse4DHead:
                         embed_dims=embed_dims,
                         num_groups=num_groups,
                         num_levels=num_levels,
-                        num_cams=num_cams,
+                        num_cams=dfa_num_cams,
                         num_pts=num_pts,
                         num_learnable_pts=num_learnable_pts,
                         use_camera_embed=True,
                         residual_mode="cat",
+                        mesh_device=mesh_device,
                     )
                 )
             elif op == "ffn":
@@ -122,6 +128,7 @@ class Sparse4DHead:
                         in_channels=embed_dims * 2,
                         embed_dims=embed_dims,
                         feedforward_channels=embed_dims * 4,
+                        mesh_device=mesh_device,
                     )
                 )
             elif op == "refine":
@@ -133,8 +140,16 @@ class Sparse4DHead:
                         num_cls=num_classes,
                         refine_yaw=True,
                         with_quality_estimation=True,
+                        mesh_device=mesh_device,
                     )
                 )
+
+        # --- DFA layer params for mesh DFA setup ---
+        self._mesh_dfa_runners = None
+        self._dfa_layer_params = {
+            i: parameters["layers"][i]
+            for i, op in enumerate(operation_order) if op == "deformable"
+        }
 
         # --- Anchor encoder ---
         self.anchor_encoder = SparseBox3DEncoder(
@@ -145,6 +160,7 @@ class Sparse4DHead:
             has_output_fc=not decouple_attn,
             in_loops=1,
             out_loops=4 if decouple_attn else 2,
+            mesh_device=mesh_device,
         )
 
         # --- Instance bank ---
@@ -155,6 +171,7 @@ class Sparse4DHead:
             num_anchor=num_anchor,
             embed_dims=embed_dims,
             num_temp_instances=num_temp_instances,
+            mesh_device=mesh_device,
         )
 
         # --- Decouple attention fc_before / fc_after ---
@@ -165,19 +182,36 @@ class Sparse4DHead:
             self.fc_before_weight = None
             self.fc_after_weight = None
 
+    def setup_mesh_dfa(self, dev1, mesh_device=None):
+        """Initialize MeshDFARunners for camera-parallel DFA on 2 submeshes."""
+        from model.mesh_dfa import MeshDFARunner
+        self._mesh_dfa_runners = {}
+        for i, op in enumerate(self.operation_order):
+            if op == "deformable" and i in self._dfa_layer_params:
+                self._mesh_dfa_runners[i] = MeshDFARunner(
+                    dfa0=self.layers[i],
+                    dev1=dev1,
+                    parameters=self._dfa_layer_params[i],
+                    model_config={},
+                    mesh_device=mesh_device,
+                )
+        logger.info(f"Mesh DFA: {len(self._mesh_dfa_runners)} runners on 2 submeshes")
+
     def _to_device(self, tensor: torch.Tensor) -> ttnn.Tensor:
         if tensor.dim() == 1:
             tensor = tensor.unsqueeze(0)
-        return ttnn.from_torch(
-            tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32
-        )
+        kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
+        if self._mesh_device is not None:
+            kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+        return ttnn.from_torch(tensor.float(), **kwargs)
 
     def _to_device_1d(self, tensor: torch.Tensor) -> ttnn.Tensor:
         if tensor.dim() == 1:
             tensor = tensor.reshape(1, 1, 1, -1)
-        return ttnn.from_torch(
-            tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32
-        )
+        kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
+        if self._mesh_device is not None:
+            kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+        return ttnn.from_torch(tensor.float(), **kwargs)
 
     def _graph_model(
         self,
@@ -191,40 +225,19 @@ class Sparse4DHead:
         num_queries: int,
         num_keys: int,
     ) -> ttnn.Tensor:
-        """Run MHA with decouple_attn wrapping.
-
-        decouple_attn=True flow:
-          query = cat([query, query_pos])      → [bs, N, 512]
-          key   = cat([key, key_pos]) or query
-          value = fc_before(value)             → [bs, M, 512]
-          out   = MHA(query, key, value)       → [bs, N, 512]
-          out   = fc_after(out)                → [bs, N, 256]
-        """
-        logger.debug(f"_graph_model[{layer_idx}]: start, decouple={self.decouple_attn}, "
-                     f"q={query.shape}, key={'None' if key is None else key.shape}, "
-                     f"value={'None' if value is None else value.shape}, num_queries={num_queries}, num_keys={num_keys}")
-
+        """Run MHA with decouple_attn wrapping (on device)."""
         if self.decouple_attn:
-            query = ttnn.concat([query, query_pos], dim=-1)  # [bs, N, 512]
+            query = ttnn.concat([query, query_pos], dim=-1)
             if key is not None and key_pos is not None:
                 key = ttnn.concat([key, key_pos], dim=-1)
             else:
                 key = query
                 num_keys = num_queries
-            ttnn.synchronize_device(self.device)
-            logger.debug(f"_graph_model[{layer_idx}]: concat done, num_keys={num_keys}")
-
-            # fc_before(value) — skip if value is None (self-attention uses query as value)
             if value is not None:
                 n_val = bs * num_keys
                 val_flat = ttnn.reshape(value, (1, 1, n_val, self.embed_dims))
-                logger.debug(f"_graph_model[{layer_idx}]: fc_before start, val_flat={val_flat.shape}")
                 value = ttnn.linear(val_flat, self.fc_before_weight)
                 value = ttnn.reshape(value, (bs, num_keys, self.embed_dims * 2))
-                ttnn.synchronize_device(self.device)
-                logger.debug(f"_graph_model[{layer_idx}]: fc_before done, value={value.shape}")
-            else:
-                logger.debug(f"_graph_model[{layer_idx}]: value=None, skip fc_before")
         else:
             if query_pos is not None:
                 query = ttnn.add(query, query_pos)
@@ -237,36 +250,22 @@ class Sparse4DHead:
                 value = key
 
         mha = self.layers[layer_idx]
-        logger.debug(f"_graph_model[{layer_idx}]: MHA.run start")
-        out = mha.run(
-            query=query, key=key, value=value,
-            bs=bs, num_queries=num_queries, num_keys=num_keys,
-        )
-        ttnn.synchronize_device(self.device)
-        logger.debug(f"_graph_model[{layer_idx}]: MHA.run done")
+        out = mha.run(query=query, key=key, value=value, bs=bs, num_queries=num_queries, num_keys=num_keys)
 
         if self.decouple_attn:
             n_q = bs * num_queries
             out_flat = ttnn.reshape(out, (1, 1, n_q, self.embed_dims * 2))
-            logger.debug(f"_graph_model[{layer_idx}]: fc_after start")
             out = ttnn.linear(out_flat, self.fc_after_weight)
             out = ttnn.reshape(out, (bs, num_queries, self.embed_dims))
-            ttnn.synchronize_device(self.device)
-            logger.debug(f"_graph_model[{layer_idx}]: fc_after done")
 
         return out
 
     def _norm(self, layer_idx: int, x: ttnn.Tensor, bs: int, num_tokens: int):
-        """LayerNorm."""
+        """LayerNorm on device."""
         norm = self.layers[layer_idx]
         x_flat = ttnn.reshape(x, (1, 1, bs * num_tokens, self.embed_dims))
-        normed = ttnn.layer_norm(
-            x_flat, weight=norm["weight"], bias=norm["bias"],
-            epsilon=1e-5,
-            compute_kernel_config=self._hifi_compute_config,
-        )
-        ttnn.synchronize_device(self.device)
-        # x_flat is reshape view, don't deallocate
+        normed = ttnn.layer_norm(x_flat, weight=norm["weight"], bias=norm["bias"],
+                                  epsilon=1e-5, compute_kernel_config=self._hifi_compute_config)
         return ttnn.reshape(normed, (bs, num_tokens, self.embed_dims))
 
     def forward(
@@ -289,6 +288,8 @@ class Sparse4DHead:
         """
         num_anchor = self.num_anchor
         debug_intermediates = {}
+
+        # (Legacy mesh DFA cache clearing removed - using native mesh SPMD now)
 
         # 1. InstanceBank.get()
         (
@@ -316,14 +317,27 @@ class Sparse4DHead:
             num_temp = 0
 
         # 3. Pre-allocate projection_mat and image_wh on device (reused across decoder loop)
-        proj_tt = ttnn.from_torch(
-            metas["projection_mat"].float(),
-            layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32,
-        )
-        wh_tt = ttnn.from_torch(
-            metas["image_wh"].float(),
-            layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32,
-        )
+        proj_pt = metas["projection_mat"].float()
+        wh_pt = metas["image_wh"].float()
+        if self._mesh_device is not None:
+            # Shard full proj/wh by camera dim: [1,6,4,4] → each device gets [1,3,4,4]
+            proj_tt = ttnn.from_torch(
+                proj_pt,
+                layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16,
+                mesh_mapper=ttnn.ShardTensorToMesh(self._mesh_device, dim=1),
+            )
+            wh_tt = ttnn.from_torch(
+                wh_pt,
+                layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16,
+                mesh_mapper=ttnn.ShardTensorToMesh(self._mesh_device, dim=1),
+            )
+        else:
+            proj_tt = ttnn.from_torch(
+                proj_pt, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16,
+            )
+            wh_tt = ttnn.from_torch(
+                wh_pt, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16,
+            )
 
         # 4. Decoder loop
         prediction = []
@@ -333,7 +347,6 @@ class Sparse4DHead:
         for i, op in enumerate(self.operation_order):
             logger.debug(f"Head decoder: op[{i}]={op} start, inst_feat dtype={instance_feature.dtype}")
             logger.debug(f"Head decoder: op[{i}]={op} sync start")
-            ttnn.synchronize_device(self.device)
             logger.debug(f"Head decoder: op[{i}]={op} sync done")
 
             if self.layers[i] is None:
@@ -408,7 +421,6 @@ class Sparse4DHead:
                     instance_feature, anchor, anchor_embed, time_interval,
                     bs=bs, num_anchor=num_anchor, return_cls=return_cls,
                 )
-                ttnn.synchronize_device(self.device)
                 logger.debug(f"Head refine[{i}]: refine.run done")
                 prediction.append(anchor)
                 classification.append(cls)
@@ -434,7 +446,6 @@ class Sparse4DHead:
                     anchor_embed = self.anchor_encoder.run(
                         anchor, bs=bs, num_anchor=num_anchor
                     )
-                    ttnn.synchronize_device(self.device)
                     ttnn.deallocate(old_anchor_embed)
                     logger.debug(f"Head refine[{i}]: anchor_encoder.run done, anchor_embed={anchor_embed.shape}")
 

--- a/model/sparse_box3d_encoder.py
+++ b/model/sparse_box3d_encoder.py
@@ -47,14 +47,16 @@ class SparseBox3DEncoder:
         in_loops: int = 1,
         out_loops: int = 4,
         use_host_compute: bool = True,
+        mesh_device=None,
     ) -> None:
-        self.device = device
+        self.device = mesh_device if mesh_device is not None else device
+        self._mesh_device = mesh_device
         self.vel_dims = vel_dims
         self.mode = mode
         self._use_host_compute = use_host_compute
         self._hifi_compute_config = ttnn.init_device_compute_kernel_config(
-            device.arch(), math_fidelity=ttnn.MathFidelity.HiFi4,
-            fp32_dest_acc_en=True, packer_l1_acc=False, math_approx_mode=False,
+            device.arch(), math_fidelity=ttnn.MathFidelity.HiFi2,
+            fp32_dest_acc_en=False, packer_l1_acc=False, math_approx_mode=False,
         )
         self.has_output_fc = has_output_fc
 
@@ -136,23 +138,26 @@ class SparseBox3DEncoder:
     def _to_device(self, tensor: torch.Tensor) -> ttnn.Tensor:
         if tensor.dim() == 1:
             tensor = tensor.unsqueeze(0)
-        return ttnn.from_torch(
-            tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32
-        )
+        kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
+        if self._mesh_device is not None:
+            kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+        return ttnn.from_torch(tensor.float(), **kwargs)
 
     def _to_device_bias(self, tensor: torch.Tensor) -> ttnn.Tensor:
         if tensor.dim() == 1:
             tensor = tensor.reshape(1, 1, 1, -1)
-        return ttnn.from_torch(
-            tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32
-        )
+        kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
+        if self._mesh_device is not None:
+            kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+        return ttnn.from_torch(tensor.float(), **kwargs)
 
     def _to_device_1d(self, tensor: torch.Tensor) -> ttnn.Tensor:
         if tensor.dim() == 1:
             tensor = tensor.reshape(1, 1, 1, -1)
-        return ttnn.from_torch(
-            tensor.float(), layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32
-        )
+        kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
+        if self._mesh_device is not None:
+            kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+        return ttnn.from_torch(tensor.float(), **kwargs)
 
     def _run_layers(self, x: ttnn.Tensor, layers: list, name: str = "") -> ttnn.Tensor:
         """Run Linear→ReLU (→LN) chain."""
@@ -160,7 +165,6 @@ class SparseBox3DEncoder:
             logger.debug(f"Encoder._run_layers[{name}][{idx}]: linear start, x={x.shape}")
             linear_in = x
             x = ttnn.linear(x, entry["weight"], bias=entry["bias"], compute_kernel_config=self._hifi_compute_config)
-            ttnn.synchronize_device(self.device)
             # Deallocate linear input (skip idx=0: caller owns input)
             if idx > 0:
                 ttnn.deallocate(linear_in)
@@ -175,7 +179,6 @@ class SparseBox3DEncoder:
                     epsilon=1e-5,
                     compute_kernel_config=self._hifi_compute_config,
                 )
-                ttnn.synchronize_device(self.device)
                 ttnn.deallocate(relu_in)
                 ttnn.deallocate(relu_out)
                 logger.debug(f"Encoder._run_layers[{name}][{idx}]: layer_norm done")
@@ -199,7 +202,10 @@ class SparseBox3DEncoder:
         """
         # Extract components via host slice (avoid ttnn.slice hang on submesh)
         logger.debug(f"Encoder.run: slice start, box_3d={box_3d.shape}, bs={bs}, num_anchor={num_anchor}")
-        box_pt = ttnn.to_torch(box_3d).float()
+        if self._mesh_device is not None:
+            box_pt = ttnn.to_torch(box_3d, mesh_composer=ttnn.ConcatMeshToTensor(self._mesh_device, dim=0)).float()[:bs]
+        else:
+            box_pt = ttnn.to_torch(box_3d).float()
         n = bs * num_anchor
 
         # Host compute path: run Linear→ReLU→LN chains on CPU for higher precision
@@ -210,26 +216,26 @@ class SparseBox3DEncoder:
         size_pt = box_pt[:, :, W:H+1].contiguous().reshape(1, 1, n, 3)
         yaw_pt = box_pt[:, :, SIN_YAW:COS_YAW+1].contiguous().reshape(1, 1, n, 2)
 
-        pos = ttnn.from_torch(pos_pt, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32)
-        size = ttnn.from_torch(size_pt, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32)
-        yaw = ttnn.from_torch(yaw_pt, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32)
+        _kw = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
+        if self._mesh_device is not None:
+            _kw["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+        pos = ttnn.from_torch(pos_pt, **_kw)
+        size = ttnn.from_torch(size_pt, **_kw)
+        yaw = ttnn.from_torch(yaw_pt, **_kw)
         logger.debug("Encoder.run: slice done")
 
         logger.debug("Encoder.run: pos_layers start")
         pos_feat = self._run_layers(pos, self.pos_layers, name="pos")
-        ttnn.synchronize_device(self.device)
         ttnn.deallocate(pos)
         logger.debug("Encoder.run: pos_layers done")
 
         logger.debug("Encoder.run: size_layers start")
         size_feat = self._run_layers(size, self.size_layers, name="size")
-        ttnn.synchronize_device(self.device)
         ttnn.deallocate(size)
         logger.debug("Encoder.run: size_layers done")
 
         logger.debug("Encoder.run: yaw_layers start")
         yaw_feat = self._run_layers(yaw, self.yaw_layers, name="yaw")
-        ttnn.synchronize_device(self.device)
         ttnn.deallocate(yaw)
         logger.debug("Encoder.run: yaw_layers done")
 
@@ -237,7 +243,6 @@ class SparseBox3DEncoder:
             output = ttnn.add(ttnn.add(pos_feat, size_feat), yaw_feat)
         else:
             output = ttnn.concat([pos_feat, size_feat, yaw_feat], dim=-1)
-        ttnn.synchronize_device(self.device)
         ttnn.deallocate(pos_feat)
         ttnn.deallocate(size_feat)
         ttnn.deallocate(yaw_feat)
@@ -245,10 +250,12 @@ class SparseBox3DEncoder:
 
         if self.vel_dims > 0:
             vel_pt = box_pt[:, :, VX:VX+self.vel_dims].contiguous().reshape(1, 1, n, self.vel_dims)
-            vel = ttnn.from_torch(vel_pt, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32)
+            _kw2 = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
+            if self._mesh_device is not None:
+                _kw2["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+            vel = ttnn.from_torch(vel_pt, **_kw2)
             logger.debug("Encoder.run: vel_layers start")
             vel_feat = self._run_layers(vel, self.vel_layers, name="vel")
-            ttnn.synchronize_device(self.device)
             ttnn.deallocate(vel)
             logger.debug("Encoder.run: vel_layers done")
             logger.debug(f"Encoder.run: vel combine start, mode={self.mode}")
@@ -257,7 +264,6 @@ class SparseBox3DEncoder:
                 output = ttnn.add(old_output, vel_feat)
             else:
                 output = ttnn.concat([old_output, vel_feat], dim=-1)
-            ttnn.synchronize_device(self.device)
             ttnn.deallocate(old_output)
             ttnn.deallocate(vel_feat)
             logger.debug(f"Encoder.run: vel combine done, output={output.shape}")
@@ -267,7 +273,6 @@ class SparseBox3DEncoder:
 
         logger.debug(f"Encoder.run: reshape start, target=({bs}, {num_anchor}, {self.output_dims}), current={output.shape}")
         output = ttnn.reshape(output, (bs, num_anchor, self.output_dims))
-        ttnn.synchronize_device(self.device)
         logger.debug(f"Encoder.run: done, output={output.shape}")
         return output
 
@@ -312,9 +317,10 @@ class SparseBox3DEncoder:
         output = output.reshape(bs, num_anchor, self.output_dims)
         logger.debug(f"Encoder._run_host: done, shape={output.shape}")
 
-        return ttnn.from_torch(
-            output, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32,
-        )
+        kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
+        if self._mesh_device is not None:
+            kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+        return ttnn.from_torch(output, **kwargs)
 
 
 def _extract_linear_relu_ln_params(sequential_module):

--- a/run_inference_video.py
+++ b/run_inference_video.py
@@ -1,0 +1,408 @@
+"""
+Sparse4D TT-NN Inference Video Generator (Mesh SPMD + BF16)
+Camera-view visualization with 3D bounding boxes on Tenstorrent N300.
+
+Usage:
+  source ~/.tenstorrent-venv/bin/activate
+  TT_METAL_LOGGER_LEVEL=ERROR python run_inference_video.py --dual-device
+  TT_METAL_LOGGER_LEVEL=ERROR python run_inference_video.py --dual-device --frames 80 --conf 0.25
+  TT_METAL_LOGGER_LEVEL=ERROR python run_inference_video.py --mode fps --dual-device --frames 50
+"""
+
+import argparse
+import copy
+import gc
+import os
+import sys
+import time
+
+import cv2
+import numpy as np
+import torch
+import ttnn
+
+TT_METAL_HOME = os.environ.get(
+    "TT_METAL_HOME", os.path.expanduser("~/project/tt-metal")
+)
+sys.path.insert(0, TT_METAL_HOME)
+sys.path.insert(0, os.path.dirname(__file__))
+
+from test.sparse4d_nuscenes_val import (
+    CLASS_NAMES,
+    NuScenesValLoader,
+    load_model,
+    OPERATION_ORDER,
+    SPATIAL_SHAPES,
+)
+
+# Class-specific colors (BGR for OpenCV)
+CLASS_COLORS = {
+    "car": (0, 255, 0),
+    "truck": (0, 200, 255),
+    "bus": (0, 150, 255),
+    "trailer": (0, 100, 200),
+    "construction_vehicle": (0, 80, 180),
+    "pedestrian": (255, 0, 0),
+    "motorcycle": (255, 255, 0),
+    "bicycle": (255, 200, 0),
+    "traffic_cone": (0, 0, 255),
+    "barrier": (200, 200, 200),
+}
+
+IMG_MEAN = np.array([123.675, 116.28, 103.53], dtype=np.float32)
+IMG_STD = np.array([58.395, 57.12, 57.375], dtype=np.float32)
+
+
+def box3d_to_corners(boxes_np):
+    """Convert [N, 7+] boxes (x,y,z,w,l,h,yaw,...) to [N, 8, 3] corners."""
+    x, y, z = boxes_np[:, 0], boxes_np[:, 1], boxes_np[:, 2]
+    w, l, h = boxes_np[:, 3], boxes_np[:, 4], boxes_np[:, 5]
+    yaw = boxes_np[:, 6]
+
+    corners = np.array([
+        [-0.5, -0.5, -0.5],
+        [-0.5, -0.5,  0.5],
+        [-0.5,  0.5,  0.5],
+        [-0.5,  0.5, -0.5],
+        [ 0.5, -0.5, -0.5],
+        [ 0.5, -0.5,  0.5],
+        [ 0.5,  0.5,  0.5],
+        [ 0.5,  0.5, -0.5],
+    ])  # [8, 3]
+
+    n = len(boxes_np)
+    dims = np.stack([w, l, h], axis=-1)  # [N, 3]
+    corners_3d = corners[None, :, :] * dims[:, None, :]  # [N, 8, 3]
+
+    cos_yaw = np.cos(yaw)
+    sin_yaw = np.sin(yaw)
+    rot = np.zeros((n, 3, 3))
+    rot[:, 0, 0] = cos_yaw
+    rot[:, 0, 1] = -sin_yaw
+    rot[:, 1, 0] = sin_yaw
+    rot[:, 1, 1] = cos_yaw
+    rot[:, 2, 2] = 1.0
+
+    corners_3d = np.einsum("nij,nmj->nmi", rot, corners_3d)
+
+    center = np.stack([x, y, z], axis=-1)[:, None, :]
+    corners_3d = corners_3d + center
+
+    return corners_3d
+
+
+def draw_box3d_on_img(img, bboxes3d, proj_mat, cls_indices, thickness=2):
+    """Draw 3D bboxes on a single camera image with class colors."""
+    if len(bboxes3d) == 0:
+        return img
+
+    corners_3d = box3d_to_corners(bboxes3d)
+    num_bbox = corners_3d.shape[0]
+    pts_4d = np.concatenate(
+        [corners_3d.reshape(-1, 3), np.ones((num_bbox * 8, 1))], axis=-1
+    )
+    proj = copy.deepcopy(proj_mat).reshape(4, 4)
+    if isinstance(proj, torch.Tensor):
+        proj = proj.cpu().numpy()
+
+    pts_2d = pts_4d @ proj.T
+    pts_2d[:, 2] = np.clip(pts_2d[:, 2], a_min=1e-5, a_max=1e5)
+    pts_2d[:, 0] /= pts_2d[:, 2]
+    pts_2d[:, 1] /= pts_2d[:, 2]
+    pts_2d = pts_2d[..., :2].reshape(num_bbox, 8, 2)
+
+    h, w = img.shape[:2]
+    line_pairs = [
+        (0, 1), (0, 3), (0, 4), (1, 2), (1, 5), (3, 2),
+        (3, 7), (4, 5), (4, 7), (2, 6), (5, 6), (6, 7),
+    ]
+    bottom_pairs = [(0, 1), (1, 2), (2, 3), (3, 0)]
+
+    for i in range(num_bbox):
+        corners = np.clip(pts_2d[i], -1e4, 1e5).astype(np.int32)
+        visible = any(0 <= c[0] < w and 0 <= c[1] < h for c in corners)
+        if not visible:
+            continue
+
+        cls_name = CLASS_NAMES[cls_indices[i]] if cls_indices[i] < len(CLASS_NAMES) else "unknown"
+        color = CLASS_COLORS.get(cls_name, (0, 255, 0))
+
+        for s, e in line_pairs:
+            cv2.line(img, tuple(corners[s]), tuple(corners[e]), color, thickness, cv2.LINE_AA)
+        for s, e in bottom_pairs:
+            cv2.line(img, tuple(corners[s]), tuple(corners[e]), color, thickness + 1, cv2.LINE_AA)
+
+        top_y = min(corners[:, 1])
+        top_x = int(np.mean(corners[:, 0]))
+        if 0 < top_x < w and 0 < top_y < h:
+            cv2.putText(img, cls_name, (top_x - 20, max(top_y - 5, 15)),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.4, color, 1, cv2.LINE_AA)
+
+    return img
+
+
+def make_frame(raw_imgs, bboxes3d, proj_mats, cls_indices, scores, frame_idx, elapsed_ms):
+    """Create a visualization frame: 3x2 camera grid with info overlay."""
+    h, w = raw_imgs.shape[1], raw_imgs.shape[2]  # 256, 704
+
+    scale = 2
+    sh, sw = h * scale, w * scale
+
+    cam_order = [2, 0, 1, 4, 3, 5]  # FL, F, FR, BL, B, BR
+    cam_names = ["FRONT_LEFT", "FRONT", "FRONT_RIGHT", "BACK_LEFT", "BACK", "BACK_RIGHT"]
+
+    rows = []
+    for row in range(2):
+        cols = []
+        for col in range(3):
+            idx = cam_order[row * 3 + col]
+            img = raw_imgs[idx].clip(0, 255).astype(np.uint8).copy()
+
+            if len(bboxes3d) > 0:
+                img = draw_box3d_on_img(img, bboxes3d, proj_mats[idx], cls_indices)
+
+            img = cv2.resize(img, (sw, sh), interpolation=cv2.INTER_LINEAR)
+
+            cv2.putText(img, cam_names[row * 3 + col], (10, 25),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.6, (255, 255, 255), 2, cv2.LINE_AA)
+            cols.append(img)
+        rows.append(np.concatenate(cols, axis=1))
+
+    canvas = np.concatenate(rows, axis=0)
+
+    # Info bar
+    info_h = 50
+    info_bar = np.zeros((info_h, canvas.shape[1], 3), dtype=np.uint8)
+    num_det = len(bboxes3d)
+
+    cv2.putText(
+        info_bar,
+        f"Frame {frame_idx:04d}  |  Detections: {num_det}  |  TT-NN {elapsed_ms:.0f}ms  |  Sparse4D N300 Mesh SPMD",
+        (15, 30), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 255, 0), 2, cv2.LINE_AA,
+    )
+
+    if num_det > 0:
+        cls_counts = {}
+        for c in cls_indices:
+            name = CLASS_NAMES[c] if c < len(CLASS_NAMES) else "?"
+            cls_counts[name] = cls_counts.get(name, 0) + 1
+        x_offset = canvas.shape[1] // 2
+        for name, cnt in cls_counts.items():
+            color = CLASS_COLORS.get(name, (0, 255, 0))
+            text = f"{name}: {cnt}"
+            cv2.putText(info_bar, text, (x_offset, 30),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.5, color, 1, cv2.LINE_AA)
+            x_offset += len(text) * 12 + 20
+
+    canvas = np.concatenate([canvas, info_bar], axis=0)
+    return canvas
+
+
+def decode_outputs(outputs, conf_threshold=0.3, mesh_device=None):
+    """Decode TT-NN model outputs to boxes, classes, scores."""
+    prediction = outputs["prediction"][-1]
+    classification = outputs["classification"][-1]
+    quality_list = outputs.get("quality", [])
+    quality = quality_list[-1] if quality_list and quality_list[-1] is not None else None
+
+    if prediction is None or classification is None:
+        return np.array([]), np.array([]), np.array([])
+
+    def _to_torch(t):
+        if isinstance(t, torch.Tensor):
+            return t.float()
+        if mesh_device is not None:
+            return ttnn.to_torch(t, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0)).float()[:1]
+        return ttnn.to_torch(t).float()
+
+    pred = _to_torch(prediction)[0]  # [num_anchor, 11]
+    cls = _to_torch(classification)[0]  # [num_anchor, num_cls]
+    cls_scores = cls.sigmoid()
+
+    cls_scores_max, cls_ids = cls_scores.max(dim=-1)
+
+    # Quality weighting
+    if quality is not None:
+        qt = _to_torch(quality)[0]
+        centerness = qt[..., 0].sigmoid()
+        cls_scores_max = cls_scores_max * centerness
+
+    mask = cls_scores_max > conf_threshold
+    if mask.sum() == 0:
+        return np.array([]), np.array([]), np.array([])
+
+    filtered_pred = pred[mask]
+    filtered_cls = cls_ids[mask]
+    filtered_scores = cls_scores_max[mask]
+
+    # Decode: x,y,z,exp(w),exp(l),exp(h),yaw,vx,vy,vz
+    yaw = torch.atan2(filtered_pred[:, 6], filtered_pred[:, 7])
+    decoded = torch.cat([
+        filtered_pred[:, :3],
+        filtered_pred[:, 3:6].exp(),
+        yaw.unsqueeze(-1),
+        filtered_pred[:, 8:],
+    ], dim=-1).numpy()
+
+    return decoded, filtered_cls.numpy(), filtered_scores.numpy()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Sparse4D TT-NN Inference Video Generator (Mesh SPMD + BF16)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--mode", choices=["video", "images", "fps"], default="video",
+                        help="output mode (default: video)")
+    parser.add_argument("--frames", type=int, default=80, help="frames to process (default: 80)")
+    parser.add_argument("--conf", type=float, default=0.3, help="confidence threshold (default: 0.3)")
+    parser.add_argument("--outdir", type=str, default="inference_output", help="output dir for images mode")
+    parser.add_argument("--output", type=str, default="inference_video_tt.mp4", help="output video path")
+    parser.add_argument("--fps", type=int, default=4, help="video fps (default: 4)")
+    parser.add_argument("--ckpt", type=str, default="ckpt/latest.pth", help="checkpoint path")
+    parser.add_argument("--data-root", type=str, default="nuscenes/trainval", help="nuScenes data root")
+    parser.add_argument("--anno-pkl", type=str, default="nuscenes_anno_pkls/nuscenes_infos_val.pkl")
+    parser.add_argument("--dual-device", action="store_true", help="use mesh SPMD dual device")
+    args = parser.parse_args()
+
+    from loguru import logger as _logger
+    _logger.remove()
+    _logger.add(sys.stderr, level="WARNING")
+
+    print("=" * 60)
+    print("  Sparse4D TT-NN Inference Video (Mesh SPMD + BF16)")
+    print("=" * 60)
+
+    # 1. Load data
+    print("\n[1/3] Loading nuScenes data...")
+    loader = NuScenesValLoader(args.data_root, args.anno_pkl)
+
+    # 2. Build model
+    print("\n[2/3] Building TT-NN model...")
+    num_devices = ttnn.get_num_devices()
+    mesh_device = None
+
+    if args.dual_device and num_devices >= 2:
+        print(f"  {num_devices} chips detected, opening mesh (1x2)...")
+        mesh_device = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(1, 2), l1_small_size=24576)
+        device = mesh_device
+        print(f"  Mesh device IDs: {mesh_device.get_device_ids()}")
+
+        model = load_model(args.ckpt, mesh_device, mesh_device=mesh_device, backbone_batch_size=3, fp32_backbone=False)
+        model.mesh_parallel_mode = True
+        model._mesh_device = mesh_device
+        model.serial_cams_per_batch = 0
+        print("  Full mesh SPMD mode: backbone+FPN+Head all on mesh_device (bf16)")
+    else:
+        device = ttnn.open_device(device_id=0, l1_small_size=24576)
+        model = load_model(args.ckpt, device, backbone_batch_size=6)
+        model.serial_cams_per_batch = 0
+        print("  Single device mode")
+
+    # 3. Run inference + generate output
+    print(f"\n[3/3] Running inference ({args.frames} frames, mode={args.mode})...")
+
+    if args.mode == "images":
+        os.makedirs(args.outdir, exist_ok=True)
+
+    writer = None
+    times = []
+    processed = 0
+
+    for scene_idx, scene_samples in enumerate(loader.scenes):
+        model.reset()
+
+        for sample_idx, global_idx in enumerate(scene_samples):
+            if processed >= args.frames:
+                break
+
+            images, metas, info = loader.get_sample(global_idx)
+
+            t0 = time.time()
+            outputs = model.forward(images, metas, bs=1)
+            elapsed = time.time() - t0
+            elapsed_ms = elapsed * 1000
+            times.append(elapsed_ms)
+            processed += 1
+
+            # Periodic GC
+            if processed % 50 == 0:
+                gc.collect()
+
+            # Decode predictions
+            decoded_boxes, cls_indices, scores = decode_outputs(
+                outputs, conf_threshold=args.conf, mesh_device=mesh_device
+            )
+            num_det = len(decoded_boxes)
+
+            if args.mode == "fps":
+                print(f"  Frame {processed:03d}: {elapsed_ms:6.1f} ms ({1000/elapsed_ms:5.1f} fps) {num_det:2d} det")
+                continue
+
+            # Denormalize images for visualization
+            raw_imgs = images[0].permute(0, 2, 3, 1).numpy()  # [6, H, W, 3]
+            raw_imgs = raw_imgs * IMG_STD + IMG_MEAN
+
+            proj_mats = metas["projection_mat"][0].numpy()  # [6, 4, 4]
+
+            frame = make_frame(
+                raw_imgs, decoded_boxes, proj_mats,
+                cls_indices, scores, processed - 1, elapsed_ms,
+            )
+
+            if args.mode == "images":
+                out_path = os.path.join(args.outdir, f"frame_{processed-1:04d}.png")
+                cv2.imwrite(out_path, cv2.cvtColor(frame, cv2.COLOR_RGB2BGR))
+            else:
+                frame_bgr = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+                if writer is None:
+                    h, w = frame.shape[:2]
+                    fourcc = cv2.VideoWriter_fourcc(*"avc1")
+                    writer = cv2.VideoWriter(args.output, fourcc, args.fps, (w, h))
+                    if not writer.isOpened():
+                        # Fallback: try x264 or mp4v if avc1 not available
+                        for codec in ["x264", "H264", "mp4v"]:
+                            fourcc = cv2.VideoWriter_fourcc(*codec)
+                            writer = cv2.VideoWriter(args.output, fourcc, args.fps, (w, h))
+                            if writer.isOpened():
+                                print(f"  Video: {w}x{h}, {args.fps} fps, codec={codec} -> {args.output}")
+                                break
+                        if not writer.isOpened():
+                            print(f"  WARNING: No H.264 encoder found, falling back to mp4v")
+                            fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+                            writer = cv2.VideoWriter(args.output, fourcc, args.fps, (w, h))
+                    else:
+                        print(f"  Video: {w}x{h}, {args.fps} fps, codec=h264 -> {args.output}")
+                writer.write(frame_bgr)
+
+            max_score = scores.max() if len(scores) > 0 else 0
+            print(f"  Frame {processed-1:03d}: {num_det:2d} det (max: {max_score:.3f}) [{elapsed_ms:.0f}ms]")
+
+        if processed >= args.frames:
+            break
+
+    # Summary
+    if times:
+        avg_ms = np.mean(times)
+        std_ms = np.std(times)
+        print(f"\n{'=' * 50}")
+        print(f"  Inference: {avg_ms:.1f} +/- {std_ms:.1f} ms/frame")
+        print(f"  FPS:       {1000/avg_ms:.1f}")
+        print(f"  Frames:    {processed}")
+        print(f"{'=' * 50}")
+
+    if args.mode == "video" and writer is not None:
+        writer.release()
+        print(f"\nSaved: {args.output} ({processed} frames)")
+    elif args.mode == "images":
+        print(f"\nSaved: {processed} images to {args.outdir}/")
+
+    # Cleanup
+    if mesh_device is not None:
+        ttnn.close_mesh_device(mesh_device)
+    else:
+        ttnn.close_device(device)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/sparse4d_nuscenes_val.py
+++ b/test/sparse4d_nuscenes_val.py
@@ -12,6 +12,7 @@ Usage:
 
 import argparse
 import copy
+import gc
 import json
 import os
 import pickle
@@ -341,7 +342,7 @@ def _build_encoder_params(sd, prefix):
     return params
 
 
-def _build_head_from_sd(sd, device):
+def _build_head_from_sd(sd, device, mesh_device=None):
     """Build TT Sparse4DHead from checkpoint state_dict."""
     layer_params = []
     for i, op in enumerate(OPERATION_ORDER):
@@ -382,6 +383,7 @@ def _build_head_from_sd(sd, device):
         num_classes=10,
         num_groups=8,
         spatial_shapes=SPATIAL_SHAPES,
+        mesh_device=mesh_device,
     )
     return head
 
@@ -409,7 +411,7 @@ def load_model(ckpt_path, device, mesh_device=None, backbone_batch_size=None, fp
     fpn = _build_fpn_from_sd(sd, device, batch_size=batch_size, fp32=fp32_backbone)
 
     print("  Building Sparse4DHead...")
-    head = _build_head_from_sd(sd, device)
+    head = _build_head_from_sd(sd, device, mesh_device=mesh_device)
 
     model = Sparse4DInference(device, backbone, fpn, head)
     print("  Model build complete.")
@@ -658,6 +660,7 @@ def postprocess_to_nuscenes(
     info,
     eval_config,
     max_dets=300,
+    mesh_device=None,
 ):
     """Convert TT-NN predictions to nuScenes detection format.
 
@@ -686,18 +689,18 @@ def postprocess_to_nuscenes(
         return []
 
     # To host
-    if isinstance(prediction, torch.Tensor):
-        pred = prediction.float()
-        cls = classification.float()
-    else:
-        pred = ttnn.to_torch(prediction).float()
-        cls = ttnn.to_torch(classification).float()
+    def _tt_to_torch(t, mesh_dev=None):
+        if isinstance(t, torch.Tensor):
+            return t.float()
+        if mesh_dev is not None:
+            return ttnn.to_torch(t, mesh_composer=ttnn.ConcatMeshToTensor(mesh_dev, dim=0)).float()[:1]
+        return ttnn.to_torch(t).float()
+
+    pred = _tt_to_torch(prediction, mesh_device)
+    cls = _tt_to_torch(classification, mesh_device)
 
     if quality is not None:
-        if isinstance(quality, torch.Tensor):
-            qt = quality.float()
-        else:
-            qt = ttnn.to_torch(quality).float()
+        qt = _tt_to_torch(quality, mesh_device)
         qt = qt[0]  # [num_anchor, num_quality]
     else:
         qt = None
@@ -1099,13 +1102,11 @@ def main():
     submeshes = None
 
     if args.dual_device and num_devices >= 2:
-        # Mesh parallel mode: 2 submeshes for backbone+FPN, Head on submesh 0
+        # Full mesh SPMD mode
         print(f"  {num_devices} chips detected, opening mesh (1x2)...")
         mesh_device = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(1, 2), l1_small_size=24576)
-        submeshes = mesh_device.create_submeshes(ttnn.MeshShape(1, 1))
-        device = submeshes[0]  # Head runs on submesh 0
-        print(f"  Submesh 0: device {submeshes[0].get_device_ids()}")
-        print(f"  Submesh 1: device {submeshes[1].get_device_ids()}")
+        device = mesh_device  # everything runs on mesh
+        print(f"  Mesh device IDs: {mesh_device.get_device_ids()}")
     else:
         device = ttnn.open_device(device_id=0, l1_small_size=24576)
         if num_devices >= 2:
@@ -1114,56 +1115,16 @@ def main():
             print("  Single device mode")
 
     try:
-        grid = device.compute_with_storage_grid_size()
-        print(f"  Device: {device.arch()}, grid: {grid.x}x{grid.y}")
-
-        if args.dual_device and submeshes is not None:
-            # Mesh parallel: backbone batch=3 on each submesh, HiFi4+fp32_acc
-            model = load_model(args.ckpt, device, mesh_device=None, backbone_batch_size=3, fp32_backbone=False)
-
-            # Build second backbone+FPN on submesh 1
-            print("  Building second backbone+FPN on submesh 1...")
-            from model.resnet_bottleneck import create_tt_resnet_bottleneck
-            from model.fpn import FPN, _FPNParameters
-            import torchvision
-
-            ckpt = torch.load(os.path.abspath(args.ckpt), map_location="cpu", weights_only=False)
-            sd = ckpt["state_dict"]
-
-            resnet1 = torchvision.models.resnet50(weights=None)
-            resnet1_sd = {k.replace("img_backbone.", ""): v for k, v in sd.items() if k.startswith("img_backbone.")}
-            resnet1.load_state_dict(resnet1_sd, strict=False)
-            resnet1.eval()
-            backbone1, _ = create_tt_resnet_bottleneck(
-                torch_model=resnet1, device=submeshes[1], batch_size=3,
-                input_height=256, input_width=704,
-            )
-
-            lateral_params = []
-            fpn_params_list = []
-            for i in range(4):
-                lateral_params.append({
-                    "weight": ttnn.from_torch(sd[f"img_neck.lateral_convs.{i}.conv.weight"]),
-                    "bias": ttnn.from_torch(sd[f"img_neck.lateral_convs.{i}.conv.bias"].reshape(1, 1, 1, -1)),
-                })
-                fpn_params_list.append({
-                    "weight": ttnn.from_torch(sd[f"img_neck.fpn_convs.{i}.conv.weight"]),
-                    "bias": ttnn.from_torch(sd[f"img_neck.fpn_convs.{i}.conv.bias"].reshape(1, 1, 1, -1)),
-                })
-            fpn1 = FPN(
-                device=submeshes[1], parameters=_FPNParameters(lateral_params, fpn_params_list),
-                batch_size=3, in_channels=[256, 512, 1024, 2048], out_channels=256,
-                model_config={"WEIGHTS_DTYPE": ttnn.bfloat16, "ACTIVATIONS_DTYPE": ttnn.bfloat16, "MATH_FIDELITY": ttnn.MathFidelity.LoFi},
-                input_spatial_shapes=SPATIAL_SHAPES,
-            )
+        if args.dual_device and mesh_device is not None:
+            # Full mesh SPMD: backbone+FPN+Head all on mesh_device (bf16)
+            # backbone batch=3 per device (SPMD), Head replicated on mesh
+            model = load_model(args.ckpt, mesh_device, mesh_device=mesh_device, backbone_batch_size=3, fp32_backbone=False)
 
             model.mesh_parallel_mode = True
-            model._backbone_dev1 = backbone1
-            model._fpn_dev1 = fpn1
-            model._submesh0 = submeshes[0]
-            model._submesh1 = submeshes[1]
+            model._mesh_device = mesh_device
             model.serial_cams_per_batch = 0
-            print("  Mesh parallel mode: backbone batch=3 x 2 chips, HiFi4+fp32_acc")
+
+            print("  Full mesh SPMD mode: backbone+FPN+Head all on mesh_device (bf16)")
         elif args.dual_device:
             # Fallback: serial batch=3 x 2 on single device
             model = load_model(args.ckpt, device, mesh_device=None, backbone_batch_size=3, fp32_backbone=False)
@@ -1214,6 +1175,8 @@ def main():
                             return None
                         if isinstance(t, torch.Tensor):
                             return t.cpu().float()
+                        if mesh_device is not None:
+                            return ttnn.to_torch(t, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0)).cpu().float()[:1]
                         return ttnn.to_torch(t).cpu().float()
 
                     entry = {
@@ -1231,12 +1194,17 @@ def main():
                     outputs,
                     info,
                     eval_config,
+                    mesh_device=mesh_device,
                 )
 
                 # Add sample_token to each detection
                 for d in dets:
                     d["sample_token"] = token
                 all_results[token] = dets
+
+                # Periodic GC to prevent host memory leak from to_torch/from_torch
+                if processed % 100 == 0:
+                    gc.collect()
 
                 if processed % 50 == 0 or processed == total_samples:
                     avg_time = total_time / processed


### PR DESCRIPTION
## Implement

- All modules support mesh_device parameter for SPMD execution
  - Weights: ReplicateTensorToMesh (replicated across 2 devices)
  - DFA feature maps: ShardTensorToMesh (3 cameras per device)
  - DFA fusion: host combine (all_reduce hangs on N300)

- Backbone+FPN run on mesh device via SPMD
  - Input images sharded by camera dim (3+3 split)
  - Single backbone instance serves both devices

- All weights converted from float32 to bfloat16
  - Head compute: HiFi2, fp32_dest_acc disabled
  - Backbone compute: HiFi4, fp32_dest_acc enabled (mesh compatibility)
  - ResNet BN-folded weights stored as bfloat16

- Instance bank: mesh-aware to_torch/from_torch with ConcatMeshToTensor

## Related

#11 #13 

## Test

- 6019 samples, avg **0.35s/sample**

| Metric | Value | vs PyTorch FP32 |
|---|---|---|
| mAP | **0.2862** | 0.4529 |
| NDS | **0.3376** | 0.5602 |
| mATE | 0.7684 | 0.5455 |
| mASE | 0.2768 | 0.2622 |
| mAOE | 0.7024 | 0.4373 |
| mAVE | 1.8389 | 0.2195 |
| mAAE | 0.3072 | 0.1987 |

### Per-class AP
| Class | AP | ATE | ASE | AOE | AVE | AAE |
|---|---|---|---|---|---|---|
| car | 0.468 | 0.554 | 0.151 | 0.217 | 2.907 | 0.326 |
| truck | 0.212 | 0.823 | 0.219 | 0.273 | 2.412 | 0.418 |
| bus | 0.268 | 0.919 | 0.221 | 0.245 | 3.105 | 0.411 |
| trailer | 0.092 | 1.218 | 0.255 | 0.885 | 0.944 | 0.207 |
| construction_vehicle | 0.029 | 1.096 | 0.497 | 1.336 | 0.428 | 0.461 |
| pedestrian | 0.379 | 0.689 | 0.304 | 1.097 | 1.156 | 0.265 |
| motorcycle | 0.287 | 0.674 | 0.247 | 0.856 | 2.501 | 0.182 |
| bicycle | 0.174 | 0.717 | 0.264 | 0.926 | 1.257 | 0.186 |
| traffic_cone | 0.506 | 0.443 | 0.324 | nan | nan | nan |
| barrier | 0.448 | 0.552 | 0.286 | 0.485 | nan | nan |

