### PR TITLE
Performance: input path row major, remove useless to_layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,27 +18,66 @@ Porting the Sparse4D v3 3D object detection model to Tenstorrent devices (Wormho
 
 ### Speed
 
-|  | PyTorch  | TT-NN Pure (N300) | TT-NN + Custom Kernels (N300) |
-| :--- | :---: | :---: | :---: |
-| **Latency** | ~95ms | 235ms | **122ms** |
-| **FPS** | 10.5 | 4.2 | **8.2** |
+|  | PyTorch | TT-NN Pure (N300) | ~~Custom Kernels v1~~ | **Custom Kernels v2 (N300)** |
+| :--- | :---: | :---: | :---: | :---: |
+| **Latency / sample** | ~95 ms | 235 ms | ~~122 ms~~ | **95.2 ms** |
+| **FPS** | 10.5 | 4.2 | ~~8.2~~ | **10.51** |
+
+Latency is `model.forward` on one 6-camera sample, median of 20 frames after warmup.
+At 95.2 ms the accelerator matches the CUDA reference on this model.
 
 - **Pure TT-NN**: Standard ttnn ops only, no custom kernel build required. Automatically used as fallback when custom kernels are not built.
-- **Custom Kernels** (recommended): 3 custom Metalium kernels (`kps_project_fused`, `transposed_s2i`, `grouped_weighted_sum`) for 1.9x speedup — see [docs/INSTALL.md](docs/INSTALL.md)
+- **Custom Kernels** (recommended): 4 custom Metalium kernels (`kps_project_fused`, `transposed_s2i`, `grouped_weighted_sum`, `grid_compact`) plus a patch to upstream `grid_sample` — see [docs/INSTALL.md](docs/INSTALL.md)
+
+**What changed in v2** (122 -> 95.2 ms), every step verified bit-identical to the path it replaced:
+
+| Change | Latency |
+| :--- | :---: |
+| v1 | 122 ms |
+| Row-major image upload — `ttnn.conv2d` takes NHWC directly, so the host tilize was waste | 139.9 ms* |
+| 1 KB upload pages — a ROW_MAJOR row is one page, so 4-channel rows made h2d 540,672 transfers of 8 B (41.0 -> 0.55 ms) | 103.7 ms |
+| Pooled OOB compaction — drop the anchors that project outside every camera before `grid_sample` sees them | **95.2 ms** |
+
+\* the row-major upload landed together with a re-measurement on different hardware seating; it is listed for provenance, not as a regression.
+
+Also fixed on the way, with no speed cost: `grouped_weighted_sum` in RM mode inherited the
+previous op's compute-pipeline configuration and so was wrong on its first call after any
+other op — silently, and only in that mode. See the accuracy table.
 
 ### Accuracy
 
-Sparse4D-TT currently exhibits a 0.05 mAP drop compared to the FP32 baseline, primarily due to BF16 precision constraints on the Wormhole N300 accelerator.
+Full nuScenes val, 6019 samples.
 
-|  | PyTorch (CUDA) | TT-NN (N300) | Gap |
-| :--- | :---: | :---: | :---: |
-| **mAP** | 0.4529 | **0.3968** | -0.0561 |
-| **NDS** | 0.5602 | **0.5192** | -0.0410 |
-| **mATE** | 0.5455 | **0.6163** | +0.0708 |
-| **mASE** | 0.2622 | **0.2689** | +0.0067 |
-| **mAOE** | 0.4373 | **0.4693** | +0.0320 |
-| **mAVE** | 0.2195 | **0.2590** | +0.0395 |
-| **mAAE** | 0.1987 | **0.1790** | -0.0197 |
+|  | PyTorch (CUDA) | ~~TT-NN v1~~ | **TT-NN v2 (N300)** | Gap (v2) |
+| :--- | :---: | :---: | :---: | :---: |
+| **mAP** | 0.4529 | ~~0.3968~~ | **0.3974** | -0.0555 |
+| **NDS** | 0.5602 | ~~0.5192~~ | **0.5190** | -0.0412 |
+| **mATE** | 0.5455 | ~~0.6163~~ | **0.6173** | +0.0718 |
+| **mASE** | 0.2622 | ~~0.2689~~ | **0.2693** | +0.0071 |
+| **mAOE** | 0.4373 | ~~0.4693~~ | **0.4730** | +0.0357 |
+| **mAVE** | 0.2195 | ~~0.2590~~ | **0.2624** | +0.0429 |
+| **mAAE** | 0.1987 | ~~0.1790~~ | **0.1747** | -0.0240 |
+
+v2 is faster *and* slightly more accurate. The gain came from fixing
+`grouped_weighted_sum`, not from tuning: mAP 0.3933 -> 0.3968 for the fix, and a further
++0.0006 from compaction, which is noise-level and in the favourable direction.
+
+**On the remaining -0.056 mAP:** it is not bf16 storage. PyTorch bf16 keeps a
+full-precision multiply and accumulates in fp32; two Wormhole settings break both halves
+of that, and both are tunable:
+
+- **Math fidelity.** The multiplier is physically 5b x 7b, and `MathFidelity` sets how many
+  passes it takes to consume the inputs. At `LoFi` — one pass, and what the backbone and
+  FPN currently use — srcA contributes its hidden bit plus only the top 4 mantissa bits, so
+  a bf16 operand is truncated to 5 of its 8 bits. That is coarser than bf16, not equal to it.
+- **Accumulator width.** With `fp32_dest_acc_en=False` (the default here, everywhere) the
+  FPU accumulates in 16-bit rather than fp32.
+
+Measured directly in this project: the same key-point projection written as ttnn
+element-wise ops produced errors quantised to 2^-11 / 2^-10 — the fp16 DEST signature —
+costing 0.042 mAP, while the identical arithmetic in a custom kernel doing fp32 soft-float
+had a maximum error of 5e-8. Input and output dtypes were fp32 in both cases; only the
+accumulator differed.
 
 ### Inference video
 
@@ -71,7 +110,7 @@ pip install -r Sparse4D-tt/requirement.txt
 
 ### tt-metal Custom Kernel Build
 
-This project uses 3 custom TT-Metal kernels (`kps_project_fused`, `grouped_weighted_sum`, `transposed_s2i`) that must be built into the tt-metal library.
+This project uses 4 custom TT-Metal kernels (`kps_project_fused`, `grouped_weighted_sum`, `transposed_s2i`, `grid_compact`) plus one patch to the upstream `grid_sample`, all of which must be built into the tt-metal library.
 
 See **[docs/INSTALL.md](docs/INSTALL.md)** for detailed build instructions.
 

--- a/README.md
+++ b/README.md
@@ -29,20 +29,15 @@ At 95.2 ms the accelerator matches the CUDA reference on this model.
 - **Pure TT-NN**: Standard ttnn ops only, no custom kernel build required. Automatically used as fallback when custom kernels are not built.
 - **Custom Kernels** (recommended): 4 custom Metalium kernels (`kps_project_fused`, `transposed_s2i`, `grouped_weighted_sum`, `grid_compact`) plus a patch to upstream `grid_sample` — see [docs/INSTALL.md](docs/INSTALL.md)
 
-**What changed in v2** (122 -> 95.2 ms), every step verified bit-identical to the path it replaced:
+**What changed in v2.** The three items below were each measured on this machine; the v1
+figure is the previously published one from an earlier state of the tree, so the two
+columns are a before/after, not a controlled A/B of a single change.
 
-| Change | Latency |
-| :--- | :---: |
-| v1 | 122 ms |
-| Row-major image upload — `ttnn.conv2d` takes NHWC directly, so the host tilize was waste | 139.9 ms* |
-| 1 KB upload pages — a ROW_MAJOR row is one page, so 4-channel rows made h2d 540,672 transfers of 8 B (41.0 -> 0.55 ms) | 103.7 ms |
-| Pooled OOB compaction — drop the anchors that project outside every camera before `grid_sample` sees them | **95.2 ms** |
-
-\* the row-major upload landed together with a re-measurement on different hardware seating; it is listed for provenance, not as a regression.
-
-Also fixed on the way, with no speed cost: `grouped_weighted_sum` in RM mode inherited the
-previous op's compute-pipeline configuration and so was wrong on its first call after any
-other op — silently, and only in that mode. See the accuracy table.
+| Change | Measured effect |
+| :--- | :--- |
+| 1 KB upload pages — a ROW_MAJOR row is one page, so 4-channel rows made h2d 540,672 transfers of 8 B against 0.13 ms of actual data | h2d 41.0 -> 0.55 ms |
+| Pooled OOB compaction — drop the anchors that project outside every camera before `grid_sample` sees them, pooling the survivors across cameras so the fixed budget covers the busiest *frame* rather than the busiest *camera* | 103.7 -> 95.2 ms, bit-identical output |
+| `grouped_weighted_sum` RM mode inherited the previous op's compute-pipeline configuration, so it was wrong on its first call after any other op — silently, and only in that mode | mAP 0.3933 -> 0.3968, no speed cost |
 
 ### Accuracy
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -17,7 +17,8 @@ pip install -r requirement.txt
 
 ## 2. Custom Kernel Build
 
-This project uses 3 custom TT-Metal kernels. They must be built into the tt-metal library before running.
+This project uses 4 custom TT-Metal kernels, plus one patch to an upstream op. All of them
+must be built into the tt-metal library before running.
 
 ### 2.1 Copy kernel source
 
@@ -25,6 +26,16 @@ This project uses 3 custom TT-Metal kernels. They must be built into the tt-meta
 cp -r tt-metal/ops/kps_project_fused ~/tt-metal/ttnn/cpp/ttnn/operations/pool/
 cp -r tt-metal/ops/grouped_weighted_sum ~/tt-metal/ttnn/cpp/ttnn/operations/pool/
 cp -r tt-metal/ops/transposed_s2i ~/tt-metal/ttnn/cpp/ttnn/operations/pool/
+cp -r tt-metal/ops/grid_compact ~/tt-metal/ttnn/cpp/ttnn/operations/pool/
+```
+
+`grid_sample` is an **upstream** op, patched rather than added — it gains an optional
+`batch_index` so a grid stick can name its own source image instead of having it inferred
+from the stick's position. Overwrite it in place; it is already registered, so sections
+2.2 - 2.4 do not apply to it:
+
+```bash
+cp -r tt-metal/ops/grid_sample ~/tt-metal/ttnn/cpp/ttnn/operations/pool/
 ```
 
 ### 2.2 Register in CMake
@@ -36,6 +47,7 @@ Add to `file(GLOB_RECURSE kernels ...)`:
     kps_project_fused/device/kernels/*
     grouped_weighted_sum/device/kernels/*
     transposed_s2i/device/kernels/*
+    grid_compact/device/kernels/*
 ```
 
 Add to `target_sources(ttnn_op_pool PRIVATE ...)`:
@@ -49,6 +61,9 @@ Add to `target_sources(ttnn_op_pool PRIVATE ...)`:
     transposed_s2i/transposed_s2i.cpp
     transposed_s2i/device/transposed_s2i_device_operation.cpp
     transposed_s2i/device/transposed_s2i_program_factory.cpp
+    grid_compact/grid_compact.cpp
+    grid_compact/device/grid_compact_device_operation.cpp
+    grid_compact/device/grid_compact_program_factory.cpp
 ```
 
 ### 2.3 Register nanobind
@@ -60,6 +75,7 @@ Add to the nanobind source list (near other `pool/` entries):
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/kps_project_fused/kps_project_fused_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/grouped_weighted_sum/grouped_weighted_sum_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/transposed_s2i/transposed_s2i_nanobind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/grid_compact/grid_compact_nanobind.cpp
 ```
 
 ### 2.4 Register Python bindings
@@ -71,6 +87,7 @@ Add includes (near other `pool/` includes):
 #include "ttnn/operations/pool/kps_project_fused/kps_project_fused_nanobind.hpp"
 #include "ttnn/operations/pool/grouped_weighted_sum/grouped_weighted_sum_nanobind.hpp"
 #include "ttnn/operations/pool/transposed_s2i/transposed_s2i_nanobind.hpp"
+#include "ttnn/operations/pool/grid_compact/grid_compact_nanobind.hpp"
 ```
 
 Add bind calls in the `m_pool` section (near `grid_sample::bind_grid_sample(m_pool)`):
@@ -78,6 +95,7 @@ Add bind calls in the `m_pool` section (near `grid_sample::bind_grid_sample(m_po
     kps_project_fused::bind_kps_project_fused(m_pool);
     grouped_weighted_sum::bind_grouped_weighted_sum(m_pool);
     transposed_s2i::bind_transposed_s2i(m_pool);
+    grid_compact::bind_grid_compact(m_pool);
 ```
 
 ### 2.5 Build & Install

--- a/model/deformable_feature_aggregation.py
+++ b/model/deformable_feature_aggregation.py
@@ -885,16 +885,15 @@ class DeformableFeatureAggregation:
                 )
             ttnn.deallocate(points_2d_sh)
 
-            # NOTE: this TILE conversion costs a 137 MB DRAM round trip per call and
-            # is avoidable — grouped_weighted_sum's RM_MODE tilizes in L1. That path
-            # was broken (missing pack_reconfig_l1_acc(0) before tilize_block) until
-            # the kernel fix; passing self._rearrange_buf directly saves ~4.7 ms/frame.
-            features = ttnn.to_layout(self._rearrange_buf, ttnn.TILE_LAYOUT)
+            # Feed the ROW_MAJOR buffer straight to grouped_weighted_sum: its RM_MODE
+            # tilizes in L1, so the ttnn.to_layout(..., TILE_LAYOUT) this replaces — a
+            # 137 MB DRAM round trip per call — is not needed. Requires the RM_MODE
+            # kernel fix (pack_reconfig_l1_acc(0) before tilize_block).
             gws_out = ttnn.grouped_weighted_sum(
-                features, weights_t, num_groups=self.num_groups, group_dims=self.group_dims
+                self._rearrange_buf, weights_t,
+                num_groups=self.num_groups, group_dims=self.group_dims,
             )
             ttnn.deallocate(weights_t)
-            ttnn.deallocate(features)
             n_padded = ((n + 31) // 32) * 32
             chunk0 = ttnn.slice(gws_out, [0, 0], [n, self.embed_dims])
             chunk1 = ttnn.slice(gws_out, [n_padded, 0], [n_padded + n, self.embed_dims])

--- a/model/deformable_feature_aggregation.py
+++ b/model/deformable_feature_aggregation.py
@@ -32,6 +32,41 @@ if _env is not None:
 else:
     _HAS_CUSTOM_KERNELS = _KERNELS_AVAILABLE
 
+
+# OOB compaction: drop the (camera, anchor) rows whose key points all project outside
+# their image before grid_sample sees them. Roughly two thirds of rows do — with 6 cameras
+# an anchor is visible to one or two. grid_sample already skips the DRAM reads for such
+# points, but it still pays CB page, barrier and reduce per point, and that fixed cost is
+# where its time actually goes. Bit-identical to the dense path, 103.7 -> 95.2 ms.
+#
+# On by default when the ops are present, like _HAS_CUSTOM_KERNELS above; TT_OOB_COMPACT=0
+# forces the dense path. It needs BOTH grid_compact and the grid_sample patch that adds
+# batch_index — an older tt-metal build can have the first without the second, and the
+# docstring is the only thing nanobind exposes to tell them apart.
+_OOB_AVAILABLE = hasattr(ttnn, "grid_compact") and "batch_index" in (ttnn.grid_sample.__doc__ or "")
+_env = _os.environ.get("TT_OOB_COMPACT")
+if _env is not None:
+    _OOB_COMPACT = _env == "1"
+else:
+    _OOB_COMPACT = _HAS_CUSTOM_KERNELS and _OOB_AVAILABLE
+
+# TT_OOB_CAP is the total row budget for the compacted grid. Shapes must not vary or every
+# call recompiles, so it is fixed and has to cover the busiest frame.
+#
+# The rows are POOLED across the device's cameras rather than kept in one block per camera.
+# That matters more than it sounds: per camera the budget must cover the busiest CAMERA,
+# and the cameras do not peak together — measured over 16 scenes (11520 camera-calls,
+# debug/measure_oob_capacity.py) the zero-loss budget is 3 x 563 = 1689 rows per camera
+# but only 902 pooled, for exactly the same guarantee. Pooling needs grid_sample to take
+# the source camera as data (its batch_index argument) instead of inferring it from a
+# row's position, which is what the accompanying tt-metal change adds.
+#
+#   pooled per device: mean 540, p50 541, p95 738, p99 819, max 902 of 2700
+#
+# Overflow costs accuracy only, never speed: the shapes are fixed, so the kernel stops
+# writing past the budget and every stage walks the same number of rows regardless.
+_OOB_CAP = int(_os.environ.get("TT_OOB_CAP", "928"))
+
 # Anchor box field indices (Sparse4D convention)
 X, Y, Z = 0, 1, 2
 W, L, H = 3, 4, 5
@@ -107,6 +142,28 @@ class DeformableFeatureAggregation:
         self._grid_sharded_mem = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, _shard_spec
         )
+
+        # Same, for the pooled compacted grid: CAP rows total instead of num_cams*900.
+        # The batch-index shard must have the same height so a core's slice of it lines up
+        # index-for-index with the grid sticks that core owns; its width is 8 only because
+        # a sharded page has to be 32 B aligned and grid_sample reads element 0.
+        _cshard_h = (_OOB_CAP + 55) // 56
+        self._cgrid_sharded_mem = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                _core_grid, (_cshard_h, _padded_last), ttnn.ShardOrientation.ROW_MAJOR
+            ),
+        )
+        self._cbidx_sharded_mem = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(_core_grid, (_cshard_h, 8), ttnn.ShardOrientation.ROW_MAJOR),
+        )
+        self._cgrid = None
+        self._cindex = None
+        self._cflags = None
+        self._cbidx = None
 
         # L1 sharded config for precomputed grid (pts*6 per point instead of pts*2)
         _padded_precomputed = ((num_pts * 6 + 7) // 8) * 8  # 78 → 80
@@ -797,6 +854,82 @@ class DeformableFeatureAggregation:
 
         return weights
 
+    def _compact_grid(self, points_2d, n, nc, spatial_shapes):
+        """Compact the sampling grid to the rows that actually hit an image.
+
+        All cameras share one pooled list, in source-row order; each kept row records its
+        camera in _cbidx, which grid_sample consumes as batch_index. Returns the sharded
+        grid and batch index; the source rows and the per-anchor keep flags land in
+        self._cindex / self._cflags.
+        """
+        if self._cgrid is None:
+            _kw = dict(
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=self.device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            if self._mesh_device is not None:
+                _kw["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+            # Rows past a camera's kept count are never written, so seed them far out
+            # of bounds: grid_sample still samples them (their index entry is SENTINEL,
+            # so transposed_s2i discards the result) and must not read a stale NaN.
+            self._cgrid = ttnn.from_torch(
+                torch.full((1, _OOB_CAP, 1, self.num_pts * 2), 9.0),
+                dtype=ttnn.float32, **_kw,
+            )
+            self._cindex = ttnn.from_torch(
+                torch.zeros(1, 1, 1, _OOB_CAP, dtype=torch.int32),
+                dtype=ttnn.uint32, **_kw,
+            )
+            self._cflags = ttnn.from_torch(
+                torch.zeros(nc, 1, 1, n), dtype=ttnn.bfloat16, **_kw
+            )
+            self._cbidx = ttnn.from_torch(
+                torch.zeros(1, 1, _OOB_CAP, 8, dtype=torch.int32),
+                dtype=ttnn.uint32, **_kw,
+            )
+
+        # With align_corners=False a point contributes iff g is in [-1 - 1/S, 1 + 1/S),
+        # S being W on x and H on y. Take the loosest LEVEL so one compaction serves all
+        # four — the grid itself is level-independent — but keep the axes separate: the
+        # coarsest level is 8 x 22, so sharing 1 + 1/8 across both would keep everything.
+        thr_x = 1.0 + 1.0 / min(w for _, w in spatial_shapes)
+        thr_y = 1.0 + 1.0 / min(h for h, _ in spatial_shapes)
+        ttnn.grid_compact(
+            points_2d, self._cgrid, self._cindex, self._cflags,
+            num_pts=self.num_pts, capacity=_OOB_CAP, anchors=n,
+            threshold_x=thr_x, threshold_y=thr_y, bidx=self._cbidx,
+        )
+        return (
+            ttnn.to_memory_config(self._cgrid, self._cgrid_sharded_mem),
+            ttnn.to_memory_config(self._cbidx, self._cbidx_sharded_mem),
+        )
+
+    def _mask_weights(self, weights_t, n, nc):
+        """Zero the attention weights of the rows compaction dropped.
+
+        A dropped row is never written into _rearrange_buf, which therefore still holds
+        LAST frame's features in that slot; grouped_weighted_sum would multiply that
+        stale data by a live weight. Masking annihilates it, and multiplying by exactly
+        0.0/1.0 is exact in every float format, so the kept rows are untouched.
+        Zeroing the 68.6 MB feature buffer instead would cost more than compaction saves.
+        """
+        f = ttnn.to_layout(self._cflags, ttnn.TILE_LAYOUT)  # [nc, 1, 1, n]
+        mask = ttnn.transpose(f, -2, -1)  # [nc, 1, n, 1]
+        ttnn.deallocate(f)
+        # clp = cam*NL*K + level*K + pt, so the camera axis splits off the front of
+        # weights_t for free (leading dims carry no tile padding) and the flag then
+        # broadcasts over the level/point axis and the group axis in one multiply.
+        w4 = ttnn.reshape(
+            weights_t, (nc, self.num_levels * self.num_pts, n, self.num_groups)
+        )
+        out = ttnn.multiply(w4, mask)
+        ttnn.deallocate(mask)
+        ttnn.deallocate(w4)
+        return ttnn.reshape(
+            out, (nc * self.num_levels * self.num_pts, n, self.num_groups)
+        )
+
     def run(
         self,
         instance_feature: ttnn.Tensor,
@@ -821,6 +954,7 @@ class DeformableFeatureAggregation:
         key_points = self._kps_generator_pre_rotation(
             anchor, instance_feature, bs, num_anchor
         )
+        # the kernel reads the anchor as row-major pages
         anchor_rm = ttnn.reshape(anchor, (n, 1, 11))
         anchor_rm = ttnn.to_layout(anchor_rm, ttnn.ROW_MAJOR_LAYOUT)
 
@@ -861,29 +995,47 @@ class DeformableFeatureAggregation:
             ttnn.deallocate(key_points)
             ttnn.deallocate(anchor_rm)
 
-            points_2d_sh = ttnn.to_memory_config(points_2d, self._grid_sharded_mem)
-            ttnn.deallocate(points_2d)
-
-            weights_t = ttnn.transpose(weights, 0, 1)
-
+            # Allocate the feature buffer BEFORE anything compaction-specific: its DRAM
+            # address must not depend on TT_OOB_COMPACT. grouped_weighted_sum reads
+            # slightly past it on the very first call (the buffer is zero-filled, so the
+            # tail it touches is whatever the allocator handed over), which makes frame
+            # 0 sensitive to allocation order — see debug/verify_oob_compact.py.
             total_clp = nc * self.num_levels * self.num_pts
-            if not hasattr(self, '_rearrange_buf') or self._rearrange_buf is None:
+            if getattr(self, "_rearrange_buf", None) is None:
                 _buf = torch.zeros(total_clp, n, self.embed_dims, dtype=torch.bfloat16)
                 _kw = dict(dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=self.device)
                 if self._mesh_device is not None:
                     _kw["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
                 self._rearrange_buf = ttnn.from_torch(_buf, **_kw)
 
+            bidx_sh = None
+            if _OOB_COMPACT:
+                points_2d_sh, bidx_sh = self._compact_grid(
+                    points_2d, n, nc, spatial_shapes
+                )
+            else:
+                points_2d_sh = ttnn.to_memory_config(points_2d, self._grid_sharded_mem)
+            ttnn.deallocate(points_2d)
+
+            weights_t = ttnn.transpose(weights, 0, 1)
+            if _OOB_COMPACT:
+                weights_t = self._mask_weights(weights_t, n, nc)
+
             for level_idx, fm_tt in enumerate(feature_maps):
                 sampled = ttnn.grid_sample(
-                    fm_tt, points_2d_sh, padding_mode="zeros", align_corners=False
+                    fm_tt, points_2d_sh, padding_mode="zeros", align_corners=False,
+                    batch_index=bidx_sh,
                 )
                 ttnn.transposed_s2i(
                     sampled, self._rearrange_buf,
                     num_cams=nc, num_pts=self.num_pts, num_anchors=n,
                     num_levels=self.num_levels, level=level_idx,
+                    index=self._cindex if _OOB_COMPACT else None,
+                    capacity=_OOB_CAP if _OOB_COMPACT else 0,
                 )
             ttnn.deallocate(points_2d_sh)
+            if bidx_sh is not None:
+                ttnn.deallocate(bidx_sh)
 
             # Feed the ROW_MAJOR buffer straight to grouped_weighted_sum: its RM_MODE
             # tilizes in L1, so the ttnn.to_layout(..., TILE_LAYOUT) this replaces — a

--- a/model/deformable_feature_aggregation.py
+++ b/model/deformable_feature_aggregation.py
@@ -63,9 +63,14 @@ else:
 #
 #   pooled per device: mean 540, p50 541, p95 738, p99 819, max 902 of 2700
 #
+# The default scales with the camera count, because the number of cameras a single DFA
+# owns is not fixed: the mesh path gives it 3 (one device's half of 6) and the
+# single-device path gives it all 6. A constant sized for 3 would silently drop about half
+# the visible anchors on the single-device path.
+#
 # Overflow costs accuracy only, never speed: the shapes are fixed, so the kernel stops
 # writing past the budget and every stage walks the same number of rows regardless.
-_OOB_CAP = int(_os.environ.get("TT_OOB_CAP", "928"))
+_OOB_CAP_ENV = _os.environ.get("TT_OOB_CAP")
 
 # Anchor box field indices (Sparse4D convention)
 X, Y, Z = 0, 1, 2
@@ -143,11 +148,18 @@ class DeformableFeatureAggregation:
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, _shard_spec
         )
 
+        # 928 rows covers 3 cameras with the measured max of 902; scale it linearly and
+        # keep it tile-aligned. TT_OOB_CAP overrides the total outright.
+        self._oob_cap = (
+            int(_OOB_CAP_ENV) if _OOB_CAP_ENV is not None
+            else ((num_cams * 928 // 3 + 31) // 32) * 32
+        )
+
         # Same, for the pooled compacted grid: CAP rows total instead of num_cams*900.
         # The batch-index shard must have the same height so a core's slice of it lines up
         # index-for-index with the grid sticks that core owns; its width is 8 only because
         # a sharded page has to be 32 B aligned and grid_sample reads element 0.
-        _cshard_h = (_OOB_CAP + 55) // 56
+        _cshard_h = (self._oob_cap + 55) // 56
         self._cgrid_sharded_mem = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             ttnn.BufferType.L1,
@@ -164,6 +176,7 @@ class DeformableFeatureAggregation:
         self._cindex = None
         self._cflags = None
         self._cbidx = None
+        self._compact_shape = None
 
         # L1 sharded config for precomputed grid (pts*6 per point instead of pts*2)
         _padded_precomputed = ((num_pts * 6 + 7) // 8) * 8  # 78 → 80
@@ -862,6 +875,12 @@ class DeformableFeatureAggregation:
         grid and batch index; the source rows and the per-anchor keep flags land in
         self._cindex / self._cflags.
         """
+        # The buffers below are sized from the first call's n/nc and then reused, so a
+        # later call with a different anchor count would silently write out of range.
+        assert (n, nc) == (self._compact_shape or (n, nc)), (
+            f"compaction buffers were built for {self._compact_shape}, got {(n, nc)}"
+        )
+        self._compact_shape = (n, nc)
         if self._cgrid is None:
             _kw = dict(
                 layout=ttnn.ROW_MAJOR_LAYOUT,
@@ -874,18 +893,18 @@ class DeformableFeatureAggregation:
             # of bounds: grid_sample still samples them (their index entry is SENTINEL,
             # so transposed_s2i discards the result) and must not read a stale NaN.
             self._cgrid = ttnn.from_torch(
-                torch.full((1, _OOB_CAP, 1, self.num_pts * 2), 9.0),
+                torch.full((1, self._oob_cap, 1, self.num_pts * 2), 9.0),
                 dtype=ttnn.float32, **_kw,
             )
             self._cindex = ttnn.from_torch(
-                torch.zeros(1, 1, 1, _OOB_CAP, dtype=torch.int32),
+                torch.zeros(1, 1, 1, self._oob_cap, dtype=torch.int32),
                 dtype=ttnn.uint32, **_kw,
             )
             self._cflags = ttnn.from_torch(
                 torch.zeros(nc, 1, 1, n), dtype=ttnn.bfloat16, **_kw
             )
             self._cbidx = ttnn.from_torch(
-                torch.zeros(1, 1, _OOB_CAP, 8, dtype=torch.int32),
+                torch.zeros(1, 1, self._oob_cap, 8, dtype=torch.int32),
                 dtype=ttnn.uint32, **_kw,
             )
 
@@ -897,7 +916,7 @@ class DeformableFeatureAggregation:
         thr_y = 1.0 + 1.0 / min(h for h, _ in spatial_shapes)
         ttnn.grid_compact(
             points_2d, self._cgrid, self._cindex, self._cflags,
-            num_pts=self.num_pts, capacity=_OOB_CAP, anchors=n,
+            num_pts=self.num_pts, capacity=self._oob_cap, anchors=n,
             threshold_x=thr_x, threshold_y=thr_y, bidx=self._cbidx,
         )
         return (
@@ -995,11 +1014,8 @@ class DeformableFeatureAggregation:
             ttnn.deallocate(key_points)
             ttnn.deallocate(anchor_rm)
 
-            # Allocate the feature buffer BEFORE anything compaction-specific: its DRAM
-            # address must not depend on TT_OOB_COMPACT. grouped_weighted_sum reads
-            # slightly past it on the very first call (the buffer is zero-filled, so the
-            # tail it touches is whatever the allocator handed over), which makes frame
-            # 0 sensitive to allocation order — see debug/verify_oob_compact.py.
+            # Allocated before anything compaction-specific so its DRAM address does not
+            # depend on TT_OOB_COMPACT, which keeps an A/B against the dense path honest.
             total_clp = nc * self.num_levels * self.num_pts
             if getattr(self, "_rearrange_buf", None) is None:
                 _buf = torch.zeros(total_clp, n, self.embed_dims, dtype=torch.bfloat16)
@@ -1031,7 +1047,7 @@ class DeformableFeatureAggregation:
                     num_cams=nc, num_pts=self.num_pts, num_anchors=n,
                     num_levels=self.num_levels, level=level_idx,
                     index=self._cindex if _OOB_COMPACT else None,
-                    capacity=_OOB_CAP if _OOB_COMPACT else 0,
+                    capacity=self._oob_cap if _OOB_COMPACT else 0,
                 )
             ttnn.deallocate(points_2d_sh)
             if bidx_sh is not None:
@@ -1039,8 +1055,9 @@ class DeformableFeatureAggregation:
 
             # Feed the ROW_MAJOR buffer straight to grouped_weighted_sum: its RM_MODE
             # tilizes in L1, so the ttnn.to_layout(..., TILE_LAYOUT) this replaces — a
-            # 137 MB DRAM round trip per call — is not needed. Requires the RM_MODE
-            # kernel fix (pack_reconfig_l1_acc(0) before tilize_block).
+            # 137 MB DRAM round trip per call — is not needed. RM_MODE is only correct
+            # with the kernel fix that configures both compute pipelines before the loop;
+            # without it the op is wrong on its first call after any other op has run.
             gws_out = ttnn.grouped_weighted_sum(
                 self._rearrange_buf, weights_t,
                 num_groups=self.num_groups, group_dims=self.group_dims,

--- a/model/sparse4d.py
+++ b/model/sparse4d.py
@@ -259,8 +259,11 @@ class Sparse4DInference:
         pad_0 = torch.nn.functional.pad(imgs_0, (0, 1), value=0)
         pad_1 = torch.nn.functional.pad(imgs_1, (0, 1), value=0)
         stacked = torch.cat([pad_0, pad_1], dim=0)
-        # Host-only tensor (TILE layout, no device)
-        return _ttnn.from_torch(stacked.bfloat16(), layout=_ttnn.TILE_LAYOUT,
+        # ROW_MAJOR, not TILE: TILE pads the 4-channel last dim out to 32, which
+        # inflates the tensor 8x (4.12 -> 33 MB/device). ttnn.conv2d takes ROW_MAJOR
+        # NHWC directly, so the host tilize (37 ms) and the extra PCIe traffic
+        # (85 -> 42 ms) are both pure waste.
+        return _ttnn.from_torch(stacked.bfloat16(), layout=_ttnn.ROW_MAJOR_LAYOUT,
                                 mesh_mapper=_ttnn.ShardTensorToMesh(self._mesh_device, dim=0))
 
     def preprocess_images(self, images: torch.Tensor):
@@ -529,7 +532,7 @@ class Sparse4DInference:
         if not hasattr(self, '_img_dev_slot') or self._img_dev_slot is None:
             self._img_dev_slot = ttnn.allocate_tensor_on_device(
                 ttnn.Shape([1, 1, 3 * 256 * 704, 4]),
-                ttnn.bfloat16, ttnn.TILE_LAYOUT, self._mesh_device)
+                ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, self._mesh_device)
         ttnn.copy_host_to_device_tensor(host_input, self._img_dev_slot)
         tt_input = self._img_dev_slot
 

--- a/model/sparse4d.py
+++ b/model/sparse4d.py
@@ -441,7 +441,11 @@ class Sparse4DInference:
         Worker process: cam3-5 on device 1 (opened independently)
 
         No dispatch core conflict because each process uses a different device.
-        Enables HiFi4 + fp32_dest_acc_en at batch=3 for improved precision.
+
+        Note: backbone and FPN run at LoFi with bf16 here, not the HiFi4 + fp32_dest_acc
+        this docstring used to claim. fp32 activations do not fit at batch=3 — L1
+        allocation fails outright — and the FPN output is within PCC 0.9998 of a
+        full-mantissa fp32-accumulate reference anyway.
 
         Args:
             images: [bs, 6, 3, 256, 704] normalized images

--- a/model/sparse4d.py
+++ b/model/sparse4d.py
@@ -144,6 +144,11 @@ class Sparse4DInference:
     Connects TtResNetBottleneck + FPN + Sparse4DHead.
     """
 
+    # Shape the image tensor is uploaded in: [mesh_dim, 1, rows, cols] holding the
+    # same 2 * 3 * 256 * 704 * 4 elements as [2, 1, 540672, 4], but with 512-wide
+    # rows so each ROW_MAJOR page is 1 KB instead of 8 B. See _prepare_host_input.
+    UPLOAD_SHAPE = (2, 1, 4224, 512)
+
     def __init__(
         self,
         device,
@@ -263,7 +268,15 @@ class Sparse4DInference:
         # inflates the tensor 8x (4.12 -> 33 MB/device). ttnn.conv2d takes ROW_MAJOR
         # NHWC directly, so the host tilize (37 ms) and the extra PCIe traffic
         # (85 -> 42 ms) are both pure waste.
-        return _ttnn.from_torch(stacked.bfloat16(), layout=_ttnn.ROW_MAJOR_LAYOUT,
+        #
+        # Upload wide, not [.., 540672, 4]: a ROW_MAJOR tensor is paged one row per
+        # page, so a 4-channel row is an 8-byte page and the 4.12 MB payload becomes
+        # 540,672 transfers. h2d then costs 540672 x 72.9 ns = 39 ms of pure per-page
+        # overhead against 0.13 ms of actual data (the link streams at 30.9 GB/s).
+        # Reshaping to 1 KB pages drops h2d to 0.55 ms; UPLOAD_SHAPE is the same
+        # bytes in the same order, so preprocess_images reshapes it back on device.
+        return _ttnn.from_torch(stacked.reshape(*self.UPLOAD_SHAPE).bfloat16(),
+                                layout=_ttnn.ROW_MAJOR_LAYOUT,
                                 mesh_mapper=_ttnn.ShardTensorToMesh(self._mesh_device, dim=0))
 
     def preprocess_images(self, images: torch.Tensor):
@@ -531,10 +544,12 @@ class Sparse4DInference:
 
         if not hasattr(self, '_img_dev_slot') or self._img_dev_slot is None:
             self._img_dev_slot = ttnn.allocate_tensor_on_device(
-                ttnn.Shape([1, 1, 3 * 256 * 704, 4]),
+                ttnn.Shape([1, 1, self.UPLOAD_SHAPE[2], self.UPLOAD_SHAPE[3]]),
                 ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, self._mesh_device)
         ttnn.copy_host_to_device_tensor(host_input, self._img_dev_slot)
-        tt_input = self._img_dev_slot
+        # Back to the NHWC shape conv2d consumes. Same bytes in the same order, so
+        # this is a re-paging on device (~2 ms) in exchange for 39 ms of h2d.
+        tt_input = ttnn.reshape(self._img_dev_slot, (1, 1, 3 * 256 * 704, 4))
 
         # Backbone SPMD: each device processes its 3 cameras
         backbone_features = self.backbone(tt_input)

--- a/test/sparse4d_nuscenes_val.py
+++ b/test/sparse4d_nuscenes_val.py
@@ -1118,7 +1118,7 @@ def main():
     parser.add_argument(
         "--dual-device",
         action="store_true",
-        help="Use 2 devices (batch=3 each) for backbone+FPN with HiFi4+fp32_acc precision",
+        help="Use 2 devices, 3 cameras each, for backbone+FPN",
     )
     parser.add_argument(
         "--bf16",
@@ -1140,7 +1140,10 @@ def main():
         type=str,
         choices=["lofi", "hifi2", "hifi4"],
         default=None,
-        help="Override math fidelity for all head modules (default: per-module setting)",
+        help="BROKEN, do not use: the override leaves a mixed-fidelity pipeline. "
+             "Measured against a HiFi4 reference, --fidelity hifi2 moves the FPN "
+             "output FURTHER from full precision than the LoFi default (PCC 0.9927 "
+             "vs 0.9998) and costs 0.024 mAP. See debug/probe_fidelity_pcc.py.",
     )
     args = parser.parse_args()
 

--- a/tt-metal/ops/grid_compact/device/grid_compact_device_operation.cpp
+++ b/tt-metal/ops/grid_compact/device/grid_compact_device_operation.cpp
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstring>
+#include "grid_compact_device_operation.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::prim {
+using namespace tt;
+using namespace tt::tt_metal;
+
+GridCompactOperation::program_factory_t GridCompactOperation::select_program_factory(
+    const operation_attributes_t&, const tensor_args_t&) {
+    return GridCompactProgramFactory{};
+}
+
+void GridCompactOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& a, const tensor_args_t& t) {
+    TT_FATAL(t.grid.dtype() == DataType::FLOAT32, "grid must be FLOAT32");
+    TT_FATAL(t.cgrid.dtype() == DataType::FLOAT32, "cgrid must be FLOAT32");
+    TT_FATAL(t.index.dtype() == DataType::UINT32, "index must be UINT32");
+    TT_FATAL(t.flags.dtype() == DataType::BFLOAT16, "flags must be BFLOAT16");
+    TT_FATAL(t.grid.layout() == Layout::ROW_MAJOR, "grid must be ROW_MAJOR");
+    TT_FATAL(t.cgrid.layout() == Layout::ROW_MAJOR, "cgrid must be ROW_MAJOR");
+    TT_FATAL(t.grid.storage_type() == StorageType::DEVICE, "grid must be on device");
+    TT_FATAL(t.cgrid.storage_type() == StorageType::DEVICE, "cgrid must be on device");
+    TT_FATAL(t.index.storage_type() == StorageType::DEVICE, "index must be on device");
+    TT_FATAL(t.flags.storage_type() == StorageType::DEVICE, "flags must be on device");
+    TT_FATAL(t.flags.layout() == Layout::ROW_MAJOR, "flags must be ROW_MAJOR");
+    TT_FATAL(
+        t.flags.logical_shape()[-1] >= a.anchors,
+        "flags last dim must be >= anchors ({} < {})",
+        t.flags.logical_shape()[-1],
+        a.anchors);
+    TT_FATAL(a.row_width >= 2 * a.num_pts, "row_width must hold 2*num_pts coordinates");
+    if (t.bidx.has_value()) {
+        TT_FATAL(t.bidx->dtype() == DataType::UINT32, "bidx must be UINT32");
+        TT_FATAL(t.bidx->layout() == Layout::ROW_MAJOR, "bidx must be ROW_MAJOR");
+        TT_FATAL(t.bidx->storage_type() == StorageType::DEVICE, "bidx must be on device");
+    }
+}
+
+TensorSpec GridCompactOperation::compute_output_specs(
+    const operation_attributes_t&, const tensor_args_t& t) {
+    return t.cgrid.tensor_spec();
+}
+
+Tensor GridCompactOperation::create_output_tensors(
+    const operation_attributes_t&, const tensor_args_t& t) {
+    return t.cgrid;
+}
+
+void grid_compact(
+    const Tensor& grid, Tensor& cgrid, Tensor& index, Tensor& flags,
+    uint32_t num_pts, uint32_t capacity, uint32_t anchors,
+    float threshold_x, float threshold_y,
+    const std::optional<Tensor>& bidx) {
+    const auto& gs = grid.logical_shape();
+    const uint32_t row_width = gs[-1];
+    uint32_t num_rows = 1;
+    for (int i = 0; i < gs.rank() - 1; i++) {
+        num_rows *= gs[i];
+    }
+    uint32_t thr_x_bits = 0, thr_y_bits = 0;
+    std::memcpy(&thr_x_bits, &threshold_x, sizeof(thr_x_bits));
+    std::memcpy(&thr_y_bits, &threshold_y, sizeof(thr_y_bits));
+
+    using Op = GridCompactOperation;
+    ttnn::device_operation::launch<Op>(
+        Op::operation_attributes_t{
+            .num_rows = num_rows,
+            .num_pts = num_pts,
+            .row_width = row_width,
+            .capacity = capacity,
+            .anchors = anchors,
+            .thr_x_bits = thr_x_bits,
+            .thr_y_bits = thr_y_bits,
+            .flag_width = static_cast<uint32_t>(flags.logical_shape()[-1]),
+            .bidx_width = bidx.has_value() ? static_cast<uint32_t>(bidx->logical_shape()[-1]) : 0u,
+            .output_mem_config = cgrid.memory_config(),
+        },
+        Op::tensor_args_t{
+            .grid = grid, .cgrid = cgrid, .index = index, .flags = flags, .bidx = bidx});
+}
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/grid_compact/device/grid_compact_device_operation.hpp
+++ b/tt-metal/ops/grid_compact/device/grid_compact_device_operation.hpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <optional>
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/device_operation.hpp"
+#include "grid_compact_device_operation_types.hpp"
+#include "grid_compact_program_factory.hpp"
+
+namespace ttnn::prim {
+
+struct GridCompactOperation {
+    using operation_attributes_t = GridCompactParams;
+    using tensor_args_t = GridCompactInputs;
+    using spec_return_value_t = tt::tt_metal::TensorSpec;
+    using tensor_return_value_t = tt::tt_metal::Tensor;
+    using program_factory_t = std::variant<GridCompactProgramFactory>;
+
+    static program_factory_t select_program_factory(
+        const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(
+        const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(
+        const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t&, const tensor_args_t&);
+};
+
+void grid_compact(
+    const tt::tt_metal::Tensor& grid,
+    tt::tt_metal::Tensor& cgrid,
+    tt::tt_metal::Tensor& index,
+    tt::tt_metal::Tensor& flags,
+    uint32_t num_pts, uint32_t capacity, uint32_t anchors,
+    float threshold_x, float threshold_y,
+    const std::optional<tt::tt_metal::Tensor>& bidx = std::nullopt);
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/grid_compact/device/grid_compact_device_operation_types.hpp
+++ b/tt-metal/ops/grid_compact/device/grid_compact_device_operation_types.hpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <tt-metalium/constants.hpp>
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::prim {
+
+// Compacts a DFA sampling grid down to the rows that actually hit an image.
+// ~80% of (camera, anchor) rows project entirely outside their camera, and
+// grid_sample pays full pipeline cost for them even though it skips the reads.
+struct GridCompactParams {
+    uint32_t num_rows;    // nc * N, e.g. 2700
+    uint32_t num_pts;     // K, points per row
+    uint32_t row_width;   // padded floats per row (>= 2*K + 1, camera id goes at 2*K)
+    uint32_t capacity;    // fixed rows kept; shapes must not vary or ttnn recompiles
+    uint32_t anchors;     // N, so camera id = row / N
+    uint32_t thr_x_bits;  // fp32 bit pattern of the in-bounds threshold, x axis
+    uint32_t thr_y_bits;  // ... and y. They differ a lot: the bound is 1 + 1/W on x
+                          // and 1 + 1/H on y, and the coarsest level is 8 x 22.
+    uint32_t flag_width;  // padded anchors per camera in the flags tensor
+    uint32_t bidx_width;  // row width of the batch-index tensor (0 = per-camera mode)
+    tt::tt_metal::MemoryConfig output_mem_config;
+};
+
+struct GridCompactInputs {
+    const tt::tt_metal::Tensor& grid;   // DRAM [nc, N, 1, row_width] fp32
+    const tt::tt_metal::Tensor& cgrid;  // DRAM [1, capacity, 1, row_width] fp32, preallocated
+    const tt::tt_metal::Tensor& index;  // DRAM [1, 1, 1, nc*capacity] uint32, preallocated
+    const tt::tt_metal::Tensor& flags;  // DRAM [nc, 1, 1, flag_width] bf16, preallocated
+    // Pooled mode. Without it the kept rows are written as one fixed block per camera,
+    // because grid_sample derives a row's camera from its POSITION — which means CAP has
+    // to cover the busiest camera, and the cameras' busy frames do not coincide (measured:
+    // 3 x 563 = 1689 rows per-camera versus 902 pooled, for the same zero-loss guarantee).
+    // With bidx the rows go into one shared list and each carries its camera, which
+    // grid_sample now accepts via its batch_index argument.
+    std::optional<tt::tt_metal::Tensor> bidx;  // DRAM [1, 1, capacity, bidx_width] uint32
+};
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/grid_compact/device/grid_compact_program_factory.cpp
+++ b/tt-metal/ops/grid_compact/device/grid_compact_program_factory.cpp
@@ -16,7 +16,7 @@ using namespace tt::tt_metal;
 // Single core on purpose: the pass is a sequential scan with a running output
 // counter, which across cores would need a prefix sum. Measured alternative --
 // giving each core its own fixed slot budget so no core has to talk -- has to size
-// for the busiest core and yields only 1.5x compaction versus 2.4x pooled.
+// for the busiest core and compacts far worse than pooling across cameras does.
 GridCompactProgramFactory::cached_program_t GridCompactProgramFactory::create(
     const GridCompactParams& attrs,
     const GridCompactInputs& t,

--- a/tt-metal/ops/grid_compact/device/grid_compact_program_factory.cpp
+++ b/tt-metal/ops/grid_compact/device/grid_compact_program_factory.cpp
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "tt-metalium/tensor_accessor_args.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/math.hpp>
+#include "grid_compact_program_factory.hpp"
+
+namespace ttnn::prim {
+using namespace tt;
+using namespace tt::tt_metal;
+
+// Single core on purpose: the pass is a sequential scan with a running output
+// counter, which across cores would need a prefix sum. Measured alternative --
+// giving each core its own fixed slot budget so no core has to talk -- has to size
+// for the busiest core and yields only 1.5x compaction versus 2.4x pooled.
+GridCompactProgramFactory::cached_program_t GridCompactProgramFactory::create(
+    const GridCompactParams& attrs,
+    const GridCompactInputs& t,
+    Tensor& /*output_tensor*/) {
+
+    Program program{};
+    const CoreCoord core{0, 0};
+    const CoreRange core_range(core, core);
+
+    constexpr uint32_t BATCH = 64;   // rows fetched per barrier
+    const uint32_t row_bytes = attrs.row_width * sizeof(float);
+    // L1 strides, 32 B aligned: NOC endpoints must be, and a 26-float row is not.
+    const uint32_t row_stride = ((row_bytes + 31) / 32) * 32;
+    const uint32_t num_cams = attrs.num_rows / attrs.anchors;
+
+    const bool pooled = t.bidx.has_value();
+    const uint32_t idx_bytes = (pooled ? attrs.capacity : num_cams * attrs.capacity) * sizeof(uint32_t);
+    const uint32_t bidx_stride = pooled ? attrs.bidx_width * sizeof(uint32_t) : 0;
+    const uint32_t bidx_bytes = pooled ? attrs.capacity * bidx_stride : 0;
+
+    constexpr uint32_t ROW_CB = tt::CBIndex::c_0;
+    constexpr uint32_t IDX_CB = tt::CBIndex::c_1;
+    constexpr uint32_t FLG_CB = tt::CBIndex::c_2;
+    const uint32_t flag_stride = ((attrs.flag_width * 2 + 31) / 32) * 32;
+    const uint32_t flag_bytes = num_cams * flag_stride;
+
+    auto row_cb_cfg = CircularBufferConfig(row_stride * BATCH, {{ROW_CB, DataFormat::Float32}})
+                          .set_page_size(ROW_CB, row_stride);
+    CreateCircularBuffer(program, core_range, row_cb_cfg);
+    auto idx_cb_cfg = CircularBufferConfig(idx_bytes, {{IDX_CB, DataFormat::UInt32}})
+                          .set_page_size(IDX_CB, idx_bytes);
+    CreateCircularBuffer(program, core_range, idx_cb_cfg);
+    auto flg_cb_cfg = CircularBufferConfig(flag_bytes, {{FLG_CB, DataFormat::Float16_b}})
+                          .set_page_size(FLG_CB, flag_bytes);
+    CreateCircularBuffer(program, core_range, flg_cb_cfg);
+    constexpr uint32_t BIDX_CB = tt::CBIndex::c_3;
+    if (pooled) {
+        auto bidx_cb_cfg = CircularBufferConfig(bidx_bytes, {{BIDX_CB, DataFormat::UInt32}})
+                               .set_page_size(BIDX_CB, bidx_bytes);
+        CreateCircularBuffer(program, core_range, bidx_cb_cfg);
+    }
+
+    std::vector<uint32_t> ct_args = {
+        attrs.num_rows,    // 0
+        attrs.num_pts,     // 1
+        attrs.row_width,   // 2
+        attrs.capacity,    // 3
+        attrs.anchors,     // 4
+        attrs.thr_x_bits,  // 5
+        ROW_CB,            // 6
+        IDX_CB,            // 7
+        BATCH,             // 8
+        FLG_CB,            // 9
+        attrs.flag_width,  // 10
+        attrs.thr_y_bits,  // 11
+        pooled ? 1u : 0u,  // 12
+        BIDX_CB,           // 13
+        attrs.bidx_width,  // 14
+    };
+    TensorAccessorArgs(*t.grid.buffer()).append_to(ct_args);
+    TensorAccessorArgs(*t.cgrid.buffer()).append_to(ct_args);
+    TensorAccessorArgs(*t.index.buffer()).append_to(ct_args);
+    TensorAccessorArgs(*t.flags.buffer()).append_to(ct_args);
+    if (pooled) {
+        TensorAccessorArgs(*t.bidx->buffer()).append_to(ct_args);
+    }
+
+    KernelHandle kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/pool/grid_compact/device/kernels/dataflow/grid_compact.cpp",
+        core_range,
+        WriterDataMovementConfig(ct_args));
+
+    SetRuntimeArgs(program, kernel_id, core, {
+        t.grid.buffer()->address(),
+        t.cgrid.buffer()->address(),
+        t.index.buffer()->address(),
+        t.flags.buffer()->address(),
+        pooled ? t.bidx->buffer()->address() : 0u});
+
+    return cached_program_t{
+        std::move(program),
+        shared_variables_t{.kernel_id = kernel_id, .core = core}};
+}
+
+void GridCompactProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const GridCompactParams&,
+    const GridCompactInputs& t,
+    Tensor& /*output_tensor*/) {
+    auto& prog = cached_program.program;
+    const auto& sv = cached_program.shared_variables;
+    auto& r = GetRuntimeArgs(prog, sv.kernel_id, sv.core);
+    r[0] = t.grid.buffer()->address();
+    r[1] = t.cgrid.buffer()->address();
+    r[2] = t.index.buffer()->address();
+    r[3] = t.flags.buffer()->address();
+    if (t.bidx.has_value()) {
+        r[4] = t.bidx->buffer()->address();
+    }
+}
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/grid_compact/device/grid_compact_program_factory.hpp
+++ b/tt-metal/ops/grid_compact/device/grid_compact_program_factory.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "ttnn/device_operation.hpp"
+#include "grid_compact_device_operation_types.hpp"
+
+namespace ttnn::prim {
+
+struct GridCompactProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle kernel_id;
+        tt::tt_metal::CoreCoord core;
+    };
+
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const GridCompactParams& params,
+        const GridCompactInputs& inputs,
+        tt::tt_metal::Tensor& output);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const GridCompactParams& params,
+        const GridCompactInputs& inputs,
+        tt::tt_metal::Tensor& output);
+};
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/grid_compact/device/kernels/dataflow/grid_compact.cpp
+++ b/tt-metal/ops/grid_compact/device/kernels/dataflow/grid_compact.cpp
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+// Grid compaction, single core.
+//
+// Walks every (camera, anchor) row of the DFA sampling grid and keeps only the rows
+// with at least one point inside the image. ~80% of rows project entirely outside
+// their camera; grid_sample skips their DRAM reads but still pays CB page, barrier
+// and reduce for each one, so removing them up front is what actually saves time.
+//
+// Bounds test is done on raw bits: for IEEE754, |v| < thr (thr > 0) is exactly
+// (bits(v) & 0x7FFFFFFF) < bits(thr). Two integer ops instead of a soft-float
+// compare, which on an FPU-less dataflow core is ~25 cycles.
+//
+// The two axes get their own threshold. With align_corners=False a point contributes
+// iff g is in [-1 - 1/S, 1 + 1/S), S being W on x and H on y -- and the coarsest FPN
+// level is 8 x 22, so one shared threshold would have to use 1 + 1/8 on BOTH axes and
+// would keep everything.
+//
+// Rows past the kept count are left untouched in cgrid — their index entry is
+// SENTINEL, and transposed_s2i skips those, so stale coordinates can never reach
+// the output. That avoids writing padding rows every call.
+//
+// Compaction is PER CAMERA: camera c's kept rows land in cgrid[c*CAP .. c*CAP+CAP).
+// Pooling all cameras into one list compacts better (2.4x vs 1.5x), but grid_sample
+// derives the source image from a row's POSITION (curr_batch advances every grid_hw
+// sticks), so a pooled list would silently sample the wrong camera. Keeping the
+// per-camera blocks preserves that mapping with no change to grid_sample at all.
+// CAP must therefore cover the BUSIEST camera, measured max 62.7% of 900.
+//
+// A third output, `flags`, marks the kept (camera, anchor) pairs with 1.0. Dropped
+// rows are never written into the feature buffer, so it keeps LAST frame's values
+// there; multiplying the attention weights by these flags annihilates that stale
+// data. Zeroing the 68.6 MB feature buffer instead would cost more than compaction
+// saves.
+
+#include <stdint.h>
+#include "api/compile_time_args.h"
+#include "api/dataflow/dataflow_api.h"
+
+// bidx's accessor args only EXIST in pooled mode, so this has to be a template: an
+// `if constexpr` inside kernel_main() would not discard the branch (kernel_main is not a
+// template) and TensorAccessorArgs<OFF> would still be instantiated past the arg list.
+template <bool POOLED, uint32_t OFF, uint32_t BIDX_CB, uint32_t CAP, uint32_t BIDX_W>
+FORCE_INLINE void write_bidx(uint32_t bidx_addr) {
+    if constexpr (POOLED) {
+        constexpr auto bidx_args = TensorAccessorArgs<OFF>();
+        const auto bidx_acc = TensorAccessor(bidx_args, bidx_addr);
+        const uint32_t bidx_l1 = get_write_ptr(BIDX_CB);
+        for (uint32_t j = 0; j < CAP; j++) {  // one page per row
+            noc_async_write(bidx_l1 + j * BIDX_W * 4, bidx_acc.get_noc_addr(j), BIDX_W * 4);
+        }
+    }
+}
+
+void kernel_main() {
+    const uint32_t grid_addr  = get_arg_val<uint32_t>(0);
+    const uint32_t cgrid_addr = get_arg_val<uint32_t>(1);
+    const uint32_t index_addr = get_arg_val<uint32_t>(2);
+    const uint32_t flags_addr = get_arg_val<uint32_t>(3);
+    const uint32_t bidx_addr  = get_arg_val<uint32_t>(4);
+
+    constexpr uint32_t NUM_ROWS = get_compile_time_arg_val(0);
+    constexpr uint32_t NUM_PTS  = get_compile_time_arg_val(1);
+    constexpr uint32_t ROW_W    = get_compile_time_arg_val(2);
+    constexpr uint32_t CAP      = get_compile_time_arg_val(3);
+    constexpr uint32_t ANCHORS  = get_compile_time_arg_val(4);
+    constexpr uint32_t THR_X    = get_compile_time_arg_val(5);
+    constexpr uint32_t ROW_CB   = get_compile_time_arg_val(6);
+    constexpr uint32_t IDX_CB   = get_compile_time_arg_val(7);
+    constexpr uint32_t BATCH    = get_compile_time_arg_val(8);
+    constexpr uint32_t FLG_CB   = get_compile_time_arg_val(9);
+    constexpr uint32_t FLG_W    = get_compile_time_arg_val(10);
+    constexpr uint32_t THR_Y    = get_compile_time_arg_val(11);
+    // Pooled: one shared list of kept rows, each carrying its camera in bidx, instead of a
+    // fixed block per camera. The cameras do not peak together, so the shared list needs
+    // barely half the capacity for the same zero-loss guarantee.
+    constexpr uint32_t POOLED   = get_compile_time_arg_val(12);
+    constexpr uint32_t BIDX_CB  = get_compile_time_arg_val(13);
+    constexpr uint32_t BIDX_W   = get_compile_time_arg_val(14);
+
+    constexpr uint32_t SENTINEL = 0xFFFFFFFFu;
+    constexpr uint32_t ABS_MASK = 0x7FFFFFFFu;
+    constexpr uint16_t BF16_ONE = 0x3F80u;  // 1.0f truncated to bfloat16
+    constexpr uint32_t row_bytes = ROW_W * 4;
+    // NOC endpoints must be 32 B aligned, and a row is 26 floats = 104 B, so the L1
+    // batch buffer is strided at the aligned size while only row_bytes is transferred.
+    // Packing rows tight in L1 put every odd row at a misaligned address and the reads
+    // came back as garbage — which read as in bounds and kept everything.
+    constexpr uint32_t row_stride = ((row_bytes + 31) / 32) * 32;
+    constexpr uint32_t NUM_CAMS = NUM_ROWS / ANCHORS;
+    constexpr uint32_t idx_bytes = (POOLED ? CAP : NUM_CAMS * CAP) * 4;
+    constexpr uint32_t flag_bytes = FLG_W * 2;
+    constexpr uint32_t flag_stride = ((flag_bytes + 31) / 32) * 32;  // same, per camera
+
+    constexpr auto grid_args  = TensorAccessorArgs<15>();  // 0-14 are the scalars above
+    constexpr auto cgrid_args = TensorAccessorArgs<grid_args.next_compile_time_args_offset()>();
+    constexpr auto index_args = TensorAccessorArgs<cgrid_args.next_compile_time_args_offset()>();
+    constexpr auto flags_args = TensorAccessorArgs<index_args.next_compile_time_args_offset()>();
+    // No explicit page size: that argument is the ALIGNED page size, and DRAM pages are
+    // padded to 32 B. A grid row is 26 floats = 104 B, which pads to 128, so passing
+    // row_bytes here put every row after the first at the wrong address — the kernel
+    // then read garbage and kept every row. Let TensorAccessorArgs supply the real one.
+    const auto grid_acc  = TensorAccessor(grid_args, grid_addr);
+    const auto cgrid_acc = TensorAccessor(cgrid_args, cgrid_addr);
+    const auto index_acc = TensorAccessor(index_args, index_addr);
+    const auto flags_acc = TensorAccessor(flags_args, flags_addr);
+
+    const uint32_t row_l1 = get_write_ptr(ROW_CB);
+    const uint32_t idx_l1 = get_write_ptr(IDX_CB);
+    const uint32_t flg_l1 = get_write_ptr(FLG_CB);
+    volatile tt_l1_ptr uint32_t* row = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(row_l1);
+    volatile tt_l1_ptr uint32_t* idx = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(idx_l1);
+    // One bf16 flag per (camera, anchor), kept in L1 for the whole pass and dumped at
+    // the end: a per-camera flush would have to barrier mid-batch before reusing the
+    // buffer. NUM_CAMS * FLG_W * 2 B is ~5 KB, so there is no reason to be clever.
+    volatile tt_l1_ptr uint16_t* flg = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(flg_l1);
+    for (uint32_t i = 0; i < NUM_CAMS * (flag_stride / 2); i++) {
+        flg[i] = 0;
+    }
+    // Every bidx slot must name a real camera, including the ones past the kept count:
+    // grid_sample still walks those sticks and turns the value into a NOC address, so a
+    // stale one would be an out-of-range read rather than a discarded sample.
+    volatile tt_l1_ptr uint32_t* bidx = nullptr;
+    if constexpr (POOLED) {
+        bidx = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(BIDX_CB));
+        for (uint32_t i = 0; i < CAP * BIDX_W; i++) {
+            bidx[i] = 0;
+        }
+    }
+
+    // Rows are fetched BATCH at a time. One barrier per batch instead of per row:
+    // a per-row barrier waits out the full DRAM round trip before issuing the next
+    // read, which measured 1.96 ms/call — the loop was latency-bound, not busy.
+    uint32_t n = 0;        // kept rows in the current camera
+    uint32_t cam = 0;
+    uint32_t cam_base = 0;
+    uint32_t next_cam_row = ANCHORS;
+
+    for (uint32_t base = 0; base < NUM_ROWS; base += BATCH) {
+        uint32_t count = BATCH;
+        if (base + count > NUM_ROWS) {
+            count = NUM_ROWS - base;
+        }
+        for (uint32_t b = 0; b < count; b++) {
+            noc_async_read(grid_acc.get_noc_addr(base + b), row_l1 + b * row_stride, row_bytes);
+        }
+        noc_async_read_barrier();
+
+        for (uint32_t b = 0; b < count; b++) {
+            const uint32_t r = base + b;
+            if (r >= next_cam_row) {  // rows are camera-major, so this walks the cameras
+                if constexpr (!POOLED) {
+                    while (n < CAP) {  // SENTINEL-fill the tail of the camera we just left
+                        idx[cam * CAP + n] = SENTINEL;
+                        n++;
+                    }
+                    n = 0;
+                }
+                cam++;
+                cam_base = next_cam_row;
+                next_cam_row += ANCHORS;
+            }
+            volatile tt_l1_ptr uint32_t* rp = row + b * (row_stride / 4);
+
+            bool valid = false;
+            for (uint32_t p = 0; p < NUM_PTS; p++) {
+                const uint32_t ax = rp[2 * p] & ABS_MASK;
+                const uint32_t ay = rp[2 * p + 1] & ABS_MASK;
+                if (ax < THR_X && ay < THR_Y) {
+                    valid = true;
+                    break;
+                }
+            }
+
+            if (valid && n < CAP) {
+                const uint32_t slot = POOLED ? n : (cam * CAP + n);
+                if constexpr (POOLED) {
+                    bidx[n * BIDX_W] = cam;
+                }
+                noc_async_write(row_l1 + b * row_stride,
+                                cgrid_acc.get_noc_addr(slot), row_bytes);
+                idx[slot] = r;
+                // Flag the rows that were actually KEPT, not the ones that merely
+                // passed the bounds test: a row past CAP is dropped too, and its
+                // slot in the feature buffer keeps last frame's values.
+                flg[cam * (flag_stride / 2) + (r - cam_base)] = BF16_ONE;
+                n++;
+            }
+        }
+        // the batch buffer is about to be refilled, so the writes out of it must land
+        noc_async_write_barrier();
+    }
+
+    if constexpr (POOLED) {
+        for (uint32_t j = n; j < CAP; j++) {
+            idx[j] = SENTINEL;
+        }
+    } else {
+        for (uint32_t j = n; j < CAP; j++) {  // tail of the last camera
+            idx[cam * CAP + j] = SENTINEL;
+        }
+    }
+    noc_async_write(idx_l1, index_acc.get_noc_addr(0), idx_bytes);
+    for (uint32_t c = 0; c < NUM_CAMS; c++) {  // one page per camera
+        noc_async_write(flg_l1 + c * flag_stride, flags_acc.get_noc_addr(c), flag_bytes);
+    }
+    write_bidx<POOLED != 0, flags_args.next_compile_time_args_offset(), BIDX_CB, CAP, BIDX_W>(
+        bidx_addr);
+    noc_async_write_barrier();
+}

--- a/tt-metal/ops/grid_compact/device/kernels/dataflow/grid_compact.cpp
+++ b/tt-metal/ops/grid_compact/device/kernels/dataflow/grid_compact.cpp
@@ -21,12 +21,14 @@
 // SENTINEL, and transposed_s2i skips those, so stale coordinates can never reach
 // the output. That avoids writing padding rows every call.
 //
-// Compaction is PER CAMERA: camera c's kept rows land in cgrid[c*CAP .. c*CAP+CAP).
-// Pooling all cameras into one list compacts better (2.4x vs 1.5x), but grid_sample
-// derives the source image from a row's POSITION (curr_batch advances every grid_hw
-// sticks), so a pooled list would silently sample the wrong camera. Keeping the
-// per-camera blocks preserves that mapping with no change to grid_sample at all.
-// CAP must therefore cover the BUSIEST camera, measured max 62.7% of 900.
+// Two output layouts. PER CAMERA (no bidx) puts camera c's kept rows in
+// cgrid[c*CAP .. c*CAP+CAP), which grid_sample can read unmodified because it derives a
+// row's source image from its POSITION. POOLED (bidx given) puts every camera's rows in
+// one shared list and records each row's camera, which needs grid_sample's batch_index.
+//
+// Pooled is what makes compaction pay. Per camera the budget must cover the busiest
+// CAMERA, and the cameras do not peak together: measured over 16 scenes, the zero-loss
+// budget is 3 x 563 = 1689 rows per camera against 902 pooled, for the same guarantee.
 //
 // A third output, `flags`, marks the kept (camera, anchor) pairs with 1.0. Dropped
 // rows are never written into the feature buffer, so it keeps LAST frame's values

--- a/tt-metal/ops/grid_compact/grid_compact.cpp
+++ b/tt-metal/ops/grid_compact/grid_compact.cpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include "grid_compact.hpp"
+#include "device/grid_compact_device_operation.hpp"
+
+namespace ttnn::operations::grid_compact {
+
+void grid_compact(
+    const tt::tt_metal::Tensor& grid, tt::tt_metal::Tensor& cgrid,
+    tt::tt_metal::Tensor& index, tt::tt_metal::Tensor& flags,
+    uint32_t num_pts, uint32_t capacity, uint32_t anchors,
+    float threshold_x, float threshold_y,
+    const std::optional<tt::tt_metal::Tensor>& bidx) {
+    ttnn::prim::grid_compact(
+        grid, cgrid, index, flags, num_pts, capacity, anchors, threshold_x, threshold_y, bidx);
+}
+
+}  // namespace ttnn::operations::grid_compact

--- a/tt-metal/ops/grid_compact/grid_compact.hpp
+++ b/tt-metal/ops/grid_compact/grid_compact.hpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <optional>
+#include "ttnn/types.hpp"
+
+namespace ttnn {
+namespace operations::grid_compact {
+
+void grid_compact(
+    const ttnn::Tensor& grid, ttnn::Tensor& cgrid, ttnn::Tensor& index, ttnn::Tensor& flags,
+    uint32_t num_pts, uint32_t capacity, uint32_t anchors,
+    float threshold_x, float threshold_y,
+    const std::optional<ttnn::Tensor>& bidx = std::nullopt);
+
+}  // namespace operations::grid_compact
+using ttnn::operations::grid_compact::grid_compact;
+}  // namespace ttnn

--- a/tt-metal/ops/grid_compact/grid_compact_nanobind.cpp
+++ b/tt-metal/ops/grid_compact/grid_compact_nanobind.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include "grid_compact_nanobind.hpp"
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+#include "ttnn-nanobind/bind_function.hpp"
+#include "grid_compact.hpp"
+
+namespace ttnn::operations::grid_compact {
+
+void bind_grid_compact(nb::module_& mod) {
+    ttnn::bind_function<"grid_compact">(
+        mod,
+        "Compacts a DFA sampling grid to the rows with at least one in-bounds point. "
+        "Writes the kept rows to cgrid and their source row ids to index (SENTINEL "
+        "0xFFFFFFFF past the kept count); the camera id is stored at slot 2*num_pts. "
+        "flags [nc, 1, 1, >=anchors] bf16 gets 1.0 for every kept (camera, anchor) and "
+        "0.0 otherwise, so the attention weights of dropped rows can be zeroed. Passing "
+        "bidx switches to POOLED mode: one shared list of kept rows instead of a fixed "
+        "block per camera, with each row's camera written to bidx for grid_sample's "
+        "batch_index. Pooling needs far less capacity because the cameras do not peak "
+        "together (measured 902 rows pooled versus 3 x 563 per camera).",
+        &ttnn::grid_compact,
+        nb::arg("grid"), nb::arg("cgrid"), nb::arg("index"), nb::arg("flags"),
+        nb::arg("num_pts"), nb::arg("capacity"), nb::arg("anchors"),
+        nb::arg("threshold_x"), nb::arg("threshold_y"),
+        nb::arg("bidx") = nb::none());
+}
+
+}  // namespace ttnn::operations::grid_compact

--- a/tt-metal/ops/grid_compact/grid_compact_nanobind.hpp
+++ b/tt-metal/ops/grid_compact/grid_compact_nanobind.hpp
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <nanobind/nanobind.h>
+namespace nb = nanobind;
+
+namespace ttnn::operations::grid_compact {
+void bind_grid_compact(nb::module_& mod);
+}

--- a/tt-metal/ops/grid_sample/device/grid_sample_bilinear_program_factory.cpp
+++ b/tt-metal/ops/grid_sample/device/grid_sample_bilinear_program_factory.cpp
@@ -277,6 +277,10 @@ ProgramDescriptor GridSampleBilinearProgramFactory::create_descriptor(
         reader_compile_time_args.push_back(batch_index_cb_index);
         reader_compile_time_args.push_back(
             use_batch_index ? static_cast<uint32_t>(batch_index_tensor->padded_shape()[-1]) : 1U);
+        // The GRID's batch, which is not the input's once batch_index is in play: a pooled
+        // grid is one batch of sticks that each name their own source image. The reader
+        // needs it to know where the real sticks end and height-sharding padding begins.
+        reader_compile_time_args.push_back(grid_shape[0]);
     }
 
     const std::string reader_kernel_path =

--- a/tt-metal/ops/grid_sample/device/grid_sample_bilinear_program_factory.cpp
+++ b/tt-metal/ops/grid_sample/device/grid_sample_bilinear_program_factory.cpp
@@ -1,0 +1,497 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/tensor_accessor_args.hpp"
+#include "tt-metalium/work_split.hpp"
+#include "grid_sample_utils.hpp"
+#include "ttnn/operations/pool/pool_utils.hpp"
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/math.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/operations/pool/grid_sample/device/grid_sample_device_operation.hpp"
+
+namespace ttnn::prim {
+
+using namespace tt::tt_metal;
+
+ProgramDescriptor GridSampleBilinearProgramFactory::create_descriptor(
+    const GridSampleParams& operation_attributes, const GridSampleInputs& tensor_args, Tensor& output_tensor) {
+    const Tensor& input_tensor = tensor_args.input_tensor;
+    const Tensor& grid_tensor = tensor_args.grid;
+    bool use_precomputed_grid = operation_attributes.use_precomputed_grid;
+    bool batch_output_channels = operation_attributes.batch_output_channels;
+
+    const bool is_sharded = grid_tensor.is_sharded();
+    ProgramDescriptor desc;
+
+    // Data formats and device
+    const auto [input_cb_data_format, grid_cb_data_format, output_cb_data_format] = std::make_tuple(
+        tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype()),
+        tt::tt_metal::datatype_to_dataformat_converter(grid_tensor.dtype()),
+        tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype()));
+    tt::tt_metal::IDevice* const device = output_tensor.device();
+
+    // Shape and dimensions
+    const auto& [input_shape, grid_shape, output_shape] =
+        std::tie(input_tensor.padded_shape(), grid_tensor.padded_shape(), output_tensor.padded_shape());
+    const uint32_t input_batch = input_shape[0], input_height = input_shape[1], input_width = input_shape[2];
+    const uint32_t grid_height = grid_shape[1], grid_width = grid_shape[2];
+    const uint32_t grid_hw = grid_height * grid_width;
+    const uint32_t grid_batching_factor = get_grid_batching_factor(grid_tensor, use_precomputed_grid);
+    const bool enable_split_reader =
+        should_use_split_reader(input_tensor, grid_tensor, use_precomputed_grid, "bilinear");
+
+    tt::tt_metal::CoreRangeSet all_cores, core_group_1, core_group_2;
+    uint32_t num_cores, grid_nsticks_per_core, output_nsticks_per_core = 0;
+    uint32_t num_sticks_per_core_group_1 = 0, num_sticks_per_core_group_2 = 0;
+    std::vector<CoreCoord> logical_cores;
+    // Calculate total work and determine actual cores needed
+    const uint32_t total_grid_nsticks = grid_tensor.physical_volume() / grid_shape[-1];
+
+    if (is_sharded) {
+        const auto grid_shard_spec = grid_tensor.shard_spec().value();
+        grid_nsticks_per_core = grid_shard_spec.shape[0];
+        output_nsticks_per_core = output_tensor.shard_spec().value().shape[0];
+
+        num_cores = grid_shard_spec.num_cores();
+        all_cores = grid_shard_spec.grid;
+        logical_cores = corerange_to_cores(
+            all_cores, num_cores, grid_shard_spec.orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR);
+
+    } else {
+        const auto compute_grid_size = device->compute_with_storage_grid_size();
+        auto [num_cores_used, all_cores_range, core_group_1_range, core_group_2_range, num_sticks_1, num_sticks_2] =
+            tt::tt_metal::split_work_to_cores(compute_grid_size, total_grid_nsticks);
+
+        std::tie(num_cores, all_cores, core_group_1, core_group_2) =
+            std::make_tuple(num_cores_used, all_cores_range, core_group_1_range, core_group_2_range);
+        num_sticks_per_core_group_1 = num_sticks_1;
+        num_sticks_per_core_group_2 = num_sticks_2;
+        grid_nsticks_per_core = num_sticks_1;
+
+        logical_cores = corerange_to_cores(all_cores, num_cores, true);
+    }
+
+    uint32_t cb_idx = tt::CBIndex::c_0;
+
+    // Create CBs
+    const auto input_face_geometry = FaceGeometry{.face_r_dim = REDUCTION_SIZE, .num_faces = 2};
+    const auto scalar_face_geometry = FaceGeometry{.face_r_dim = 1, .num_faces = 2};
+    const bool last_output_tile_is_partial = input_shape[-1] % tt::constants::TILE_WIDTH != 0;
+    const bool single_partial_output_fits_in_face =
+        last_output_tile_is_partial && input_shape[-1] <= tt::constants::FACE_WIDTH;
+    const auto output_face_geometry =
+        FaceGeometry{.face_r_dim = 1, .num_faces = single_partial_output_fits_in_face ? 1U : 2U};
+    const std::optional<TileDescriptor> output_tile =
+        single_partial_output_fits_in_face ? std::optional{TileDescriptor{1, tt::constants::FACE_WIDTH, false}}
+                                           : std::nullopt;
+
+    const uint32_t grid_stick_size =
+        is_sharded ? grid_shape[-1] * grid_tensor.element_size() : get_aligned_stick_size(grid_shape, grid_tensor);
+    const uint32_t grid_cb_index = cb_idx++;
+    const uint32_t grid_cb_num_pages = is_sharded ? grid_nsticks_per_core : 1;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = grid_cb_num_pages * grid_stick_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(grid_cb_index),
+            .data_format = grid_cb_data_format,
+            .page_size = grid_stick_size,
+        }}},
+        .buffer = is_sharded ? grid_tensor.buffer() : nullptr,
+    });
+
+    // Per-stick source batch, if the caller supplied one. Same shard height as the grid,
+    // so a core's slice lines up index-for-index with the grid sticks it owns.
+    const auto& batch_index_tensor = tensor_args.batch_index;
+    const bool use_batch_index = batch_index_tensor.has_value();
+    uint32_t batch_index_cb_index = 0;
+    if (use_batch_index) {
+        const uint32_t bidx_stick_size =
+            batch_index_tensor->padded_shape()[-1] * batch_index_tensor->element_size();
+        batch_index_cb_index = cb_idx++;
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = grid_nsticks_per_core * bidx_stick_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(batch_index_cb_index),
+                .data_format = tt::DataFormat::UInt32,
+                .page_size = bidx_stick_size,
+            }}},
+            .buffer = batch_index_tensor->buffer(),
+        });
+    }
+
+    // Resolve compute kernel config early: under fp32_dest_acc_en + half-sync, DEST holds only 4
+    // fp32 tiles, so each chunk must shrink to <= 4 tiles. When the user explicitly enables
+    // dst_full_sync_en, full-sync DEST holds 8 fp32 tiles and the 4-tile clamp would be a
+    // gratuitous slowdown — so we keep the full 8-tile chunk in that case. The compute kernel
+    // reads the same flag (ct_arg[16]) and recomputes its own MAX_TILES_PER_REDUCTION accordingly.
+    const auto [resolved_math_fidelity, resolved_math_approx, resolved_fp32_acc, resolved_l1_acc, user_dst_full_sync] =
+        ttnn::get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
+    (void)resolved_l1_acc;  // not consumed in this factory
+    const bool force_4_tile_chunk = resolved_fp32_acc && !user_dst_full_sync;
+    const uint32_t effective_max_tiles_per_reduction = force_4_tile_chunk ? 4U : MAX_TILES_PER_REDUCTION;
+
+    const uint32_t in_ntiles_c =
+        static_cast<uint32_t>(std::ceil(static_cast<float>(input_shape[-1]) / tt::constants::TILE_WIDTH));
+    // When in_ntiles_c exceeds effective_max_tiles_per_reduction the channel dimension is processed
+    // in chunks; the input CB only needs to hold one chunk at a time, keeping the per-core L1
+    // footprint bounded regardless of how wide the input stick is.
+    const uint32_t max_tiles_per_iter = std::min<uint32_t>(in_ntiles_c, effective_max_tiles_per_reduction);
+    const uint32_t in_nblocks_c =
+        static_cast<uint32_t>(std::ceil(static_cast<float>(in_ntiles_c) / effective_max_tiles_per_reduction));
+    const uint32_t input_chunk_nbytes =
+        effective_max_tiles_per_reduction * tt::constants::TILE_WIDTH * input_tensor.element_size();
+    const uint32_t input_cb_page_size = max_tiles_per_iter * tt::constants::TILE_HW * input_tensor.element_size();
+    // When the last channel chunk holds fewer than effective_max_tiles_per_reduction tiles, the
+    // reader must pack it with a tight write stride (== chunk_bytes) so the unpacker's
+    // tiles_to_reduce matches compute_pool_2d's `tilize_reconfig` path. We require
+    // !last_tile_is_partial — currently guaranteed by the padded-width % TILE_WIDTH == 0 check in
+    // grid_sample_device_operation.cpp — and window_size_hw (REDUCTION_SIZE=4) <= FACE_HEIGHT,
+    // which is a static property of bilinear.
+    const bool last_tile_is_partial = (input_shape[-1] % tt::constants::TILE_WIDTH) != 0;
+    const bool last_chunk_partial =
+        (in_nblocks_c > 1) && (in_ntiles_c % effective_max_tiles_per_reduction != 0) && !last_tile_is_partial;
+    const uint32_t input_cb_index_0 = cb_idx++;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = BUFFERING_FACTOR * input_cb_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(input_cb_index_0),
+            .data_format = input_cb_data_format,
+            .page_size = input_cb_page_size,
+            .face_geometry = input_face_geometry,
+        }}},
+    });
+
+    uint32_t input_cb_index_1 = DUMMY_CB_ID;
+    if (is_sharded && enable_split_reader) {
+        input_cb_index_1 = cb_idx++;
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = BUFFERING_FACTOR * input_cb_page_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(input_cb_index_1),
+                .data_format = input_cb_data_format,
+                .page_size = input_cb_page_size,
+                .face_geometry = input_face_geometry,
+            }}},
+        });
+    }
+
+    const uint32_t scalar_cb_page_size = tt::tile_size(input_cb_data_format);
+    const uint32_t scalar_cb_index_0 = cb_idx++;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = BUFFERING_FACTOR * scalar_cb_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(scalar_cb_index_0),
+            .data_format = input_cb_data_format,
+            .page_size = scalar_cb_page_size,
+            .face_geometry = scalar_face_geometry,
+        }}},
+    });
+
+    uint32_t scalar_cb_index_1 = DUMMY_CB_ID;
+    if (is_sharded && enable_split_reader) {
+        scalar_cb_index_1 = cb_idx++;
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = BUFFERING_FACTOR * scalar_cb_page_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(scalar_cb_index_1),
+                .data_format = input_cb_data_format,
+                .page_size = scalar_cb_page_size,
+                .face_geometry = scalar_face_geometry,
+            }}},
+        });
+    }
+
+    const uint32_t out_ntiles_c =
+        static_cast<uint32_t>(std::ceil(static_cast<float>(output_shape[-1]) / tt::constants::FACE_WIDTH));
+    const uint32_t output_cb_page_size = tt::constants::FACE_WIDTH * output_tensor.element_size();
+    const uint32_t output_cb_pages =
+        is_sharded ? output_nsticks_per_core * out_ntiles_c : out_ntiles_c * BUFFERING_FACTOR;
+    const uint32_t output_cb_index = cb_idx++;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = output_cb_pages * output_cb_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = output_cb_data_format,
+            .page_size = output_cb_page_size,
+            .tile = output_tile,
+            .face_geometry = output_face_geometry,
+        }}},
+        .buffer = is_sharded ? output_tensor.buffer() : nullptr,
+    });
+
+    // Prepare stick size arguments with proper names
+    const uint32_t input_stick_size = get_aligned_stick_size(input_shape, input_tensor);
+    const uint32_t grid_stick_size_arg =
+        is_sharded ? grid_shape[-1] * grid_tensor.element_size() : get_aligned_stick_size(grid_shape, grid_tensor);
+
+    // Reader compile-time arguments - shared arguments first, then specific ones
+    std::vector<uint32_t> reader_compile_time_args = {
+        input_cb_index_0,                              // ct_arg[0]: input_cb_index_0
+        grid_cb_index,                                 // ct_arg[1]: grid_cb_index
+        scalar_cb_index_0,                             // ct_arg[2]: scalar_cb_index_0
+        input_stick_size,                              // ct_arg[3]: input_stick_size
+        grid_stick_size_arg,                           // ct_arg[4]: grid_stick_size
+        input_batch,                                   // ct_arg[5]: input_batch
+        input_height,                                  // ct_arg[6]: input_height
+        input_width,                                   // ct_arg[7]: input_width
+        grid_batching_factor,                          // ct_arg[8]: grid_batching_factor (shared)
+        static_cast<uint32_t>(grid_tensor.dtype()),    // ct_arg[9]: grid_dtype (shared)
+        grid_hw,                                       // ct_arg[10]: grid_hw (shared)
+        use_precomputed_grid ? 1U : 0U,                // ct_arg[11]: use_precomputed_grid (shared)
+        operation_attributes.align_corners ? 1U : 0U,  // ct_arg[12]: align_corners (shared)
+        in_nblocks_c,                                  // ct_arg[13]: in_nblocks_c (shared)
+        input_chunk_nbytes,                            // ct_arg[14]: input_chunk_nbytes (shared)
+        last_chunk_partial ? 1U : 0U                   // ct_arg[15]: last_chunk_partial (shared)
+    };
+
+    if (is_sharded) {
+        reader_compile_time_args.push_back(enable_split_reader ? 1U : 0U);  // ct_arg[16]: enable_split_reader
+        reader_compile_time_args.push_back(0U);  // ct_arg[17]: reader_id (will be set later per reader)
+        reader_compile_time_args.push_back(grid_nsticks_per_core);  // ct_arg[18]: grid_nsticks_per_core
+    }
+
+    tt::tt_metal::TensorAccessorArgs(*input_tensor.buffer()).append_to(reader_compile_time_args);
+    if (!is_sharded) {
+        tt::tt_metal::TensorAccessorArgs(*grid_tensor.buffer()).append_to(reader_compile_time_args);
+    }
+    if (is_sharded) {
+        // After the accessor, so ct_arg[19] stays the accessor base the reader hardcodes.
+        reader_compile_time_args.push_back(use_batch_index ? 1U : 0U);
+        reader_compile_time_args.push_back(batch_index_cb_index);
+        reader_compile_time_args.push_back(
+            use_batch_index ? static_cast<uint32_t>(batch_index_tensor->padded_shape()[-1]) : 1U);
+    }
+
+    const std::string reader_kernel_path =
+        is_sharded ? "ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp"
+                   : "ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/"
+                     "reader_grid_sample_interleaved_start_id.cpp";
+
+    KernelDescriptor reader0_desc;
+    KernelDescriptor reader1_desc;
+    if (is_sharded) {
+        auto reader0_compile_time_args = reader_compile_time_args;
+        reader0_compile_time_args[17] = 0;  // ct_arg[17]: reader_id = 0
+
+        reader0_desc.kernel_source = reader_kernel_path;
+        reader0_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        reader0_desc.core_ranges = all_cores;
+        reader0_desc.compile_time_args = std::move(reader0_compile_time_args);
+        reader0_desc.config = DataMovementConfigDescriptor{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt::tt_metal::NOC::RISCV_0_default,
+        };
+
+        if (enable_split_reader) {
+            auto reader1_compile_time_args = reader_compile_time_args;
+            reader1_compile_time_args[0] = input_cb_index_1;   // ct_arg[0]: input_cb_index_1
+            reader1_compile_time_args[2] = scalar_cb_index_1;  // ct_arg[2]: scalar_cb_index_1
+            reader1_compile_time_args[17] = 1;                 // ct_arg[17]: reader_id = 1
+
+            reader1_desc.kernel_source = reader_kernel_path;
+            reader1_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+            reader1_desc.core_ranges = all_cores;
+            reader1_desc.compile_time_args = std::move(reader1_compile_time_args);
+            reader1_desc.config = DataMovementConfigDescriptor{
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = tt::tt_metal::NOC::RISCV_1_default,
+            };
+        }
+    } else {
+        reader0_desc.kernel_source = reader_kernel_path;
+        reader0_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        reader0_desc.core_ranges = all_cores;
+        reader0_desc.compile_time_args = std::move(reader_compile_time_args);
+        // Use ReaderConfigDescriptor so the framework preserves
+        // ReaderDataMovementConfig defaults (preferred_noc_for_dram_read(arch)).
+        reader0_desc.config = ReaderConfigDescriptor{};
+    }
+
+    const bool is_output_tiled = false;
+    const bool is_output_block_format = false;
+    const uint32_t pre_tilize_cb_id =
+        32;  // Unused CB for pool compute kernel for grid sample, we don't have tiled output in gridsample
+
+    // Compute kernels
+    const uint32_t channels_per_shard = input_shape[-1];
+
+    auto pool_defines_map = ttnn::operations::pool::get_defines(ttnn::operations::pool::Pool2DType::AVG_POOL2D);
+
+    auto make_compute_desc = [&](tt::tt_metal::CoreRangeSet cores, uint32_t total_interpolations) {
+        // Compute kernel compile-time arguments
+        std::vector<uint32_t> compute_compile_time_args = {
+            in_ntiles_c,                       // ct_arg[0]: in_ntiles_c
+            REDUCTION_SIZE,                    // ct_arg[1]: REDUCTION_SIZE
+            enable_split_reader,               // ct_arg[2]: enable_split_reader
+            total_interpolations,              // ct_arg[3]: total_interpolations
+            channels_per_shard,                // ct_arg[4]: channels_per_shard
+            in_nblocks_c,                      // ct_arg[5]: in_nblocks_c
+            MAX_ROWS_FOR_REDUCTION,            // ct_arg[6]: MAX_ROWS_FOR_REDUCTION
+            input_cb_index_0,                  // ct_arg[7]: input_cb_index_0
+            input_cb_index_1,                  // ct_arg[8]: input_cb_index_1
+            scalar_cb_index_0,                 // ct_arg[9]: scalar_cb_index_0
+            scalar_cb_index_1,                 // ct_arg[10]: scalar_cb_index_1
+            output_cb_index,                   // ct_arg[11]: output_cb_index
+            ONE_SCALAR_PER_CORE,               // ct_arg[12]: ONE_SCALAR_PER_CORE
+            pre_tilize_cb_id,                  // ct_arg[13]: pre_tilize_cb_id
+            is_output_tiled ? 1U : 0U,         // ct_arg[14]: is_output_tiled
+            is_output_block_format ? 1U : 0U,  // ct_arg[15]: is_output_block_format
+            force_4_tile_chunk ? 1U : 0U,      // ct_arg[16]: force_max_tiles_per_reduction_4
+            DUMMY_CB_ID,                       // ct_arg[17]: unused (in_idx_cb_id for mpwi)
+            DUMMY_CB_ID,                       // ct_arg[18]: unused (pack_tmp_cb_id for mpwi)
+            DUMMY_CB_ID,                       // ct_arg[19]: unused (pack_idx_tmp_cb_id for mpwi)
+            DUMMY_CB_ID,                       // ct_arg[20]: unused (right_inc_cb_id for mpwi)
+            DUMMY_CB_ID,                       // ct_arg[21]: unused (down_left_wrap_inc_cb_id for mpwi)
+            DUMMY_CB_ID,                       // ct_arg[22]: unused (up_left_wrap_inc_cb_id for mpwi)
+            DUMMY_CB_ID,                       // ct_arg[23]: unused (out_idx_cb_id for mpwi)
+            1,                                 // ct_arg[24]: stride_h (unused by grid_sample)
+            1,                                 // ct_arg[25]: stride_w (unused by grid_sample)
+            1,                                 // ct_arg[26]: in_h_padded (unused by grid_sample)
+            1,                                 // ct_arg[27]: in_w_padded (unused by grid_sample)
+            1,                                 // ct_arg[28]: eff_kernel_h (unused by grid_sample)
+            1,                                 // ct_arg[29]: eff_kernel_w (unused by grid_sample)
+            1,                                 // ct_arg[30]: pad_l (unused by grid_sample)
+            DUMMY_CB_ID,                       // ct_arg[31]: intra_kernel_right_inc_cb_id (unused)
+            DUMMY_CB_ID,                       // ct_arg[32]: intra_kernel_down_left_wrap_inc_cb_id (unused)
+            DUMMY_CB_ID,                       // ct_arg[33]: compute_tmp_idx_cb_id (unused)
+            DUMMY_CB_ID,                       // ct_arg[34]: clear_value_cb_id (unused)
+            1,                                 // ct_arg[35]: kernel_h (unused by grid_sample)
+            1,                                 // ct_arg[36]: kernel_w (unused by grid_sample)
+            0,                                 // ct_arg[37]: indexes_32_bit (unused by grid_sample)
+            DUMMY_CB_ID,                       // ct_arg[38]: fast_tilize_cb_id (tiled-output only)
+        };
+
+        KernelDescriptor compute_desc;
+        compute_desc.kernel_source = "ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp";
+        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        compute_desc.core_ranges = std::move(cores);
+        compute_desc.compile_time_args = std::move(compute_compile_time_args);
+        compute_desc.defines = {pool_defines_map.begin(), pool_defines_map.end()};
+        compute_desc.config = ComputeConfigDescriptor{
+            .math_fidelity = resolved_math_fidelity,
+            .fp32_dest_acc_en = resolved_fp32_acc,
+            .dst_full_sync_en = user_dst_full_sync,
+            .math_approx_mode = resolved_math_approx,
+        };
+        return compute_desc;
+    };
+
+    std::vector<KernelDescriptor> compute_descs;
+    if (is_sharded || core_group_1.num_cores() > 0) {
+        compute_descs.push_back(make_compute_desc(
+            is_sharded ? all_cores : core_group_1,
+            grid_batching_factor * (is_sharded ? grid_nsticks_per_core : num_sticks_per_core_group_1)));
+    }
+    if (!is_sharded && core_group_2.num_cores() > 0) {
+        compute_descs.push_back(make_compute_desc(core_group_2, grid_batching_factor * num_sticks_per_core_group_2));
+    }
+
+    // Writer kernel (interleaved only)
+    KernelDescriptor writer_desc;
+    bool has_writer = !is_sharded;
+    if (has_writer) {
+        // Writer compile-time arguments - expanded row by row for readability
+        std::vector<uint32_t> writer_compile_time_args = {
+            output_cb_index,                                      // ct_arg[0]: output_cb_index
+            get_aligned_stick_size(output_shape, output_tensor),  // ct_arg[1]: output_stick_size
+            out_ntiles_c                                          // ct_arg[2]: out_ntiles_c
+        };
+        tt::tt_metal::TensorAccessorArgs(*output_tensor.buffer()).append_to(writer_compile_time_args);
+
+        writer_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/writer_grid_sample_interleaved.cpp";
+        writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        writer_desc.core_ranges = all_cores;
+        writer_desc.compile_time_args = std::move(writer_compile_time_args);
+        // Use WriterConfigDescriptor so the framework preserves
+        // WriterDataMovementConfig defaults (preferred_noc_for_dram_write(arch)).
+        writer_desc.config = WriterConfigDescriptor{};
+    }
+
+    // Set runtime arguments
+    if (is_sharded) {
+        for (uint32_t i = 0; i < num_cores; i++) {
+            const CoreCoord& core = logical_cores[i];
+
+            // Runtime arguments for sharded reader
+            reader0_desc.emplace_runtime_args(
+                core,
+                {
+                    input_tensor.buffer(),     // rt_arg[0]: input_buffer_address
+                    i * grid_nsticks_per_core  // rt_arg[1]: grid_stick_offset
+                });
+            if (enable_split_reader) {
+                reader1_desc.emplace_runtime_args(
+                    core,
+                    {
+                        input_tensor.buffer(),     // rt_arg[0]: input_buffer_address
+                        i * grid_nsticks_per_core  // rt_arg[1]: grid_stick_offset
+                    });
+            }
+        }
+    } else {
+        uint32_t grid_processed = 0;
+        uint32_t output_processed = 0;
+
+        for (uint32_t i = 0; i < num_cores; i++) {
+            const CoreCoord& core = logical_cores[i];
+            const uint32_t grid_sticks =
+                core_group_1.contains(core) ? num_sticks_per_core_group_1 : num_sticks_per_core_group_2;
+            const uint32_t output_sticks = batch_output_channels ? grid_sticks : grid_sticks * grid_batching_factor;
+
+            // Runtime arguments for interleaved reader - expanded row by row
+            reader0_desc.emplace_runtime_args(
+                core,
+                {
+                    input_tensor.buffer(),  // rt_arg[0]: input_buffer_address
+                    grid_tensor.buffer(),   // rt_arg[1]: grid_buffer_address
+                    grid_sticks,            // rt_arg[2]: grid_sticks
+                    grid_processed          // rt_arg[3]: grid_processed
+                });
+
+            // Runtime arguments for interleaved writer - expanded row by row
+            writer_desc.emplace_runtime_args(
+                core,
+                {
+                    output_tensor.buffer(),  // rt_arg[0]: output_buffer_address
+                    output_sticks,           // rt_arg[1]: output_sticks
+                    output_processed         // rt_arg[2]: output_processed
+                });
+
+            grid_processed += grid_sticks;
+            output_processed += output_sticks;
+        }
+    }
+
+    desc.kernels.push_back(std::move(reader0_desc));
+    if (is_sharded && enable_split_reader) {
+        desc.kernels.push_back(std::move(reader1_desc));
+    }
+    for (auto& cd : compute_descs) {
+        desc.kernels.push_back(std::move(cd));
+    }
+    if (has_writer) {
+        desc.kernels.push_back(std::move(writer_desc));
+    }
+
+    return desc;
+}
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/grid_sample/device/grid_sample_device_operation.cpp
+++ b/tt-metal/ops/grid_sample/device/grid_sample_device_operation.cpp
@@ -1,0 +1,352 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/pool/grid_sample/device/grid_sample_device_operation.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+#include "ttnn/device_operation.hpp"
+#include <tt-metalium/work_split.hpp>
+
+namespace ttnn::prim {
+using namespace tt;
+using namespace tt::tt_metal;
+
+GridSampleOperation::program_factory_t GridSampleOperation::select_program_factory(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& /*tensor_args*/) {
+    const std::string mode = operation_attributes.mode;
+    if (mode == "bilinear") {
+        return GridSampleBilinearProgramFactory{};
+    }
+    return GridSampleNearestProgramFactory{};
+}
+
+void GridSampleOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input_tensor;
+    const auto& grid_tensor = tensor_args.grid;
+
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Input tensor must be on device!");
+    TT_FATAL(grid_tensor.storage_type() == StorageType::DEVICE, "Grid tensor must be on device!");
+    TT_FATAL(input_tensor.buffer() != nullptr, "Input tensor must be allocated in buffer on device!");
+    TT_FATAL(grid_tensor.buffer() != nullptr, "Grid tensor must be allocated in buffer on device!");
+
+    // Shape validation
+    TT_FATAL(
+        input_tensor.logical_shape().rank() == 4,
+        "Input tensor must be 4D (N, H, W, C), but got shape {} with {} dimensions",
+        input_tensor.logical_shape(),
+        input_tensor.logical_shape().rank());
+    TT_FATAL(
+        grid_tensor.logical_shape().rank() == 4,
+        "Grid tensor must be 4D (N, H_out, W_out, coords), but got shape {} with {} dimensions",
+        grid_tensor.logical_shape(),
+        grid_tensor.logical_shape().rank());
+
+    uint32_t grid_last_dim = grid_tensor.logical_shape()[-1];
+    if (operation_attributes.use_precomputed_grid) {
+        TT_FATAL(
+            grid_last_dim % (operation_attributes.mode == "nearest" ? PRECOMPUTED_GRID_ELEMENTS_PER_POINT_NEAREST
+                                                                    : PRECOMPUTED_GRID_ELEMENTS_PER_POINT) ==
+                    0 &&
+                grid_last_dim >= (operation_attributes.mode == "nearest" ? PRECOMPUTED_GRID_ELEMENTS_PER_POINT_NEAREST
+                                                                         : PRECOMPUTED_GRID_ELEMENTS_PER_POINT),
+            "Precomputed grid tensor last dimension must be a multiple of {} (for h_nw, w_nw, weight_nw, weight_ne, "
+            "weight_sw, weight_se), but got {} in shape {}",
+            (operation_attributes.mode == "nearest" ? PRECOMPUTED_GRID_ELEMENTS_PER_POINT_NEAREST
+                                                    : PRECOMPUTED_GRID_ELEMENTS_PER_POINT),
+            grid_last_dim,
+            grid_tensor.logical_shape());
+    } else {
+        TT_FATAL(
+            grid_last_dim % STANDARD_GRID_ELEMENTS_PER_POINT == 0 && grid_last_dim >= STANDARD_GRID_ELEMENTS_PER_POINT,
+            "Standard grid tensor last dimension must be a multiple of {} (for x, y coordinates), but got {} in shape "
+            "{}",
+            STANDARD_GRID_ELEMENTS_PER_POINT,
+            grid_last_dim,
+            grid_tensor.logical_shape());
+    }
+
+    if (tensor_args.batch_index.has_value()) {
+        const auto& bidx = *tensor_args.batch_index;
+        TT_FATAL(bidx.dtype() == DataType::UINT32, "batch_index must be UINT32");
+        TT_FATAL(bidx.layout() == Layout::ROW_MAJOR, "batch_index must be ROW_MAJOR");
+        TT_FATAL(bidx.is_sharded(), "batch_index must be L1 sharded, like the grid it indexes");
+        TT_FATAL(grid_tensor.is_sharded(), "batch_index is only supported with a sharded grid");
+        TT_FATAL(
+            bidx.shard_spec()->shape[0] == grid_tensor.shard_spec()->shape[0],
+            "batch_index must have the same shard height as the grid ({} vs {})",
+            bidx.shard_spec()->shape[0],
+            grid_tensor.shard_spec()->shape[0]);
+    } else {
+        TT_FATAL(
+        input_tensor.logical_shape()[0] == grid_tensor.logical_shape()[0],
+        "Batch size mismatch: input tensor shape {} has batch size {}, but grid tensor shape {} has batch size {}",
+        input_tensor.logical_shape(),
+        input_tensor.logical_shape()[0],
+        grid_tensor.logical_shape(),
+        grid_tensor.logical_shape()[0]);
+    }
+
+    // batch_output_channels validation - must have batched input (K > 1)
+    if (operation_attributes.batch_output_channels) {
+        const uint32_t num_elements_per_grid_point = operation_attributes.use_precomputed_grid
+                                                         ? operation_attributes.mode == "nearest"
+                                                               ? PRECOMPUTED_GRID_ELEMENTS_PER_POINT_NEAREST
+                                                               : PRECOMPUTED_GRID_ELEMENTS_PER_POINT
+                                                         : STANDARD_GRID_ELEMENTS_PER_POINT;
+        const uint32_t grid_batching_factor = grid_last_dim / num_elements_per_grid_point;
+        TT_FATAL(
+            grid_batching_factor > 1,
+            "batch_output_channels=True requires grid batching factor K > 1. Use a batched grid with multiple "
+            "coordinate sets per row of grid.");
+    }
+
+    // Data type validation
+    TT_FATAL(
+        input_tensor.dtype() == DataType::BFLOAT16 || input_tensor.dtype() == DataType::FLOAT32,
+        "Input tensor must be BFLOAT16 or FLOAT32");
+    if (operation_attributes.use_precomputed_grid) {
+        TT_FATAL(grid_tensor.dtype() == DataType::BFLOAT16, "Precomputed grid tensor must be BFLOAT16");
+    } else {
+        TT_FATAL(
+            grid_tensor.dtype() == DataType::BFLOAT16 || grid_tensor.dtype() == DataType::FLOAT32,
+            "Grid tensor must be BFLOAT16 or FLOAT32");
+    }
+
+    // Layout validation
+    TT_FATAL(input_tensor.layout() == Layout::ROW_MAJOR, "Input tensor must be ROW_MAJOR layout");
+    TT_FATAL(grid_tensor.layout() == Layout::ROW_MAJOR, "Grid tensor must be ROW_MAJOR layout");
+
+    TT_FATAL(operation_attributes.padding_mode == "zeros", "Only zeros padding mode is currently supported");
+
+    // Mode and precomputed grid compatibility validation
+    TT_FATAL(
+        !(operation_attributes.mode == "nearest" && !operation_attributes.use_precomputed_grid),
+        "use_precomputed_grid = false is not supported with mode = 'nearest'. Please use precomputed grid with nearest "
+        "mode.");
+
+    // Memory layout validation - support interleaved and height sharded
+    auto input_memory_layout = input_tensor.memory_config().memory_layout();
+    auto grid_memory_layout = grid_tensor.memory_config().memory_layout();
+    auto output_memory_layout = operation_attributes.output_mem_config.memory_layout();
+
+    // Input tensor can be interleaved or height sharded
+    TT_FATAL(
+        input_memory_layout == TensorMemoryLayout::INTERLEAVED ||
+            input_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED,
+        "Input tensor must have INTERLEAVED or HEIGHT_SHARDED memory layout");
+
+    // Grid tensor can be interleaved or height sharded
+    TT_FATAL(
+        grid_memory_layout == TensorMemoryLayout::INTERLEAVED ||
+            grid_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED,
+        "Grid tensor must have INTERLEAVED or HEIGHT_SHARDED memory layout");
+
+    // Output can be interleaved or height sharded
+    TT_FATAL(
+        output_memory_layout == TensorMemoryLayout::INTERLEAVED ||
+            output_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED,
+        "Output tensor must have INTERLEAVED or HEIGHT_SHARDED memory layout");
+
+    TT_FATAL(
+        input_tensor.padded_shape()[-1] % tt::constants::TILE_WIDTH == 0,
+        "Input tensor last dimension must be divisible by TILE_WIDTH ({}), but got {} in padded shape {}",
+        tt::constants::TILE_WIDTH,
+        input_tensor.padded_shape()[-1],
+        input_tensor.padded_shape());
+}
+
+TensorSpec GridSampleOperation::compute_output_specs(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input_tensor;
+    const auto& grid_tensor = tensor_args.grid;
+
+    const auto& input_shape = input_tensor.logical_shape();
+    const auto& grid_shape = grid_tensor.logical_shape();
+
+    // Extract dimensions. With a batch_index the grid is a single pooled list whose
+    // sticks each name their own source batch, so the output has ONE batch of grid_shape[1]
+    // rows rather than one block per input batch.
+    uint32_t N = tensor_args.batch_index.has_value() ? grid_shape[0] : input_shape[0];
+    uint32_t C = input_shape[-1];
+    uint32_t H_out = grid_shape[1];
+    uint32_t W_out = grid_shape[2];
+    uint32_t grid_last_dim = grid_shape[-1];
+
+    // Calculate the number of batched grid points per grid row
+
+    const uint32_t num_of_elements_per_grid_point = operation_attributes.use_precomputed_grid
+                                                        ? operation_attributes.mode == "nearest"
+                                                              ? PRECOMPUTED_GRID_ELEMENTS_PER_POINT_NEAREST
+                                                              : PRECOMPUTED_GRID_ELEMENTS_PER_POINT
+                                                        : STANDARD_GRID_ELEMENTS_PER_POINT;
+    uint32_t grid_batching_factor = grid_last_dim / num_of_elements_per_grid_point;
+
+    // Define output shape based on batch_output_channels flag
+    ttnn::Shape output_logical_shape;
+    if (operation_attributes.batch_output_channels) {
+        // batch_output_channels=True: extend channels (legacy behavior)
+        // Output shape: (N, H_out, W_out, C * grid_batching_factor)
+        uint32_t C_out = C * grid_batching_factor;
+        output_logical_shape = ttnn::Shape({N, H_out, W_out, C_out});
+    } else {
+        // batch_output_channels=False: extend W dimension (default behavior)
+        // Output shape: (N, H_out, W_out * grid_batching_factor, C)
+        uint32_t W_out_extended = W_out * grid_batching_factor;
+        output_logical_shape = ttnn::Shape({N, H_out, W_out_extended, C});
+    }
+
+    // Output has same data type as input
+    const DataType output_data_type = input_tensor.dtype();
+
+    // Output layout is ROW_MAJOR (same as input)
+    const Layout output_layout = Layout::ROW_MAJOR;
+
+    // Determine the memory config of the output
+    MemoryConfig output_memory_config = operation_attributes.output_mem_config;
+
+    // Get grid padded shape - needed for both sharded and interleaved cases
+    const auto& grid_padded_shape = grid_tensor.padded_shape();
+    const auto& input_padded_shape = input_tensor.padded_shape();
+
+    // For bilinear mode with interleaved input/grid, keep output interleaved to avoid core count issues
+    // For nearest mode or sharded cases, use sharded output
+    if ((operation_attributes.mode == "bilinear" && !grid_tensor.memory_config().is_sharded() &&
+         operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED)) {
+        // Bilinear mode with interleaved tensors - use interleaved output (original behavior)
+        output_memory_config = operation_attributes.output_mem_config;
+    } else {
+        // Check if user provided a shard spec - if so, respect it
+        if (operation_attributes.output_mem_config.shard_spec().has_value() &&
+            !grid_tensor.memory_config().is_sharded()) {
+            // User provided shard spec - use it as is
+            output_memory_config = operation_attributes.output_mem_config;
+        } else {
+            // User didn't provide shard spec - generate one automatically
+            // Nearest mode or sharded cases - create sharded output configuration
+            const uint32_t input_padded_channel_width = input_tensor.padded_shape()[-1];
+
+            CoreRangeSet output_core_range_set;
+            ShardOrientation output_shard_orientation;
+            uint32_t grid_points_per_shard;
+
+            if (grid_tensor.memory_config().is_sharded()) {
+                // Case 1: Grid is sharded - use its sharding configuration
+                const ShardSpec grid_shard_spec = grid_tensor.shard_spec().value();
+
+                // Use the same core grid and orientation as the grid tensor
+                output_core_range_set = grid_shard_spec.grid;
+                output_shard_orientation = grid_shard_spec.orientation;
+                grid_points_per_shard = grid_shard_spec.shape[0];
+            } else {
+                // Case 2: Grid is not sharded - create sharding based on grid dimensions
+                const uint32_t total_grid_points = grid_padded_shape[1] * grid_padded_shape[2];  // H * W
+
+                // Get device compute grid for sharding
+                tt::tt_metal::IDevice* device = input_tensor.device();
+                const auto compute_grid_size = device->compute_with_storage_grid_size();
+
+                // Split grid points across available cores
+                auto
+                    [num_cores_used,
+                     all_cores_range,
+                     core_group_1_range,
+                     core_group_2_range,
+                     num_points_1,
+                     num_points_2] = tt::tt_metal::split_work_to_cores(compute_grid_size, total_grid_points);
+
+                output_core_range_set = all_cores_range;
+                output_shard_orientation = ShardOrientation::ROW_MAJOR;
+                grid_points_per_shard = num_points_1;  // Use primary group size
+            }
+
+            // Calculate output shard dimensions based on grid points per core and batching
+            // For nearest interpolation, each grid point produces one output point per channel
+            const uint32_t output_shard_height = operation_attributes.batch_output_channels
+                                                     ? grid_points_per_shard
+                                                     : grid_points_per_shard * grid_batching_factor;
+
+            // Output width is the number of input channels, extended by batching factor if needed
+            const uint32_t output_shard_width = operation_attributes.batch_output_channels
+                                                    ? input_padded_channel_width * grid_batching_factor
+                                                    : input_padded_channel_width;
+
+            // Create sharding configuration
+            const TensorMemoryLayout output_memory_layout = TensorMemoryLayout::HEIGHT_SHARDED;
+            const BufferType output_buffer_type = BufferType::L1;
+
+            const ShardSpec output_shard_spec =
+                ShardSpec(output_core_range_set, {output_shard_height, output_shard_width}, output_shard_orientation);
+
+            output_memory_config = MemoryConfig(output_memory_layout, output_buffer_type, output_shard_spec);
+        }
+    }
+
+    // Batch and height dimensions: same as grid tensor's padded shape
+    uint32_t N_padded = grid_padded_shape[0];
+    uint32_t H_out_padded = grid_padded_shape[1];
+
+    // Width dimension: expand by grid_batching_factor if batch_output_channels=false
+    uint32_t W_out_padded;
+    if (operation_attributes.batch_output_channels) {
+        W_out_padded = grid_padded_shape[2];  // batch_output_channels=true: use grid's padded width
+    } else {
+        W_out_padded = grid_padded_shape[2] * grid_batching_factor;  // batch_output_channels=false: expand width
+    }
+
+    // Channel dimension: use input tensor's padded channels and apply channel extend factor
+    uint32_t C_padded =
+        input_padded_shape[-1] * (operation_attributes.batch_output_channels ? grid_batching_factor : 1);
+
+    ttnn::Shape output_padded_shape({N_padded, H_out_padded, W_out_padded, C_padded});
+
+    return TensorSpec(
+        output_logical_shape,
+        TensorLayout::fromPaddedShape(
+            output_data_type,
+            PageConfig(output_layout),
+            output_memory_config,
+            output_logical_shape,
+            output_padded_shape));
+}
+
+Tensor GridSampleOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    auto output_spec = compute_output_specs(operation_attributes, tensor_args);
+    return create_device_tensor(output_spec, tensor_args.input_tensor.device());
+}
+
+ttnn::Tensor grid_sample(
+    const Tensor& input_tensor,
+    const Tensor& grid,
+    const std::string& mode,
+    const std::string& padding_mode,
+    bool align_corners,
+    bool use_precomputed_grid,
+    bool batch_output_channels,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
+    const std::optional<Tensor>& batch_index) {
+    using OperationType = GridSampleOperation;
+    const auto resolved_compute_kernel_config = ttnn::init_device_compute_kernel_config(
+        input_tensor.device()->arch(),
+        compute_kernel_config,
+        /*default_fidelity=*/tt::tt_metal::MathFidelity::HiFi4,
+        /*default_approx_mode=*/false,
+        /*default_fp32_acc=*/false,
+        /*default_l1_acc=*/false);
+    return ttnn::device_operation::launch<OperationType>(
+        OperationType::operation_attributes_t{
+            .mode = mode,
+            .padding_mode = padding_mode,
+            .align_corners = align_corners,
+            .use_precomputed_grid = use_precomputed_grid,
+            .batch_output_channels = batch_output_channels,
+            .output_mem_config = memory_config.value_or(grid.memory_config()),
+            .compute_kernel_config = resolved_compute_kernel_config,
+        },
+        OperationType::tensor_args_t{
+            .input_tensor = input_tensor, .grid = grid, .batch_index = batch_index});
+}
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/grid_sample/device/grid_sample_device_operation.hpp
+++ b/tt-metal/ops/grid_sample/device/grid_sample_device_operation.hpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include <variant>
+#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/core/core.hpp"
+
+#include "ttnn/device_operation.hpp"
+#include <tt-metalium/global_circular_buffer.hpp>
+#include "ttnn/operations/pool/grid_sample/device/grid_sample_device_operation_types.hpp"
+
+namespace ttnn::prim {
+
+constexpr uint32_t PRECOMPUTED_GRID_ELEMENTS_PER_POINT = 6;
+constexpr uint32_t PRECOMPUTED_GRID_ELEMENTS_PER_POINT_NEAREST = 2;
+constexpr uint32_t STANDARD_GRID_ELEMENTS_PER_POINT = 2;
+
+struct GridSampleBilinearProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const GridSampleParams& operation_attributes, const GridSampleInputs& tensor_args, Tensor& output_tensor);
+};
+
+struct GridSampleNearestProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const GridSampleParams& operation_attributes, const GridSampleInputs& tensor_args, Tensor& output_tensor);
+};
+
+struct GridSampleOperation {
+    using operation_attributes_t = GridSampleParams;
+    using tensor_args_t = GridSampleInputs;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
+    using program_factory_t = std::variant<GridSampleBilinearProgramFactory, GridSampleNearestProgramFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+};
+
+}  // namespace ttnn::prim
+
+namespace ttnn::prim {
+ttnn::Tensor grid_sample(
+    const Tensor& input_tensor,
+    const Tensor& grid,
+    const std::string& mode = "bilinear",
+    const std::string& padding_mode = "zeros",
+    bool align_corners = false,
+    bool use_precomputed_grid = false,
+    bool batch_output_channels = false,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
+    const std::optional<Tensor>& batch_index = std::nullopt);
+}  // namespace ttnn::prim

--- a/tt-metal/ops/grid_sample/device/grid_sample_device_operation_types.hpp
+++ b/tt-metal/ops/grid_sample/device/grid_sample_device_operation_types.hpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+
+namespace ttnn::prim {
+
+struct GridSampleParams {
+    std::string mode = "bilinear";
+    std::string padding_mode = "zeros";
+    bool align_corners = false;
+    bool use_precomputed_grid = false;
+    bool batch_output_channels = false;
+    tt::tt_metal::MemoryConfig output_mem_config;
+    ttnn::DeviceComputeKernelConfig compute_kernel_config{};
+
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "mode",
+        "padding_mode",
+        "align_corners",
+        "use_precomputed_grid",
+        "batch_output_channels",
+        "output_mem_config",
+        "compute_kernel_config");
+    auto attribute_values() const {
+        return std::forward_as_tuple(
+            this->mode,
+            this->padding_mode,
+            this->align_corners,
+            this->use_precomputed_grid,
+            this->batch_output_channels,
+            this->output_mem_config,
+            this->compute_kernel_config);
+    }
+};
+
+struct GridSampleInputs {
+    Tensor input_tensor;
+    Tensor grid;
+    // Optional per-grid-stick source batch. Without it the reader derives the batch
+    // positionally — stick i belongs to batch i / grid_hw — which forces a caller that
+    // compacts its grid to keep one fixed-size block per batch, sized for the busiest
+    // one. With it the grid can be a single pooled list in any order.
+    // L1 height-sharded UINT32, same shard height as the grid, one row per grid stick.
+    std::optional<Tensor> batch_index;
+};
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/grid_sample/device/grid_sample_nearest_program_factory.cpp
+++ b/tt-metal/ops/grid_sample/device/grid_sample_nearest_program_factory.cpp
@@ -1,0 +1,267 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/tensor_accessor_args.hpp"
+#include "tt-metalium/work_split.hpp"
+#include "grid_sample_utils.hpp"
+#include "ttnn/operations/pool/pool_utils.hpp"
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/math.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/operations/pool/grid_sample/device/grid_sample_device_operation.hpp"
+
+namespace ttnn::prim {
+
+using namespace tt::tt_metal;
+
+ProgramDescriptor GridSampleNearestProgramFactory::create_descriptor(
+    const GridSampleParams& operation_attributes, const GridSampleInputs& tensor_args, Tensor& output_tensor) {
+    const Tensor& input_tensor = tensor_args.input_tensor;
+    const Tensor& grid_tensor = tensor_args.grid;
+    const bool use_precomputed_grid = operation_attributes.use_precomputed_grid;
+    const bool align_corners = operation_attributes.align_corners;
+
+    const bool is_sharded = grid_tensor.is_sharded();
+    ProgramDescriptor desc;
+
+    // Data formats and device
+    const auto [input_cb_data_format, grid_cb_data_format, output_cb_data_format] = std::make_tuple(
+        tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype()),
+        tt::tt_metal::datatype_to_dataformat_converter(grid_tensor.dtype()),
+        tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype()));
+    tt::tt_metal::IDevice* const device = output_tensor.device();
+
+    // Shape and dimensions
+    const auto& [input_shape, grid_shape, output_shape] =
+        std::tie(input_tensor.padded_shape(), grid_tensor.padded_shape(), output_tensor.padded_shape());
+    const uint32_t input_height = input_shape[1], input_width = input_shape[2];
+    const uint32_t grid_height = grid_shape[1], grid_width = grid_shape[2];
+    const uint32_t grid_hw = grid_height * grid_width;
+    const uint32_t grid_batching_factor = get_grid_batching_factor(grid_tensor, use_precomputed_grid, "nearest");
+    const bool enable_split_reader =
+        should_use_split_reader(input_tensor, grid_tensor, use_precomputed_grid, "nearest");
+    tt::tt_metal::CoreRangeSet all_cores, core_group_1, core_group_2;
+    uint32_t num_cores, grid_nsticks_per_core, output_nsticks_per_core = 0;
+    uint32_t num_sticks_per_core_group_1 = 0, num_sticks_per_core_group_2 = 0;
+    std::vector<CoreCoord> logical_cores;
+
+    if (is_sharded) {
+        const auto grid_shard_spec = grid_tensor.shard_spec().value();
+        all_cores = grid_shard_spec.grid;
+        num_cores = grid_shard_spec.num_cores();
+        grid_nsticks_per_core = grid_shard_spec.shape[0];
+        output_nsticks_per_core = output_tensor.shard_spec().value().shape[0];
+        logical_cores = corerange_to_cores(
+            all_cores, num_cores, grid_shard_spec.orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR);
+    } else {
+        const auto compute_grid_size = device->compute_with_storage_grid_size();
+        uint32_t grid_nsticks = grid_tensor.physical_volume() / grid_shape[-1];
+        if (output_tensor.shard_spec().has_value()) {
+            grid_nsticks = output_tensor.shard_spec().value().shape[0] * output_tensor.shard_spec().value().num_cores();
+        } else {
+            grid_nsticks = tt::round_up(grid_nsticks, compute_grid_size.x * compute_grid_size.y);
+        }
+        auto [num_cores_used, all_cores_range, core_group_1_range, core_group_2_range, num_sticks_1, num_sticks_2] =
+            tt::tt_metal::split_work_to_cores(compute_grid_size, grid_nsticks);
+
+        std::tie(num_cores, all_cores, core_group_1, core_group_2) =
+            std::make_tuple(num_cores_used, all_cores_range, core_group_1_range, core_group_2_range);
+        num_sticks_per_core_group_1 = num_sticks_1;
+        num_sticks_per_core_group_2 = num_sticks_2;
+        grid_nsticks_per_core = num_sticks_1;
+        output_nsticks_per_core = num_sticks_1;
+        logical_cores = corerange_to_cores(all_cores, num_cores, true);
+    }
+
+    uint32_t cb_idx = tt::CBIndex::c_0;
+
+    // Create CBs
+    const uint32_t grid_stick_size =
+        is_sharded ? grid_shape[-1] * grid_tensor.element_size() : get_aligned_stick_size(grid_shape, grid_tensor);
+    const uint32_t grid_cb_index0 = cb_idx++;
+    const uint32_t grid_cb_num_pages0 = is_sharded ? grid_nsticks_per_core : 1;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = grid_cb_num_pages0 * grid_stick_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(grid_cb_index0),
+            .data_format = grid_cb_data_format,
+            .page_size = grid_stick_size,
+        }}},
+        .buffer = is_sharded ? grid_tensor.buffer() : nullptr,
+    });
+
+    uint32_t grid_cb_index1 = DUMMY_CB_ID;
+    // Nearest mode has support for DRAM interleaved grid and sharded output
+    if (enable_split_reader && !is_sharded) {
+        grid_cb_index1 = cb_idx++;
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = grid_stick_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(grid_cb_index1),
+                .data_format = grid_cb_data_format,
+                .page_size = grid_stick_size,
+            }}},
+        });
+    }
+
+    const uint32_t output_cb_page_size =
+        static_cast<uint32_t>(static_cast<float>(output_shape[-1]) * output_tensor.element_size());
+    const uint32_t output_cb_pages = output_nsticks_per_core;
+
+    // Fill CB - single page to hold pre-filled stick
+    const uint32_t fill_cb_index = cb_idx++;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = output_cb_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(fill_cb_index),
+            .data_format = output_cb_data_format,
+            .page_size = output_cb_page_size,
+        }}},
+    });
+
+    const uint32_t output_cb_index = cb_idx++;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = output_cb_pages * output_cb_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_cb_index),
+            .data_format = output_cb_data_format,
+            .page_size = output_cb_page_size,
+        }}},
+        .buffer = output_tensor.buffer(),
+    });
+
+    // Prepare stick size arguments with proper names
+    const uint32_t input_stick_size = get_aligned_stick_size(input_shape, input_tensor);
+    const uint32_t grid_stick_size_arg =
+        is_sharded ? grid_shape[-1] * grid_tensor.element_size() : get_aligned_stick_size(grid_shape, grid_tensor);
+
+    // Writer for nearest mode with sharded grid - matches sharded reader argument structure
+    std::vector<uint32_t> writer_compile_time_args = {
+        grid_cb_index0,                              // ct_arg[0]: grid_cb_index
+        output_cb_index,                             // ct_arg[1]: output_cb_index (replaces scalar_cb_index)
+        input_stick_size,                            // ct_arg[2]: input_stick_size
+        grid_stick_size_arg,                         // ct_arg[3]: grid_stick_size
+        input_height,                                // ct_arg[4]: input_height
+        input_width,                                 // ct_arg[5]: input_width
+        grid_batching_factor,                        // ct_arg[6]: grid_batching_factor
+        static_cast<uint32_t>(grid_tensor.dtype()),  // ct_arg[7]: grid_dtype
+        grid_hw,                                     // ct_arg[8]: grid_hw
+        use_precomputed_grid ? 1U : 0U,              // ct_arg[9]: use_precomputed_grid
+        align_corners ? 1U : 0U,                     // ct_arg[10]: align_corners
+        enable_split_reader ? 1U : 0U,               // ct_arg[11]: split_reader (same as reader)
+        0U,                                          // ct_arg[12]: reader_id (will be set per core)
+        grid_nsticks_per_core,                       // ct_arg[13]: grid_nsticks_per_core
+        is_sharded ? 1U : 0U,                        // ct_arg[14]: is_sharded
+        fill_cb_index,                               // ct_arg[15]: fill_cb_index
+        input_shape[0]                               // ct_arg[16]: batch_size
+    };
+
+    // Add tensor accessor args for input tensor (17 compile time args offset)
+    tt::tt_metal::TensorAccessorArgs(*input_tensor.buffer()).append_to(writer_compile_time_args);
+    if (!is_sharded) {
+        tt::tt_metal::TensorAccessorArgs(*grid_tensor.buffer()).append_to(writer_compile_time_args);
+    } else {
+        tt::tt_metal::TensorAccessorArgs(*input_tensor.buffer()).append_to(writer_compile_time_args);
+    }
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/writer_grid_sample_nearest_sharded.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = writer_compile_time_args;
+    writer_desc.config = DataMovementConfigDescriptor{
+        .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+        .noc = tt::tt_metal::NOC::RISCV_0_default,
+    };
+
+    KernelDescriptor writer1_desc;
+    if (enable_split_reader) {
+        auto writer1_compile_time_args = writer_compile_time_args;
+        writer1_compile_time_args[0] = is_sharded ? grid_cb_index0 : grid_cb_index1;  // ct_arg[0]: grid_cb_index1
+        writer1_compile_time_args[12] = 1;                                            // ct_arg[12]: reader_id = 1
+
+        writer1_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/writer_grid_sample_nearest_sharded.cpp";
+        writer1_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        writer1_desc.core_ranges = all_cores;
+        writer1_desc.compile_time_args = std::move(writer1_compile_time_args);
+        writer1_desc.config = DataMovementConfigDescriptor{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = tt::tt_metal::NOC::RISCV_1_default,
+        };
+    }
+
+    // Set runtime arguments
+    if (is_sharded) {
+        for (uint32_t i = 0; i < num_cores; i++) {
+            const CoreCoord& core = logical_cores[i];
+
+            // Runtime arguments for sharded reader
+            writer_desc.emplace_runtime_args(
+                core,
+                {
+                    input_tensor.buffer(),     // rt_arg[0]: input_buffer_address
+                    i * grid_nsticks_per_core  // rt_arg[1]: grid_stick_offset
+                });
+            if (enable_split_reader) {
+                writer1_desc.emplace_runtime_args(
+                    core,
+                    {
+                        input_tensor.buffer(),     // rt_arg[0]: input_buffer_address
+                        i * grid_nsticks_per_core  // rt_arg[1]: grid_stick_offset
+                    });
+            }
+        }
+    } else {
+        uint32_t grid_processed = 0;
+
+        for (uint32_t i = 0; i < num_cores; i++) {
+            const CoreCoord& core = logical_cores[i];
+            const uint32_t grid_sticks =
+                core_group_1.contains(core) ? num_sticks_per_core_group_1 : num_sticks_per_core_group_2;
+
+            // Runtime arguments for interleaved reader - expanded row by row
+            writer_desc.emplace_runtime_args(
+                core,
+                {
+                    input_tensor.buffer(),  // rt_arg[0]: input_buffer_address
+                    grid_tensor.buffer(),   // rt_arg[1]: grid_buffer_address
+                    grid_sticks,            // rt_arg[2]: grid_sticks
+                    grid_processed          // rt_arg[3]: grid_processed
+                });
+            if (enable_split_reader) {
+                // For split reader in nearest mode, second writer needs same runtime args
+                // The kernel logic handles the split internally via reader_id
+                writer1_desc.emplace_runtime_args(
+                    core,
+                    {
+                        input_tensor.buffer(),  // rt_arg[0]: input_buffer_address
+                        grid_tensor.buffer(),   // rt_arg[1]: grid_buffer_address
+                        grid_sticks,            // rt_arg[2]: grid_sticks
+                        grid_processed          // rt_arg[3]: grid_processed
+                    });
+            }
+
+            grid_processed += grid_sticks;
+        }
+    }
+
+    desc.kernels.push_back(std::move(writer_desc));
+    if (enable_split_reader) {
+        desc.kernels.push_back(std::move(writer1_desc));
+    }
+
+    return desc;
+}
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/grid_sample/device/grid_sample_utils.cpp
+++ b/tt-metal/ops/grid_sample/device/grid_sample_utils.cpp
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/pool/grid_sample/device/grid_sample_utils.hpp"
+#include "ttnn/operations/pool/grid_sample/device/grid_sample_device_operation.hpp"
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/math.hpp>
+
+namespace ttnn::prim {
+
+bool should_use_split_reader(
+    const Tensor& input_tensor, const Tensor& grid_tensor, bool use_precomputed_grid, const std::string& mode) {
+    // Split reader is only compatible with a sharded grid tensor
+    if (mode == "nearest") {
+        return true;
+    }
+
+    if (!grid_tensor.is_sharded()) {
+        return false;
+    }
+
+    // In the case when the grid is not precomputed, majority of processing time goes to computing the coordinates and
+    // the weights Processing time is in most cases halved, as both NCRISC and BRISC calculate these weights and
+    // coordinates
+    if (!use_precomputed_grid) {
+        return true;
+    }
+
+    // As one of the NoCs is significantly slower than the other when it comes to DRAM reads, we avoid using split
+    // reader when input tensor is in DRAM
+    if (input_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM) {
+        return false;
+    }
+
+    // Get device architecture
+    tt::tt_metal::IDevice* device = input_tensor.device();
+    const auto arch = device->arch();
+
+    // On wormhole, the bottleneck is always the reading of the input image, so split reader is beneficial
+    if (arch == tt::ARCH::WORMHOLE_B0) {
+        return true;
+    }
+
+    // On blackhole, for a lower number of channels, the bottleneck is the reading of the input image, so split reader
+    // is beneficial On higher number of channels, the bottleneck is on the unpacker side, where using split reader also
+    // adds additional overhead, so it slows down the program
+    if (arch == tt::ARCH::BLACKHOLE) {
+        const uint32_t input_channels = input_tensor.padded_shape()[-1];
+        return input_channels <= 224;
+    }
+
+    // Default case for other architectures, currently should be unreachable
+    return false;
+}
+
+uint32_t get_grid_batching_factor(const Tensor& grid_tensor, bool use_precomputed_grid, const std::string& mode) {
+    uint32_t elements_per_point;
+    if (use_precomputed_grid) {
+        elements_per_point =
+            (mode == "nearest") ? PRECOMPUTED_GRID_ELEMENTS_PER_POINT_NEAREST : PRECOMPUTED_GRID_ELEMENTS_PER_POINT;
+    } else {
+        elements_per_point = STANDARD_GRID_ELEMENTS_PER_POINT;
+    }
+    return grid_tensor.logical_shape()[-1] / elements_per_point;
+}
+
+uint32_t get_aligned_stick_size(const Shape& shape, const Tensor& tensor) {
+    const uint32_t stick_nbytes = shape[-1] * tensor.element_size();
+    const uint32_t alignment = tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
+                                   ? tt::tt_metal::hal::get_dram_alignment()
+                                   : tt::tt_metal::hal::get_l1_alignment();
+    return tt::round_up(stick_nbytes, alignment);
+}
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/grid_sample/device/grid_sample_utils.hpp
+++ b/tt-metal/ops/grid_sample/device/grid_sample_utils.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::prim {
+
+// Constants
+constexpr uint32_t MAX_TILES_PER_REDUCTION = 8;
+constexpr uint32_t BUFFERING_FACTOR = 2;
+constexpr uint32_t REDUCTION_SIZE = 4;
+constexpr uint32_t MAX_ROWS_FOR_REDUCTION = 16;  // Height of one face (always 16)
+constexpr bool ONE_SCALAR_PER_CORE = false;
+constexpr uint32_t DUMMY_CB_ID = 32;
+
+// Function declarations
+bool should_use_split_reader(
+    const Tensor& input_tensor, const Tensor& grid_tensor, bool use_precomputed_grid, const std::string& mode);
+
+uint32_t get_grid_batching_factor(
+    const Tensor& grid_tensor, bool use_precomputed_grid, const std::string& mode = "bilinear");
+
+uint32_t get_aligned_stick_size(const ttnn::Shape& shape, const Tensor& tensor);
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/grid_sample/device/kernels/dataflow/reader_grid_sample_interleaved_start_id.cpp
+++ b/tt-metal/ops/grid_sample/device/kernels/dataflow/reader_grid_sample_interleaved_start_id.cpp
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cmath>
+#include <stdint.h>
+#include "api/compile_time_args.h"
+#include <api/dataflow/dataflow_api.h>
+#include "ttnn/operations/pool/device/kernels/pool_kernels_common.hpp"
+#include "../grid_sample_reader_common.hpp"
+
+#define PRINT_AND_PROFILE 0
+#if PRINT_AND_PROFILE
+#include "tt_metal/tools/profiler/kernel_profiler.hpp"
+#include "api/debug/dprint.h"
+#endif
+
+void kernel_main() {
+    uint32_t input_addr = get_arg_val<uint32_t>(0);
+    uint32_t grid_addr = get_arg_val<uint32_t>(1);
+    uint32_t num_pages = get_arg_val<uint32_t>(2);
+    uint32_t start_page_id = get_arg_val<uint32_t>(3);
+
+    constexpr uint32_t input_cb_index = get_compile_time_arg_val(0);
+    constexpr uint32_t grid_cb_index = get_compile_time_arg_val(1);
+    constexpr uint32_t scalar_cb_index = get_compile_time_arg_val(2);
+    constexpr uint32_t input_stick_nbytes = get_compile_time_arg_val(3);
+    constexpr uint32_t grid_stick_nbytes = get_compile_time_arg_val(4);
+
+    constexpr uint32_t input_height = get_compile_time_arg_val(6);
+    constexpr uint32_t input_width = get_compile_time_arg_val(7);
+    constexpr uint32_t grid_batches = get_compile_time_arg_val(8);
+    constexpr uint32_t grid_dtype = get_compile_time_arg_val(9);
+    constexpr uint32_t output_hw_size = get_compile_time_arg_val(10);
+    constexpr bool use_precomputed_grid = get_compile_time_arg_val(11);
+    constexpr bool align_corners = get_compile_time_arg_val(12);
+    constexpr uint32_t in_nblocks_c = get_compile_time_arg_val(13);
+    constexpr uint32_t input_chunk_nbytes = get_compile_time_arg_val(14);
+    constexpr bool last_chunk_partial = get_compile_time_arg_val(15);
+
+    constexpr auto src_args = TensorAccessorArgs<16>();
+    constexpr auto grid_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+
+    const auto grid_tensor_accessor = TensorAccessor(grid_args, grid_addr);
+    const auto input_tensor_accessor = TensorAccessor(src_args, input_addr);
+
+    experimental::CB grid_cb(grid_cb_index);
+    Noc noc;
+
+    const uint32_t end_id = start_page_id + num_pages;
+
+    /*
+    In the case of grid sampling, we need to account for the fact that the grid coordinates may fall outside the bounds
+    of the input image. Since the padding mode is zero, we would simply set the weights for the appropriate sticks to
+    zero in the for loop, and simply do not read from DRAM. In that case the stick we send to reduction would be the
+    last pixel that we read for the appropriate location (SW, SE, NW, NE), but since weights are 0 this is not a
+    problem.
+
+    However, if there was no previous read for the appropriate stick, the memory in that location is invalid, and could
+    include NaN and Inf values. For that reason we zero out the input_cb at the start.
+    */
+    experimental::CB input_cb(input_cb_index);
+    experimental::CB scalar_cb(scalar_cb_index);
+    zero_out_tiles<input_cb_index>(noc, input_cb);
+
+    // Calculate starting batch from starting spatial position (avoid division in loop)
+    uint32_t curr_batch = start_page_id / output_hw_size;
+    uint32_t spatial_points_processed = start_page_id % output_hw_size;
+    uint32_t batch_offset = curr_batch * input_height * input_width;
+
+    // Outer loop: iterate over spatial positions (output sticks)
+    for (uint32_t spatial_pos = start_page_id; spatial_pos < end_id; ++spatial_pos) {
+        // Read the grid stick for this spatial position (contains grid_batches sets of coordinates)
+        noc.async_read(grid_tensor_accessor, grid_cb, grid_stick_nbytes, {.page_id = spatial_pos}, {});
+        noc.async_read_barrier();
+
+        // Cast to appropriate pointer type for grid data access
+        volatile tt_l1_ptr uint16_t* grid_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(grid_cb.get_write_ptr());
+
+        // Inner loop: process grid_batches coordinate sets within this spatial position
+        for (uint32_t grid_idx = 0; grid_idx < grid_batches; ++grid_idx) {
+            // Direct template dispatch - no branching needed
+            process_grid_point<
+                grid_dtype,
+                use_precomputed_grid,
+                align_corners,
+                input_height,
+                input_width,
+                input_stick_nbytes,
+                in_nblocks_c,
+                input_chunk_nbytes,
+                last_chunk_partial,
+                input_cb_index,
+                scalar_cb_index>(noc, input_cb, scalar_cb, grid_ptr, grid_idx, input_tensor_accessor, batch_offset);
+        }
+
+        // Update batch tracking (avoid division in loop)
+        ++spatial_points_processed;
+        if (spatial_points_processed == output_hw_size) {
+            spatial_points_processed = 0;
+            ++curr_batch;
+            batch_offset = curr_batch * input_height * input_width;
+        }
+    }
+}

--- a/tt-metal/ops/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
+++ b/tt-metal/ops/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
@@ -96,6 +96,7 @@ void kernel_main() {
     constexpr uint32_t use_batch_index = get_compile_time_arg_val(BIDX_OFFSET);
     constexpr uint32_t batch_index_cb_index = get_compile_time_arg_val(BIDX_OFFSET + 1);
     constexpr uint32_t batch_index_stride = get_compile_time_arg_val(BIDX_OFFSET + 2);
+    constexpr uint32_t grid_batch = get_compile_time_arg_val(BIDX_OFFSET + 3);
 
     volatile tt_l1_ptr uint32_t* batch_index_ptr = nullptr;
     if constexpr (use_batch_index) {
@@ -120,7 +121,11 @@ void kernel_main() {
 
     // Clamp this core's stick count to exclude height-sharding padding.
     // Padding sticks contain garbage that would produce invalid NOC addresses.
-    constexpr uint32_t total_valid_sticks = input_batch * grid_hw;  // logical grid sticks across all batches
+    // Grid batch, not input batch: with a pooled grid the two differ (one batch of sticks
+    // against N input images), and using input_batch here made the reader treat the
+    // height-sharding padding sticks as real — garbage coordinates and, worse, a garbage
+    // batch index turned into a NOC address.
+    constexpr uint32_t total_valid_sticks = grid_batch * grid_hw;
     const uint32_t remaining =  // valid sticks from this core's start to end of grid
         (global_grid_stick_start < total_valid_sticks) ? (total_valid_sticks - global_grid_stick_start) : 0;
     const uint32_t valid_sticks_this_core =  // min(assigned, remaining) — actual work for this core

--- a/tt-metal/ops/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
+++ b/tt-metal/ops/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
@@ -1,0 +1,214 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cmath>
+#include <stdint.h>
+#include <api/dataflow/dataflow_api.h>
+#include "ttnn/operations/pool/device/kernels/pool_kernels_common.hpp"
+#include "../grid_sample_reader_common.hpp"
+
+#define PRINT_AND_PROFILE 0
+#if PRINT_AND_PROFILE
+#include "tt_metal/tools/profiler/kernel_profiler.hpp"
+#include "api/debug/dprint.h"
+#endif
+
+// Push in_nblocks_c dummy input pages and one zeroed scalar page into their CBs.
+// Used for height-sharding padding sticks that have no real grid data:
+// the compute kernel always consumes a fixed number of CB entries per core,
+// so we must push placeholder pages to keep reader and compute in sync.
+// The scalar page is zeroed so the interpolation weight is 0, making the
+// padded output harmless (written to the shard but masked by valid_sticks).
+template <uint32_t scalar_cb_index, uint32_t in_nblocks_c>
+ALWI void push_noop_sticks(Noc noc, experimental::CB input_cb, experimental::CB scalar_cb) {
+    for (uint32_t c_i = 0; c_i < in_nblocks_c; ++c_i) {
+        input_cb.reserve_back(1);
+        input_cb.push_back(1);
+    }
+
+    scalar_cb.reserve_back(1);
+    zero_out_page(noc, scalar_cb);
+    noc.async_read_barrier();
+    scalar_cb.push_back(1);
+}
+
+ALWI void advance_grid_index_bounded(
+    uint32_t& in_grid_row_idx,
+    uint32_t& grid_stick_idx,
+    uint32_t& l1_grid_addr,
+    uint32_t& grid_points_processed,
+    uint32_t& curr_batch,
+    const uint32_t grid_batching_factor,
+    const uint32_t grid_stick_nbytes,
+    const uint32_t grid_hw,
+    const uint32_t grid_nsticks_per_core,
+    const uint32_t input_batch) {
+    ++in_grid_row_idx;
+    if (in_grid_row_idx == grid_batching_factor) {
+        in_grid_row_idx = 0;
+        ++grid_stick_idx;
+        l1_grid_addr += grid_stick_nbytes;
+        ++grid_points_processed;
+        if (grid_points_processed == grid_hw) {
+            grid_points_processed = 0;
+            if (curr_batch + 1 < input_batch) {
+                ++curr_batch;
+            }
+        }
+    }
+}
+
+void kernel_main() {
+    // Runtime arguments
+    const uint32_t input_addr = get_arg_val<uint32_t>(0);
+    const uint32_t global_grid_stick_start = get_arg_val<uint32_t>(1);
+
+    // Compile time arguments
+    constexpr uint32_t input_cb_index = get_compile_time_arg_val(0);
+    constexpr uint32_t grid_cb_index = get_compile_time_arg_val(1);
+    constexpr uint32_t scalar_cb_index = get_compile_time_arg_val(2);
+    constexpr uint32_t input_stick_nbytes = get_compile_time_arg_val(3);
+    constexpr uint32_t grid_stick_nbytes = get_compile_time_arg_val(4);
+    constexpr uint32_t input_batch = get_compile_time_arg_val(5);
+    constexpr uint32_t input_height = get_compile_time_arg_val(6);
+    constexpr uint32_t input_width = get_compile_time_arg_val(7);
+    constexpr uint32_t grid_batching_factor = get_compile_time_arg_val(8);
+    constexpr uint32_t grid_dtype = get_compile_time_arg_val(9);
+    constexpr uint32_t grid_hw = get_compile_time_arg_val(10);
+    constexpr uint32_t use_precomputed_grid = get_compile_time_arg_val(11);
+    constexpr bool align_corners = get_compile_time_arg_val(12);
+    constexpr uint32_t in_nblocks_c = get_compile_time_arg_val(13);
+    constexpr uint32_t input_chunk_nbytes = get_compile_time_arg_val(14);
+    constexpr bool last_chunk_partial = get_compile_time_arg_val(15);
+    constexpr uint32_t split_reader = get_compile_time_arg_val(16);
+    constexpr uint32_t reader_id = get_compile_time_arg_val(17);
+    constexpr uint32_t grid_nsticks_per_core = get_compile_time_arg_val(18);
+
+    // Input tensor accessor for remote NOC reads (updated for new arg count)
+    constexpr auto input_tensor_args = TensorAccessorArgs<19>();
+    const auto input_tensor_accessor = TensorAccessor(input_tensor_args, input_addr);
+
+    // Optional per-stick source batch. Positional batch tracking forces the caller to lay
+    // the grid out as one fixed-size block per batch; with this the grid can be a single
+    // pooled list, which is what makes compacting it worthwhile.
+    constexpr uint32_t BIDX_OFFSET = input_tensor_args.next_compile_time_args_offset();
+    constexpr uint32_t use_batch_index = get_compile_time_arg_val(BIDX_OFFSET);
+    constexpr uint32_t batch_index_cb_index = get_compile_time_arg_val(BIDX_OFFSET + 1);
+    constexpr uint32_t batch_index_stride = get_compile_time_arg_val(BIDX_OFFSET + 2);
+
+    volatile tt_l1_ptr uint32_t* batch_index_ptr = nullptr;
+    if constexpr (use_batch_index) {
+        experimental::CB batch_index_cb(batch_index_cb_index);
+        batch_index_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(batch_index_cb.get_read_ptr());
+    }
+
+    // Calculate starting batch from global grid stick position
+    // All grid points in one grid stick are in the same batch
+    const uint32_t starting_batch = global_grid_stick_start / grid_hw;
+
+    // Zero out input CB to handle invalid coordinates properly
+    Noc noc;
+    experimental::CB input_cb(input_cb_index);
+    experimental::CB scalar_cb(scalar_cb_index);
+    zero_out_tiles<input_cb_index>(noc, input_cb);
+
+    // Get local grid data base address (already in L1)
+    experimental::CB grid_cb(grid_cb_index);
+    const uint32_t l1_grid_base_addr = grid_cb.get_read_ptr();
+
+    // Clamp this core's stick count to exclude height-sharding padding.
+    // Padding sticks contain garbage that would produce invalid NOC addresses.
+    constexpr uint32_t total_valid_sticks = input_batch * grid_hw;  // logical grid sticks across all batches
+    const uint32_t remaining =  // valid sticks from this core's start to end of grid
+        (global_grid_stick_start < total_valid_sticks) ? (total_valid_sticks - global_grid_stick_start) : 0;
+    const uint32_t valid_sticks_this_core =  // min(assigned, remaining) — actual work for this core
+        (remaining < grid_nsticks_per_core) ? remaining : grid_nsticks_per_core;
+
+    // Process each grid stick assigned to this core
+    uint32_t grid_stick_idx = 0;
+    uint32_t l1_grid_addr = l1_grid_base_addr;
+
+    // For split reader: track grid point index starting from reader_id
+    uint32_t in_grid_row_idx = 0;
+
+    // Track current batch and grid position for batch increment logic
+    uint32_t curr_batch = starting_batch;
+    uint32_t grid_points_processed = global_grid_stick_start % grid_hw;
+
+    // Advance at start if needed
+    if constexpr (split_reader && reader_id == 1) {
+        advance_grid_index_bounded(
+            in_grid_row_idx,
+            grid_stick_idx,
+            l1_grid_addr,
+            grid_points_processed,
+            curr_batch,
+            grid_batching_factor,
+            grid_stick_nbytes,
+            grid_hw,
+            grid_nsticks_per_core,
+            input_batch);
+    }
+
+    while (grid_stick_idx < grid_nsticks_per_core) {
+        if (grid_stick_idx < valid_sticks_this_core) {
+            volatile tt_l1_ptr uint16_t* const grid_stick_ptr =
+                reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_grid_addr);
+
+            uint32_t batch_offset;
+            if constexpr (use_batch_index) {
+                batch_offset =
+                    batch_index_ptr[grid_stick_idx * batch_index_stride] * input_height * input_width;
+            } else {
+                batch_offset = curr_batch * input_height * input_width;
+            }
+            process_grid_point<
+                grid_dtype,
+                use_precomputed_grid,
+                align_corners,
+                input_height,
+                input_width,
+                input_stick_nbytes,
+                in_nblocks_c,
+                input_chunk_nbytes,
+                last_chunk_partial,
+                input_cb_index,
+                scalar_cb_index>(
+                noc, input_cb, scalar_cb, grid_stick_ptr, in_grid_row_idx, input_tensor_accessor, batch_offset);
+        } else {
+            // Padding stick from height-sharding — push zero-weight data to CBs
+            // so the compute kernel receives the expected number of items.
+            push_noop_sticks<scalar_cb_index, in_nblocks_c>(noc, input_cb, scalar_cb);
+        }
+
+        // Always advance once after processing
+        advance_grid_index_bounded(
+            in_grid_row_idx,
+            grid_stick_idx,
+            l1_grid_addr,
+            grid_points_processed,
+            curr_batch,
+            grid_batching_factor,
+            grid_stick_nbytes,
+            grid_hw,
+            grid_nsticks_per_core,
+            input_batch);
+
+        // For split reader, advance one more time to skip the coordinate that the other reader will process
+        if constexpr (split_reader) {
+            advance_grid_index_bounded(
+                in_grid_row_idx,
+                grid_stick_idx,
+                l1_grid_addr,
+                grid_points_processed,
+                curr_batch,
+                grid_batching_factor,
+                grid_stick_nbytes,
+                grid_hw,
+                grid_nsticks_per_core,
+                input_batch);
+        }
+    }
+}

--- a/tt-metal/ops/grid_sample/device/kernels/dataflow/writer_grid_sample_interleaved.cpp
+++ b/tt-metal/ops/grid_sample/device/kernels/dataflow/writer_grid_sample_interleaved.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <api/dataflow/dataflow_api.h>
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+
+void kernel_main() {
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_sticks_to_write = get_arg_val<uint32_t>(1);
+    uint32_t start_stick_id = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
+    constexpr uint32_t output_stick_size = get_compile_time_arg_val(1);
+    constexpr uint32_t ntiles_c = get_compile_time_arg_val(2);
+
+    constexpr auto dst_args = TensorAccessorArgs<3>();
+
+    const auto s0 = TensorAccessor(dst_args, dst_addr);
+
+    experimental::CB out_cb(cb_id_out0);
+    Noc noc;
+
+    uint32_t end_stick_id = start_stick_id + num_sticks_to_write;
+
+    // For grid sample: output is row major, each stick is written directly
+    // We wait for ntiles_c pages to accumulate one full output stick
+    for (uint32_t stick_id = start_stick_id; stick_id < end_stick_id; stick_id++) {
+        {
+            // Wait for ntiles_c pages in output CB (one full stick)
+            out_cb.wait_front(ntiles_c);
+
+            // Write the complete stick
+            noc.async_write(out_cb, s0, output_stick_size, {}, {.page_id = stick_id});
+
+            noc.async_write_barrier();
+
+            // Pop the ntiles_c pages we just consumed
+            out_cb.pop_front(ntiles_c);
+        }
+    }
+}

--- a/tt-metal/ops/grid_sample/device/kernels/dataflow/writer_grid_sample_nearest_sharded.cpp
+++ b/tt-metal/ops/grid_sample/device/kernels/dataflow/writer_grid_sample_nearest_sharded.cpp
@@ -1,0 +1,291 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cmath>
+#include <stdint.h>
+#include <api/dataflow/dataflow_api.h>
+#include "api/debug/dprint.h"
+#include <ttnn/cpp/ttnn/operations/pool/device/kernels/pool_kernels_common.hpp>
+#include "../grid_sample_reader_common.hpp"
+// experimental headers already included via grid_sample_reader_common.hpp
+
+// Process single grid point for nearest neighbor - adapted from common utilities
+template <
+    uint32_t grid_dtype,
+    bool is_sharded,
+    bool use_precomputed_grid,
+    bool align_corners,
+    uint32_t input_height,
+    uint32_t input_width,
+    uint32_t input_stick_nbytes,
+    uint32_t output_cb_index,
+    typename TensorAccessor,
+    typename GridPtrType>
+ALWI void process_grid_point_nearest(
+    Noc noc,
+    GridPtrType grid_ptr,
+    uint32_t grid_idx,
+    const TensorAccessor& input_tensor_accessor,
+    uint32_t batch_offset,
+    experimental::CB output_cb,
+    uint32_t output_write_offset,
+    uint32_t fill_stick_addr) {
+    // Compute scaling factors to match prepare_grid.cpp
+    constexpr float input_height_f = float(input_height);
+    constexpr float input_width_f = float(input_width);
+
+    // Scale factors for coordinate transformation based on align_corners mode
+    constexpr float height_scale =
+        align_corners ? ((input_height > 1) ? (input_height_f - 1.0f) * 0.5f : 0.0f) : input_height_f * 0.5f;
+    constexpr float width_scale =
+        align_corners ? ((input_width > 1) ? (input_width_f - 1.0f) * 0.5f : 0.0f) : input_width_f * 0.5f;
+    constexpr float height_offset = align_corners ? 0.0f : -0.5f;
+    constexpr float width_offset = align_corners ? 0.0f : -0.5f;
+
+    int32_t nearest_h, nearest_w;
+
+    if constexpr (use_precomputed_grid) {
+        // Each precomputed grid entry for nearest mode has 2 values (coordinates only)
+        const uint32_t precomputed_data_offset = grid_idx * PRECOMPUTED_GRID_ELEMENTS_PER_POINT_NEAREST;
+        const int16_t h_raw = *reinterpret_cast<volatile int16_t*>(&grid_ptr[precomputed_data_offset + 0]);
+        const int16_t w_raw = *reinterpret_cast<volatile int16_t*>(&grid_ptr[precomputed_data_offset + 1]);
+
+        nearest_h = static_cast<int32_t>(h_raw);
+        nearest_w = static_cast<int32_t>(w_raw);
+    } else {
+        // Each regular grid entry has 2 values: x, y coordinates - compute nearest neighbor
+        float h_coord_rel, w_coord_rel;
+        if constexpr (grid_dtype == DTYPE_FLOAT32) {
+            // For FLOAT32 grid, each coordinate is a 32-bit float
+            volatile tt_l1_ptr float* float_data = reinterpret_cast<volatile tt_l1_ptr float*>(grid_ptr);
+            const uint32_t float_offset = grid_idx * STANDARD_GRID_ELEMENTS_PER_POINT;
+            w_coord_rel = float_data[float_offset + 0];  // x coordinate
+            h_coord_rel = float_data[float_offset + 1];  // y coordinate
+        } else {
+            // For BFLOAT16 grid, read as uint16 and convert
+            const uint32_t coordinate_pair_offset = grid_idx * STANDARD_GRID_ELEMENTS_PER_POINT;
+            const uint16_t h_coord_raw = grid_ptr[coordinate_pair_offset + 1];  // y coordinate
+            const uint16_t w_coord_raw = grid_ptr[coordinate_pair_offset + 0];  // x coordinate
+            h_coord_rel = bf16_to_fp32(h_coord_raw);
+            w_coord_rel = bf16_to_fp32(w_coord_raw);
+        }
+
+        // Transform to image coordinates using the same formula as prepare_grid.cpp
+        const float h_coord_image = ((h_coord_rel + 1.0f) * height_scale) + height_offset;
+        const float w_coord_image = ((w_coord_rel + 1.0f) * width_scale) + width_offset;
+        if constexpr (align_corners) {
+            // For align_corners=True, use floor(coord) directly
+            nearest_h = static_cast<int32_t>(round(h_coord_image));
+            nearest_w = static_cast<int32_t>(round(w_coord_image));
+        } else {
+            // For nearest neighbor, use floor(coord + 0.5) to match preprocessing
+            nearest_h = static_cast<int32_t>(floor(h_coord_image + 0.5f));
+            nearest_w = static_cast<int32_t>(floor(w_coord_image + 0.5f));
+        }
+    }
+
+    // Full coordinate validation for both precomputed and regular grids.
+    // This catches out-of-bounds coordinates from padded shard data in addition
+    // to the precomputed grid sentinel value (-1), which fails the >= 0 check.
+    bool h_valid = is_coordinate_valid(nearest_h, input_height);
+    bool w_valid = is_coordinate_valid(nearest_w, input_width);
+
+    if (h_valid && w_valid) {
+        // Read the nearest neighbor pixel
+        const uint32_t input_stick_index = batch_offset + (nearest_h * input_width) + nearest_w;
+        noc.async_read(
+            input_tensor_accessor,
+            output_cb,
+            input_stick_nbytes,
+            {.page_id = input_stick_index},
+            {.offset_bytes = output_write_offset});
+    } else {
+        UnicastEndpoint self_ep;
+        noc.async_read(
+            self_ep,
+            output_cb,
+            input_stick_nbytes,
+            experimental::local_addr(fill_stick_addr, noc.get_noc_id()),
+            {.offset_bytes = output_write_offset});
+    }
+}
+
+// Advance grid index utility - same as sharded reader
+template <bool is_sharded>
+ALWI void advance_grid_index(
+    uint32_t& in_grid_row_idx,
+    uint32_t& grid_stick_idx,
+    uint32_t& l1_grid_addr,
+    uint32_t& grid_points_processed,
+    uint32_t& curr_batch,
+    const uint32_t grid_batching_factor,
+    const uint32_t grid_stick_nbytes,
+    const uint32_t grid_hw,
+    const uint32_t grid_nsticks_per_core) {
+    ++in_grid_row_idx;
+    if (in_grid_row_idx == grid_batching_factor) {
+        in_grid_row_idx = 0;
+        ++grid_stick_idx;
+        if constexpr (is_sharded) {
+            l1_grid_addr += grid_stick_nbytes;
+        }
+        ++grid_points_processed;
+        if (grid_points_processed == grid_hw) {
+            grid_points_processed = 0;
+            ++curr_batch;
+        }
+    }
+}
+
+void kernel_main() {
+    // Compile time arguments - same as sharded reader
+    constexpr uint32_t grid_cb_index = get_compile_time_arg_val(0);
+    constexpr uint32_t output_cb_index = get_compile_time_arg_val(1);  // output instead of scalar
+    constexpr uint32_t input_stick_nbytes = get_compile_time_arg_val(2);
+    constexpr uint32_t grid_stick_nbytes = get_compile_time_arg_val(3);
+    constexpr uint32_t input_height = get_compile_time_arg_val(4);
+    constexpr uint32_t input_width = get_compile_time_arg_val(5);
+    constexpr uint32_t grid_batching_factor = get_compile_time_arg_val(6);
+    constexpr uint32_t grid_dtype = get_compile_time_arg_val(7);
+    constexpr uint32_t grid_hw = get_compile_time_arg_val(8);
+    constexpr uint32_t use_precomputed_grid = get_compile_time_arg_val(9);
+    constexpr uint32_t align_corners = get_compile_time_arg_val(10);
+    constexpr uint32_t split_reader = get_compile_time_arg_val(11);
+    constexpr uint32_t reader_id = get_compile_time_arg_val(12);
+    constexpr uint32_t grid_nsticks_per_core = get_compile_time_arg_val(13);
+    constexpr uint32_t is_sharded = get_compile_time_arg_val(14);
+    constexpr uint32_t fill_cb_index = get_compile_time_arg_val(15);
+    constexpr uint32_t batch_size = get_compile_time_arg_val(16);
+
+    uint32_t input_addr = 0;
+    uint32_t global_grid_stick_start = 0;
+    uint32_t grid_addr = 0;
+    uint32_t start_page_id = 0;
+    if constexpr (is_sharded) {
+        // Runtime arguments - same as sharded reader
+        input_addr = get_arg_val<uint32_t>(0);
+        global_grid_stick_start = get_arg_val<uint32_t>(1);
+    } else {
+        input_addr = get_arg_val<uint32_t>(0);
+        grid_addr = get_arg_val<uint32_t>(1);
+        start_page_id = get_arg_val<uint32_t>(3);
+        global_grid_stick_start = start_page_id;
+    }
+
+    // Input tensor accessor for remote NOC reads - same as sharded reader
+    constexpr auto input_tensor_args = TensorAccessorArgs<17>();
+    const auto input_tensor_accessor = TensorAccessor(input_tensor_args, input_addr);
+
+    constexpr auto grid_tensor_args = TensorAccessorArgs<input_tensor_args.next_compile_time_args_offset()>();
+    const auto grid_tensor_accessor = TensorAccessor(grid_tensor_args, grid_addr);
+
+    // Calculate starting batch from global grid stick position
+    const uint32_t starting_batch = global_grid_stick_start / grid_hw;
+
+    // Get local grid data base address (already in L1)
+    experimental::CB grid_cb(grid_cb_index);
+    experimental::CB output_cb(output_cb_index);
+    experimental::CB fill_cb(fill_cb_index);
+    Noc noc;
+
+    const uint32_t l1_grid_base_addr = grid_cb.get_write_ptr();
+
+    // Process each grid stick assigned to this core
+    uint32_t grid_stick_idx = 0;
+    uint32_t l1_grid_addr = l1_grid_base_addr;
+
+    uint32_t fill_stick_addr = fill_cb.get_write_ptr();
+    zero_out_page(noc, fill_cb);
+
+    // For split reader: track grid point index starting from reader_id
+    uint32_t in_grid_row_idx = 0;
+
+    // Track current batch and grid position for batch increment logic
+    uint32_t curr_batch = starting_batch;
+    uint32_t grid_points_processed = global_grid_stick_start % grid_hw;
+    // Advance at start if needed (for split reader)
+    if constexpr (split_reader && reader_id == 1) {
+        advance_grid_index<is_sharded>(
+            in_grid_row_idx,
+            grid_stick_idx,
+            l1_grid_addr,
+            grid_points_processed,
+            curr_batch,
+            grid_batching_factor,
+            grid_stick_nbytes,
+            grid_hw,
+            grid_nsticks_per_core);
+    }
+
+    while (grid_stick_idx < grid_nsticks_per_core) {
+        volatile tt_l1_ptr uint16_t* grid_stick_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_grid_addr);
+
+        uint32_t batch_offset = curr_batch * input_height * input_width;
+
+        if constexpr (!is_sharded) {
+            noc.async_read(
+                grid_tensor_accessor, grid_cb, grid_stick_nbytes, {.page_id = grid_stick_idx + start_page_id}, {});
+            noc.async_read_barrier();
+        }
+        uint32_t output_write_offset =
+            grid_stick_idx * grid_batching_factor * input_stick_nbytes + in_grid_row_idx * input_stick_nbytes;
+
+        if (curr_batch < batch_size) {
+            // Process nearest neighbor sampling and write directly to output
+            process_grid_point_nearest<
+                grid_dtype,
+                is_sharded,
+                use_precomputed_grid,
+                align_corners,
+                input_height,
+                input_width,
+                input_stick_nbytes,
+                output_cb_index>(
+                noc,
+                grid_stick_ptr,
+                in_grid_row_idx,
+                input_tensor_accessor,
+                batch_offset,
+                output_cb,
+                output_write_offset,
+                fill_stick_addr);
+        } else {
+            // Padding stick beyond valid batches - write zeros
+            UnicastEndpoint self_ep;
+            noc.async_read(
+                self_ep,
+                output_cb,
+                input_stick_nbytes,
+                experimental::local_addr(fill_stick_addr, noc.get_noc_id()),
+                {.offset_bytes = output_write_offset});
+        }
+
+        // Always advance once after processing
+        advance_grid_index<is_sharded>(
+            in_grid_row_idx,
+            grid_stick_idx,
+            l1_grid_addr,
+            grid_points_processed,
+            curr_batch,
+            grid_batching_factor,
+            grid_stick_nbytes,
+            grid_hw,
+            grid_nsticks_per_core);
+
+        // For split reader, advance one more time to skip the coordinate that the other reader will process
+        if constexpr (split_reader) {
+            advance_grid_index<is_sharded>(
+                in_grid_row_idx,
+                grid_stick_idx,
+                l1_grid_addr,
+                grid_points_processed,
+                curr_batch,
+                grid_batching_factor,
+                grid_stick_nbytes,
+                grid_hw,
+                grid_nsticks_per_core);
+        }
+    }
+    noc.async_read_barrier();
+}

--- a/tt-metal/ops/grid_sample/device/kernels/grid_sample_reader_common.hpp
+++ b/tt-metal/ops/grid_sample/device/kernels/grid_sample_reader_common.hpp
@@ -1,0 +1,409 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cmath>
+#include <stdint.h>
+#include <api/dataflow/dataflow_api.h>
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+#include "api/numeric/bfloat16.h"
+
+#define ALWI inline __attribute__((always_inline))
+
+// Constants shared between interleaved and sharded kernels
+constexpr uint32_t PRECOMPUTED_GRID_ELEMENTS_PER_POINT = 6;          // For bilinear mode
+constexpr uint32_t PRECOMPUTED_GRID_ELEMENTS_PER_POINT_NEAREST = 2;  // For nearest mode
+constexpr uint32_t STANDARD_GRID_ELEMENTS_PER_POINT = 2;
+
+// Data type constants (from ttnn/api/ttnn/tensor/types.hpp DataType enum)
+constexpr uint32_t DTYPE_BFLOAT16 = 0;
+constexpr uint32_t DTYPE_FLOAT32 = 1;
+
+// Utility functions
+ALWI bool is_coordinate_valid(int32_t coord, uint32_t max_size) {
+    return (coord >= 0) && (coord < static_cast<int32_t>(max_size));
+}
+
+ALWI void fill_four_val(uint32_t begin_addr, uint16_t val, uint16_t val1, uint16_t val2, uint16_t val3) {
+    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(begin_addr);
+    ptr[0] = (val | (val1 << 16));
+    ptr[1] = (val2 | (val3 << 16));
+}
+
+// Grid coordinate reading functions
+template <uint32_t grid_dtype, bool use_precomputed_grid>
+struct GridCoordinateReader {
+    // Read grid coordinates and return corner coordinates and weights
+    template <typename GridPtrType>
+    ALWI static void read_grid_point(
+        GridPtrType grid_ptr,
+        uint32_t grid_idx,
+        float height_scale,
+        float height_offset,
+        float width_scale,
+        float width_offset,
+        uint32_t input_height,
+        uint32_t input_width,
+        int32_t& h0,
+        int32_t& h1,
+        int32_t& w0,
+        int32_t& w1,
+        uint16_t& weight_nw_bf,
+        uint16_t& weight_ne_bf,
+        uint16_t& weight_sw_bf,
+        uint16_t& weight_se_bf) {
+        if constexpr (use_precomputed_grid) {
+            // Each precomputed grid entry has 6 values: h0, w0, weight_nw, weight_ne, weight_sw, weight_se
+            const uint32_t precomputed_data_offset = grid_idx * PRECOMPUTED_GRID_ELEMENTS_PER_POINT;
+            const int16_t h0_raw = *reinterpret_cast<volatile int16_t*>(&grid_ptr[precomputed_data_offset + 0]);
+            const int16_t w0_raw = *reinterpret_cast<volatile int16_t*>(&grid_ptr[precomputed_data_offset + 1]);
+
+            h0 = static_cast<int32_t>(h0_raw);
+            w0 = static_cast<int32_t>(w0_raw);
+            h1 = h0 + 1;
+            w1 = w0 + 1;
+
+            // Read precomputed weights
+            weight_nw_bf = grid_ptr[precomputed_data_offset + 2];
+            weight_ne_bf = grid_ptr[precomputed_data_offset + 3];
+            weight_sw_bf = grid_ptr[precomputed_data_offset + 4];
+            weight_se_bf = grid_ptr[precomputed_data_offset + 5];
+        } else {
+            // Each regular grid entry has 2 values: x, y coordinates
+            float h_coord_rel, w_coord_rel;
+            if constexpr (grid_dtype == DTYPE_FLOAT32) {
+                // For FLOAT32 grid, each coordinate is a 32-bit float
+                volatile tt_l1_ptr float* float_data = reinterpret_cast<volatile tt_l1_ptr float*>(grid_ptr);
+                const uint32_t float_offset = grid_idx * STANDARD_GRID_ELEMENTS_PER_POINT;
+                w_coord_rel = float_data[float_offset + 0];  // x coordinate
+                h_coord_rel = float_data[float_offset + 1];  // y coordinate
+            } else {
+                // For BFLOAT16 grid, read as uint16 and convert
+                const uint32_t coordinate_pair_offset = grid_idx * STANDARD_GRID_ELEMENTS_PER_POINT;
+                const uint16_t h_coord_raw = grid_ptr[coordinate_pair_offset + 1];  // y coordinate
+                const uint16_t w_coord_raw = grid_ptr[coordinate_pair_offset + 0];  // x coordinate
+                h_coord_rel = bf16_to_fp32(h_coord_raw);
+                w_coord_rel = bf16_to_fp32(w_coord_raw);
+            }
+
+            const float h_coord_image = h_coord_rel * height_scale + height_offset;
+            const float w_coord_image = w_coord_rel * width_scale + width_offset;
+
+            h0 = static_cast<int32_t>(floor(h_coord_image));
+            h1 = h0 + 1;
+            w0 = static_cast<int32_t>(floor(w_coord_image));
+            w1 = w0 + 1;
+
+            // Calculate bilinear interpolation weights
+            const float h0_f = static_cast<float>(h0);
+            const float w0_f = static_cast<float>(w0);
+
+            const float h_frac = h_coord_image - h0_f;
+            const float w_frac = w_coord_image - w0_f;
+            const float h_frac_inv = 1.0f - h_frac;
+            const float w_frac_inv = 1.0f - w_frac;
+
+            // Boundary checks
+            const bool h0_valid = is_coordinate_valid(h0, input_height);
+            const bool h1_valid = is_coordinate_valid(h1, input_height);
+            const bool w0_valid = is_coordinate_valid(w0, input_width);
+            const bool w1_valid = is_coordinate_valid(w1, input_width);
+
+            const float weight_nw = (h0_valid && w0_valid) ? (h_frac_inv * w_frac_inv) : 0.0f;  // North-West
+            const float weight_ne = (h0_valid && w1_valid) ? (h_frac_inv * w_frac) : 0.0f;      // North-East
+            const float weight_sw = (h1_valid && w0_valid) ? (h_frac * w_frac_inv) : 0.0f;      // South-West
+            const float weight_se = (h1_valid && w1_valid) ? (h_frac * w_frac) : 0.0f;          // South-East
+
+            weight_nw_bf = fp32_to_bf16_truncate(weight_nw);
+            weight_ne_bf = fp32_to_bf16_truncate(weight_ne);
+            weight_sw_bf = fp32_to_bf16_truncate(weight_sw);
+            weight_se_bf = fp32_to_bf16_truncate(weight_se);
+        }
+    }
+};
+
+// Input data reading template - handles both tensor accessor and direct NOC reads.
+// Reads a single chunk slice of the 4 corner sticks for one grid point.
+// - read_bytes: bytes to copy per corner (chunk width)
+// - write_stride: distance between consecutive corners in the destination CB page
+// - src_byte_offset: byte offset within the source stick (= c_i * input_chunk_nbytes)
+template <typename TensorAccessorT>
+ALWI void read_four_corner_inputs(
+    Noc noc,
+    const TensorAccessorT& input_tensor_accessor,
+    uint32_t batch_offset,
+    uint32_t input_width,
+    uint32_t read_bytes,
+    uint32_t write_stride,
+    uint32_t src_byte_offset,
+    int32_t h0,
+    int32_t h1,
+    int32_t w0,
+    int32_t w1,
+    uint32_t input_height,
+    experimental::CB input_cb) {
+    // Boundary checks (recompute for performance)
+    const bool h0_valid = is_coordinate_valid(h0, input_height);
+    const bool h1_valid = is_coordinate_valid(h1, input_height);
+    const bool w0_valid = is_coordinate_valid(w0, input_width);
+    const bool w1_valid = is_coordinate_valid(w1, input_width);
+
+    uint32_t write_offset = 0;
+
+    // Read 4 corner input sticks via NOC from remote input tensor
+    if (h0_valid && w0_valid) {
+        const uint32_t north_west_stick_index = batch_offset + (h0 * input_width) + w0;
+        noc.async_read(
+            input_tensor_accessor,
+            input_cb,
+            read_bytes,
+            {.page_id = north_west_stick_index, .offset_bytes = src_byte_offset},
+            {.offset_bytes = write_offset});
+    }
+    write_offset += write_stride;
+
+    if (h0_valid && w1_valid) {
+        const uint32_t north_east_stick_index = batch_offset + (h0 * input_width) + w1;
+        noc.async_read(
+            input_tensor_accessor,
+            input_cb,
+            read_bytes,
+            {.page_id = north_east_stick_index, .offset_bytes = src_byte_offset},
+            {.offset_bytes = write_offset});
+    }
+    write_offset += write_stride;
+
+    if (h1_valid && w0_valid) {
+        const uint32_t south_west_stick_index = batch_offset + (h1 * input_width) + w0;
+        noc.async_read(
+            input_tensor_accessor,
+            input_cb,
+            read_bytes,
+            {.page_id = south_west_stick_index, .offset_bytes = src_byte_offset},
+            {.offset_bytes = write_offset});
+    }
+    write_offset += write_stride;
+
+    if (h1_valid && w1_valid) {
+        const uint32_t south_east_stick_index = batch_offset + (h1 * input_width) + w1;
+        noc.async_read(
+            input_tensor_accessor,
+            input_cb,
+            read_bytes,
+            {.page_id = south_east_stick_index, .offset_bytes = src_byte_offset},
+            {.offset_bytes = write_offset});
+    }
+}
+
+template <typename TensorAccessorT>
+ALWI void read_four_corner_inputs_with_fill(
+    Noc noc,
+    const TensorAccessorT& input_tensor_accessor,
+    uint32_t batch_offset,
+    uint32_t input_width,
+    uint32_t input_stick_nbytes,
+    int32_t h0,
+    int32_t h1,
+    int32_t w0,
+    int32_t w1,
+    uint32_t input_height,
+    experimental::CB input_cb,
+    uint32_t fill_stick_addr) {
+    const bool h0_valid = is_coordinate_valid(h0, input_height);
+    const bool h1_valid = is_coordinate_valid(h1, input_height);
+    const bool w0_valid = is_coordinate_valid(w0, input_width);
+    const bool w1_valid = is_coordinate_valid(w1, input_width);
+
+    UnicastEndpoint self_ep;
+    const auto fill_src = experimental::local_addr(fill_stick_addr, noc.get_noc_id());
+    uint32_t write_offset = 0;
+
+    if (h0_valid && w0_valid) {
+        const uint32_t north_west_stick_index = batch_offset + (h0 * input_width) + w0;
+        noc.async_read(
+            input_tensor_accessor,
+            input_cb,
+            input_stick_nbytes,
+            {.page_id = north_west_stick_index},
+            {.offset_bytes = write_offset});
+    } else {
+        noc.async_read(self_ep, input_cb, input_stick_nbytes, fill_src, {.offset_bytes = write_offset});
+    }
+    write_offset += input_stick_nbytes;
+
+    if (h0_valid && w1_valid) {
+        const uint32_t north_east_stick_index = batch_offset + (h0 * input_width) + w1;
+        noc.async_read(
+            input_tensor_accessor,
+            input_cb,
+            input_stick_nbytes,
+            {.page_id = north_east_stick_index},
+            {.offset_bytes = write_offset});
+    } else {
+        noc.async_read(self_ep, input_cb, input_stick_nbytes, fill_src, {.offset_bytes = write_offset});
+    }
+    write_offset += input_stick_nbytes;
+
+    if (h1_valid && w0_valid) {
+        const uint32_t south_west_stick_index = batch_offset + (h1 * input_width) + w0;
+        noc.async_read(
+            input_tensor_accessor,
+            input_cb,
+            input_stick_nbytes,
+            {.page_id = south_west_stick_index},
+            {.offset_bytes = write_offset});
+    } else {
+        noc.async_read(self_ep, input_cb, input_stick_nbytes, fill_src, {.offset_bytes = write_offset});
+    }
+    write_offset += input_stick_nbytes;
+
+    if (h1_valid && w1_valid) {
+        const uint32_t south_east_stick_index = batch_offset + (h1 * input_width) + w1;
+        noc.async_read(
+            input_tensor_accessor,
+            input_cb,
+            input_stick_nbytes,
+            {.page_id = south_east_stick_index},
+            {.offset_bytes = write_offset});
+    } else {
+        noc.async_read(self_ep, input_cb, input_stick_nbytes, fill_src, {.offset_bytes = write_offset});
+    }
+}
+
+// Process single grid point - common logic for both interleaved and sharded.
+//
+// When in_nblocks_c > 1 the channel dimension is split into chunks of at most
+// input_chunk_nbytes bytes (= MAX_TILES_PER_REDUCTION * TILE_WIDTH * elem_size). For each chunk we
+// reserve one input CB page, NOC-read the c_i-th slice of all 4 corner sticks, and push that page
+// to the compute kernel, which iterates over the same in_nblocks_c chunks. The scalar (bilinear
+// weights) CB is pushed once per grid point since the weights are shared across chunks.
+template <
+    uint32_t grid_dtype,
+    bool use_precomputed_grid,
+    bool align_corners,
+    uint32_t input_height,
+    uint32_t input_width,
+    uint32_t input_stick_nbytes,
+    uint32_t in_nblocks_c,
+    uint32_t input_chunk_nbytes,
+    bool last_chunk_partial,
+    uint32_t input_cb_index,
+    uint32_t scalar_cb_index,
+    typename TensorAccessor,
+    typename GridPtrType>
+ALWI void process_grid_point(
+    Noc noc,
+    experimental::CB input_cb,
+    experimental::CB scalar_cb,
+    GridPtrType grid_ptr,
+    uint32_t grid_idx,
+    const TensorAccessor& input_tensor_accessor,
+    uint32_t batch_offset) {
+    // PyTorch grid_sample coordinate convention:
+    //   align_corners=True : maps grid in [-1, 1] to image positions [0, size - 1]
+    //                        => coord_image = ((grid + 1) / 2) * (size - 1)
+    //                                       = grid * (size - 1) / 2 + (size - 1) / 2
+    //   align_corners=False: maps grid in [-1, 1] to image positions [-0.5, size - 0.5]
+    //                        => coord_image = ((grid + 1) / 2) * size - 0.5
+    //                                       = grid * size / 2 + size / 2 - 0.5
+    constexpr float input_height_f = float(input_height);
+    constexpr float input_width_f = float(input_width);
+    constexpr float height_scale =
+        align_corners ? (input_height_f > 1.0f ? (input_height_f - 1.0f) * 0.5f : 0.0f) : input_height_f * 0.5f;
+    constexpr float height_offset = align_corners ? (input_height_f > 1.0f ? (input_height_f - 1.0f) * 0.5f : 0.0f)
+                                                  : (input_height_f * 0.5f - 0.5f);
+    constexpr float width_scale =
+        align_corners ? (input_width_f > 1.0f ? (input_width_f - 1.0f) * 0.5f : 0.0f) : input_width_f * 0.5f;
+    constexpr float width_offset =
+        align_corners ? (input_width_f > 1.0f ? (input_width_f - 1.0f) * 0.5f : 0.0f) : (input_width_f * 0.5f - 0.5f);
+
+    int32_t h0, h1, w0, w1;
+    uint16_t weight_nw_bf, weight_ne_bf, weight_sw_bf, weight_se_bf;
+
+    // Read grid coordinates and compute weights
+    GridCoordinateReader<grid_dtype, use_precomputed_grid>::template read_grid_point(
+        grid_ptr,
+        grid_idx,
+        height_scale,
+        height_offset,
+        width_scale,
+        width_offset,
+        input_height,
+        input_width,
+        h0,
+        h1,
+        w0,
+        w1,
+        weight_nw_bf,
+        weight_ne_bf,
+        weight_sw_bf,
+        weight_se_bf);
+
+    // For precomputed grid, we need to compute boundary checks here
+    // since they weren't computed in the coordinate reading phase
+    if constexpr (use_precomputed_grid) {
+        const bool h0_valid = is_coordinate_valid(h0, input_height);
+        const bool h1_valid = is_coordinate_valid(h1, input_height);
+        const bool w0_valid = is_coordinate_valid(w0, input_width);
+        const bool w1_valid = is_coordinate_valid(w1, input_width);
+
+        // Zero out weights for invalid coordinates
+        if (!(h0_valid && w0_valid)) {
+            weight_nw_bf = 0;
+        }
+        if (!(h0_valid && w1_valid)) {
+            weight_ne_bf = 0;
+        }
+        if (!(h1_valid && w0_valid)) {
+            weight_sw_bf = 0;
+        }
+        if (!(h1_valid && w1_valid)) {
+            weight_se_bf = 0;
+        }
+    }
+
+    // Store bilinear interpolation weights for this grid point. The same weights apply to every
+    // channel chunk, so we push the scalar CB only once.
+    scalar_cb.reserve_back(1);
+    const uint32_t l1_write_scalar_addr = scalar_cb.get_write_ptr();
+    fill_four_val(l1_write_scalar_addr, weight_nw_bf, weight_ne_bf, weight_sw_bf, weight_se_bf);
+    scalar_cb.push_back(1);
+
+    // Iterate over channel chunks. For the common case in_nblocks_c == 1 the loop runs once and the
+    // behavior matches the original non-chunked reader (chunk_bytes == input_stick_nbytes,
+    // src_byte_offset == 0, write_stride == input_stick_nbytes). last_chunk_partial is computed
+    // host-side to mirror compute_pool_2d's tile-reduce condition so the per-stick write stride
+    // matches the unpacker's tiles_to_reduce; computing it independently here would silently diverge
+    // if the host ever lifted the padded_C % TILE_WIDTH == 0 invariant.
+    constexpr uint32_t last_chunk_idx = in_nblocks_c - 1;
+    constexpr uint32_t partial_chunk_nbytes = input_stick_nbytes - last_chunk_idx * input_chunk_nbytes;
+    constexpr uint32_t base_write_stride = (in_nblocks_c > 1) ? input_chunk_nbytes : input_stick_nbytes;
+
+    for (uint32_t c_i = 0; c_i < in_nblocks_c; ++c_i) {
+        const uint32_t src_byte_offset = c_i * input_chunk_nbytes;
+        const uint32_t chunk_bytes = (c_i == last_chunk_idx) ? partial_chunk_nbytes : input_chunk_nbytes;
+        const uint32_t write_stride = (last_chunk_partial && c_i == last_chunk_idx) ? chunk_bytes : base_write_stride;
+
+        input_cb.reserve_back(1);
+
+        read_four_corner_inputs(
+            noc,
+            input_tensor_accessor,
+            batch_offset,
+            input_width,
+            chunk_bytes,
+            write_stride,
+            src_byte_offset,
+            h0,
+            h1,
+            w0,
+            w1,
+            input_height,
+            input_cb);
+
+        noc.async_read_barrier();
+        input_cb.push_back(1);
+    }
+}

--- a/tt-metal/ops/grid_sample/grid_sample.cpp
+++ b/tt-metal/ops/grid_sample/grid_sample.cpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "grid_sample.hpp"
+// #include "device/grid_sample_op.hpp"
+#include "ttnn/operations/pool/grid_sample/device/grid_sample_device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operation.hpp"
+
+namespace ttnn::operations::grid_sample {
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+ttnn::Tensor grid_sample(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& grid,
+    const std::string& mode,
+    const std::string& padding_mode,
+    bool align_corners,
+    bool use_precomputed_grid,
+    bool batch_output_channels,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
+    const std::optional<ttnn::Tensor>& batch_index) {
+    return ttnn::prim::grid_sample(
+        input_tensor,
+        grid,
+        mode,
+        padding_mode,
+        align_corners,
+        use_precomputed_grid,
+        batch_output_channels,
+        memory_config,
+        compute_kernel_config,
+        batch_index);
+}
+
+}  // namespace ttnn::operations::grid_sample

--- a/tt-metal/ops/grid_sample/grid_sample.hpp
+++ b/tt-metal/ops/grid_sample/grid_sample.hpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "grid_sample_prepare_grid.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn {
+
+namespace operations::grid_sample {
+
+/**
+ * Grid sample operation for spatial sampling with bilinear interpolation.
+ *
+ * Samples input tensor at grid locations using bilinear interpolation.
+ * Grid coordinates are expected to be normalized to [-1, 1] range.
+ *
+ * Args:
+ *   input_tensor: Input tensor of shape (N, C, H_in, W_in)
+ *   grid: Sampling grid of shape (N, H_out, W_out, 2) with coordinates in [-1, 1]
+ *   mode: Interpolation mode, currently only "bilinear" is supported
+ *   padding_mode: How to handle out-of-bounds coordinates, currently only "zeros" is supported
+ *   align_corners: Whether to align corners when mapping normalized coordinates to pixel indices
+ *   use_precomputed_grid: Whether to use precomputed grid coordinates, currently only false is supported
+ *   batch_output_channels: If true, fold output channels into the batch dimension
+ *   memory_config: Memory configuration for the output tensor
+ *   compute_kernel_config: Optional compute kernel configuration (math fidelity, fp32 dest
+ *     accumulation, etc.). Defaults are arch-specific.
+ *   batch_index: Optional per-grid-stick source batch (L1 sharded UINT32, one row per
+ *     grid stick). When given, the grid no longer has to be laid out in per-batch
+ *     blocks — any order works, and grid batch may be 1 while the input has N.
+ *
+ * Returns:
+ *   Output tensor of shape (N, C, H_out, W_out)
+ */
+ttnn::Tensor grid_sample(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& grid,
+    const std::string& mode = "bilinear",
+    const std::string& padding_mode = "zeros",
+    bool align_corners = false,
+    bool use_precomputed_grid = false,
+    bool batch_output_channels = false,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
+    const std::optional<ttnn::Tensor>& batch_index = std::nullopt);
+
+}  // namespace operations::grid_sample
+
+// Import functions to main ttnn namespace
+using ttnn::operations::grid_sample::grid_sample;
+using ttnn::operations::grid_sample::prepare_grid_sample_grid;
+
+}  // namespace ttnn

--- a/tt-metal/ops/grid_sample/grid_sample_nanobind.cpp
+++ b/tt-metal/ops/grid_sample/grid_sample_nanobind.cpp
@@ -1,0 +1,231 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "grid_sample_nanobind.hpp"
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/string.h>
+
+#include "ttnn-nanobind/bind_function.hpp"
+#include "grid_sample.hpp"
+#include "grid_sample_prepare_grid.hpp"
+
+namespace ttnn::operations::grid_sample {
+
+namespace {
+
+void bind_grid_sample_op(nb::module_& mod) {
+    const auto* const doc = R"doc(
+        Performs grid sampling on the input tensor using the provided sampling grid.
+
+        Grid sample uses bilinear interpolation to sample input values at arbitrary
+        grid locations. This is commonly used for spatial transformations, image warping,
+        and implementing spatial transformer networks.
+
+        Args:
+            input_tensor (ttnn.Tensor): Input tensor of shape (N, H_in, W_in, C) - channel last format
+            grid (ttnn.Tensor): Sampling grid with flexible batching support.
+
+                * Standard mode (use_precomputed_grid=False):
+
+                  - Shape (N, H_grid, W_grid, 2*K) where K is the grid batching factor
+                  - Contains K sets of normalized coordinates in range [-1, 1] packed into the last dimension
+                  - Each coordinate pair (x, y): x=-1 (leftmost), x=+1 (rightmost), y=-1 (topmost), y=+1 (bottommost)
+                  - Data type: BFLOAT16 or FLOAT32 (FLOAT32 provides higher precision for coordinate calculations)
+                  - When K=1: standard single coordinate per location (maps 1:1 to PyTorch F.grid_sample behavior)
+                  - When K>1: K coordinate sets are packed per spatial location, typically created by reshaping
+                    a larger grid from (N, H_grid, W_grid*K, 2) to (N, H_grid, W_grid, 2*K), where the desired grid shape would be W_grid*K
+
+                * Precomputed mode (use_precomputed_grid=True):
+
+                  - Shape (N, H_grid, W_grid, 6*K) containing K sets of precomputed data packed into the last dimension
+                  - Each set has 6 elements: pixel coordinates and bilinear interpolation weights
+                  - Data type: BFLOAT16 only (precomputed grids must be BFLOAT16)
+                  - When K=1: standard precomputed grid
+                  - When K>1: K precomputed sets are packed per spatial location, typically created by reshaping
+                    a larger precomputed grid from (N, H_grid, W_grid*K, 6) to (N, H_grid, W_grid, 6*K), where the desired grid shape would be W_grid*K
+                  - Generated using ttnn.prepare_grid_sample_grid() for K=1, then ttnn.reshape() for K>1, both being done on host side
+        Keyword Args:
+            mode (str): Interpolation mode.
+            padding_mode (str): How to handle out-of-bounds coordinates. Currently only "zeros" is supported.
+            align_corners (bool): Whether to align corners when mapping normalized coordinates to pixel indices.
+            use_precomputed_grid (bool): Whether to use precomputed grid coordinates.
+
+                When False (default): grid should be normalized coordinates in [-1, 1]
+
+                When True: grid should be preprocessed using ttnn.prepare_grid_sample_grid()
+
+            batch_output_channels (bool): Controls how grid batching factor K affects output dimensions.
+
+                When False (default): extend W dimension - output shape (N, H_grid, W_grid*K, C).
+                The K coordinate sets produce K spatial outputs, expanding the width dimension.
+
+                When True: batch output channels - output shape (N, H_grid, W_grid, C*K).
+                The K coordinate sets produce K channel groups, expanding the channel dimension.
+
+                Setting this argument to True requires for K (grid batching factor) to be larger than one.
+                Note: K doesn't disappear when batch_output_channels=False, it just gets distributed to the width dimension.
+
+            memory_config (ttnn.MemoryConfig, optional): Output memory configuration for the operation.
+
+            compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): Compute kernel configuration.
+            batch_index (ttnn.Tensor, optional): Per-grid-stick source batch, L1 sharded UINT32 with
+                the same shard height as the grid. Without it the batch of a stick is its position
+                (stick i belongs to batch i / grid_hw), which forces a caller that compacts its grid
+                to keep one fixed-size block per batch. With it the grid may be a single pooled list
+                in any order, and its batch dimension may be 1 while the input has N.
+                Notable fields:
+
+                - fp32_dest_acc_en: Use FP32 destination accumulation (higher precision; halves DEST tile capacity).
+                - dst_full_sync_en: Use full-sync DEST mode (doubles DEST tile capacity; auto-forced when
+                  fp32_dest_acc_en requires it).
+
+                Defaults to `None` (arch-specific defaults).
+
+        Returns:
+            ttnn.Tensor: Output tensor shape depends on batch_output_channels flag.
+
+                - When batch_output_channels=False (default): (N, H_grid, W_grid*K, C) - W dimension extended
+                - When batch_output_channels=True: (N, H_grid, W_grid, C*K) - channels batched
+
+                Where K is the grid batching factor.
+
+        Example:
+            >>> # Create input tensor (N=1, H=4, W=4, C=32) - channel last format
+            >>> input_tensor = ttnn.from_torch(torch.randn(1, 4, 4, 32), device=device)
+
+            >>> # Example 1: Standard single grid (K=1) - both batch_output_channels values produce same result
+            >>> theta = torch.tensor([[[1., 0., 0.], [0., 1., 0.]]], dtype=torch.float)
+            >>> grid = torch.nn.functional.affine_grid(theta, (1, 32, 4, 4), align_corners=False)
+            >>> grid_tensor = ttnn.from_torch(grid.to(torch.bfloat16), device=device)
+            >>> output_default = ttnn.grid_sample(input_tensor, grid_tensor)  # batch_output_channels=False (default)
+            >>> print(output_default.shape)  # [1, 4, 4, 32] - same for both when K=1
+
+            >>> # Example 2: Grid batching (K=4) - demonstrates proper reshaping workflow
+            >>> # Step 1: Create natural grid as you normally would (like in PyTorch)
+            >>> K = 4  # Grid batching factor
+            >>> natural_grid = torch.randn(1, 4, 16, 2) * 0.5  # Natural shape: (N, H_grid, W_grid*K, 2)
+            >>>
+            >>> # Step 2: Reshape for optimization - pack K coordinate sets into last dimension
+            >>> W_grid = 16 // K  # W_grid = 4
+            >>> batched_grid = natural_grid.view(1, 4, W_grid, 2*K)  # Reshaped: (1, 4, 4, 8)
+            >>> batched_grid_tensor = ttnn.from_torch(batched_grid.to(torch.bfloat16), device=device)
+            >>>
+            >>> # batch_output_channels=False (default): W dimension extended
+            >>> output_w_extend = ttnn.grid_sample(input_tensor, batched_grid_tensor)
+            >>> print(output_w_extend.shape)  # [1, 4, 16, 32] - W extended from 4 to 16 (W_grid*K)
+            >>>
+            >>> # batch_output_channels=True: channels batched
+            >>> output_c_extend = ttnn.grid_sample(input_tensor, batched_grid_tensor, batch_output_channels=True)
+            >>> print(output_c_extend.shape)  # [1, 4, 4, 128] - channels batched from 32 to 128 (K*C)
+
+            >>> # Example 3: Using FLOAT32 grid for higher precision
+            >>> grid_float32 = ttnn.from_torch(grid.to(torch.float32), dtype=ttnn.float32, device=device)
+            >>> output_float32 = ttnn.grid_sample(input_tensor, grid_float32)  # Higher precision coordinates
+            >>> print(output_float32.shape)  # [1, 4, 4, 32]
+
+            >>> # Example 4: Using precomputed grid for better performance
+            >>> grid_float32_host = ttnn.from_torch(grid, dtype=ttnn.float32)
+            >>> input_shape = [1, 4, 4, 32]  # [N, H, W, C] format
+            >>> prepared_grid = ttnn.prepare_grid_sample_grid(
+            ...     grid_float32_host, input_shape, padding_mode="zeros", output_dtype=ttnn.bfloat16
+            ... )
+            >>> prepared_grid = ttnn.to_device(prepared_grid, device)
+            >>> output_precomputed = ttnn.grid_sample(input_tensor, prepared_grid, use_precomputed_grid=True)
+            >>> print(output_precomputed.shape)  # [1, 4, 4, 32]
+        )doc";
+
+    ttnn::bind_function<"grid_sample">(
+        mod,
+        doc,
+        &ttnn::grid_sample,
+        nb::arg("input_tensor"),
+        nb::arg("grid"),
+        nb::kw_only(),
+        nb::arg("mode") = nb::str("bilinear"),
+        nb::arg("padding_mode") = nb::str("zeros"),
+        nb::arg("align_corners") = false,
+        nb::arg("use_precomputed_grid") = false,
+        nb::arg("batch_output_channels") = false,
+        nb::arg("memory_config") = nb::none(),
+        nb::arg("compute_kernel_config") = nb::none(),
+        nb::arg("batch_index") = nb::none());
+}
+
+void bind_prepare_grid_sample_grid(nb::module_& mod) {
+    // Bind prepare_grid_sample_grid function
+    mod.def(
+        "prepare_grid_sample_grid",
+        prepare_grid_sample_grid,
+        nb::arg("grid"),
+        nb::arg("input_shape"),
+        nb::kw_only(),
+        nb::arg("mode") = nb::str("bilinear"),
+        nb::arg("padding_mode") = nb::str("zeros"),
+        nb::arg("align_corners") = false,
+        nb::arg("output_dtype") = nb::none(),
+        R"doc(
+        Precomputes grid sample data for optimized kernel execution.
+
+        This function takes a normalized grid tensor and precomputes the pixel coordinates
+        and bilinear interpolation weights needed for grid sampling.
+
+        Args:
+            grid (ttnn.Tensor): Grid tensor of shape (N, H_out, W_out, 2) with normalized coordinates in [-1, 1]
+                               Note: This function only supports unbatched grids (batching factor K=1).
+                               For grid batching (K>1), use ttnn.reshape() to convert the output to
+                               (N, H_out, W_out//K, 6*K) format for use with ttnn.grid_sample().
+            input_shape (List[int]): Input tensor dimensions [N, H_in, W_in, C] in NHWC format
+
+        Keyword Args:
+            mode (str): Nearest or bilinear operation. Currently only "bilinear" is supported.
+            padding_mode (str): How to handle out-of-bounds coordinates. Currently only "zeros" is supported.
+            align_corners (bool): Whether to align corners when sampling (default: false)
+            output_dtype (ttnn.DataType, optional): Data type for the output tensor. Default: bfloat16
+
+        Returns:
+            ttnn.Tensor: Precomputed grid tensor of shape (N, H_out, W_out, 6) where:
+
+                - [:, :, :, 0]: North-west height coordinate (as integer stored in bfloat16)
+                - [:, :, :, 1]: North-west width coordinate (as integer stored in bfloat16)
+                - [:, :, :, 2]: Weight for north-west pixel
+                - [:, :, :, 3]: Weight for north-east pixel
+                - [:, :, :, 4]: Weight for south-west pixel
+                - [:, :, :, 5]: Weight for south-east pixel
+
+        Example:
+            >>> # Create a normalized grid with coordinates in [-1, 1] range
+            >>> torch_grid = torch.randn(1, 8, 8, 2) * 0.8  # Keep within valid range
+            >>> grid = ttnn.from_torch(torch_grid, dtype=ttnn.float32)
+            >>> input_shape = [1, 32, 32, 64]  # N, H, W, C format
+            >>>
+            >>> # Precompute grid for optimized sampling
+            >>> precomputed_grid = ttnn.prepare_grid_sample_grid(
+            ...     grid, input_shape, mode="bilinear", padding_mode="zeros", align_corners=False, output_dtype=ttnn.bfloat16
+            ... )
+            >>> print(precomputed_grid.shape)  # [1, 8, 8, 6]
+            >>>
+            >>> # The output contains:
+            >>> # precomputed_grid[:, :, :, 0] = North-west height coordinates
+            >>> # precomputed_grid[:, :, :, 1] = North-west width coordinates
+            >>> # precomputed_grid[:, :, :, 2] = North-west pixel weight
+            >>> # precomputed_grid[:, :, :, 3] = North-east pixel weight
+            >>> # precomputed_grid[:, :, :, 4] = South-west pixel weight
+            >>> # precomputed_grid[:, :, :, 5] = South-east pixel weight
+            >>>
+            >>> # Use with grid_sample for better performance on repeated operations
+            >>> precomputed_grid_device = ttnn.to_device(precomputed_grid, device)
+            >>> output = ttnn.grid_sample(input_tensor, precomputed_grid_device, use_precomputed_grid=True)
+        )doc");
+}
+
+}  // namespace
+
+void bind_grid_sample(nb::module_& mod) {
+    bind_grid_sample_op(mod);
+    bind_prepare_grid_sample_grid(mod);
+}
+
+}  // namespace ttnn::operations::grid_sample

--- a/tt-metal/ops/grid_sample/grid_sample_nanobind.hpp
+++ b/tt-metal/ops/grid_sample/grid_sample_nanobind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::grid_sample {
+namespace nb = nanobind;
+void bind_grid_sample(nb::module_& mod);
+
+}  // namespace ttnn::operations::grid_sample

--- a/tt-metal/ops/grid_sample/grid_sample_prepare_grid.cpp
+++ b/tt-metal/ops/grid_sample/grid_sample_prepare_grid.cpp
@@ -1,0 +1,245 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt_stl/reflection.hpp>
+#include "grid_sample_prepare_grid.hpp"
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
+#include "ttnn/tensor/host_buffer/functions.hpp"
+#include "tt-metalium/bfloat16.hpp"
+#include "tt-metalium/host_buffer.hpp"
+#include "ttnn/tensor/types.hpp"
+#include <cmath>
+#include <algorithm>
+#include <vector>
+
+namespace ttnn::operations::grid_sample {
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+namespace {
+
+// Unified helper function for grid preprocessing (both nearest and bilinear modes)
+template <typename InputType, typename OutputType>
+tt::tt_metal::HostBuffer create_host_buffer_for_grid_preprocessing(
+    const Tensor& input_tensor,
+    const ttnn::Shape& output_shape,
+    const std::string& mode,
+    bool align_corners,
+    const std::vector<uint32_t>& tensor_input_shape) {
+    auto input_buffer = tt::tt_metal::host_buffer::get_as<InputType>(input_tensor);
+    std::vector<OutputType> output_buffer(output_shape.volume());
+
+    // Extract dimensions
+    uint32_t input_h = tensor_input_shape[1];
+    uint32_t input_w = tensor_input_shape[2];
+
+    // Extract dimensions from grid tensor shape
+    auto grid_shape = input_tensor.logical_shape();
+    uint32_t grid_n = grid_shape[0];
+    uint32_t grid_h = grid_shape[1];
+    uint32_t grid_w = grid_shape[2];
+
+    // Scale factors for coordinate transformation based on align_corners mode
+    float height_scale, height_offset, width_scale, width_offset;
+
+    if (align_corners) {
+        // align_corners=True: maps [-1,1] to [0, size-1]
+        height_scale = (input_h > 1) ? static_cast<float>(input_h - 1) * 0.5f : 0.0f;
+        width_scale = (input_w > 1) ? static_cast<float>(input_w - 1) * 0.5f : 0.0f;
+        height_offset = 0.0f;
+        width_offset = 0.0f;
+    } else {
+        // align_corners=False: maps [-1,1] to [-0.5, size-0.5]
+        height_scale = static_cast<float>(input_h) * 0.5f;
+        width_scale = static_cast<float>(input_w) * 0.5f;
+        height_offset = -0.5f;
+        width_offset = -0.5f;
+    }
+
+    // Process each grid point
+    for (uint32_t n = 0; n < grid_n; n++) {
+        for (uint32_t h = 0; h < grid_h; h++) {
+            for (uint32_t w = 0; w < grid_w; w++) {
+                // Calculate input indices for grid coordinates
+                uint32_t x_idx = (((n * grid_h + h) * grid_w + w) * 2) + 0;  // x coordinate
+                uint32_t y_idx = (((n * grid_h + h) * grid_w + w) * 2) + 1;  // y coordinate
+
+                // Extract normalized coordinates [-1, 1]
+                float x_coord = static_cast<float>(input_buffer[x_idx]);
+                float y_coord = static_cast<float>(input_buffer[y_idx]);
+
+                // Transform to image coordinates - use consistent formula
+                float h_coord_image = ((y_coord + 1.0f) * height_scale) + height_offset;
+                float w_coord_image = ((x_coord + 1.0f) * width_scale) + width_offset;
+
+                if (mode == "nearest") {
+                    // For nearest neighbor: use round() for align_corners=True, floor(coord + 0.5) for
+                    // align_corners=False
+                    int32_t h_nearest, w_nearest;
+                    if (align_corners) {
+                        h_nearest = static_cast<int32_t>(std::round(h_coord_image));
+                        w_nearest = static_cast<int32_t>(std::round(w_coord_image));
+                    } else {
+                        h_nearest = static_cast<int32_t>(std::floor(h_coord_image + 0.5f));
+                        w_nearest = static_cast<int32_t>(std::floor(w_coord_image + 0.5f));
+                    }
+
+                    // Check if coordinates are valid - proper pixel bounds
+                    bool h_valid = (h_nearest >= 0) && (h_nearest < static_cast<int32_t>(input_h));
+                    bool w_valid = (w_nearest >= 0) && (w_nearest < static_cast<int32_t>(input_w));
+
+                    // Calculate output indices for nearest mode (2 values per point)
+                    uint32_t output_base = (((n * grid_h + h) * grid_w + w) * 2);
+
+                    // Store optimized coordinates with validity information
+                    if constexpr (std::is_same_v<OutputType, bfloat16>) {
+                        if (h_valid && w_valid) {
+                            // Store valid coordinates as int16 bit patterns
+                            int16_t h_clamped = static_cast<int16_t>(std::clamp(h_nearest, -32768, 32767));
+                            int16_t w_clamped = static_cast<int16_t>(std::clamp(w_nearest, -32768, 32767));
+
+                            uint16_t h_bits = static_cast<uint16_t>(h_clamped);
+                            uint16_t w_bits = static_cast<uint16_t>(w_clamped);
+
+                            output_buffer[output_base + 0] = std::bit_cast<bfloat16>(h_bits);  // h coordinate
+                            output_buffer[output_base + 1] = std::bit_cast<bfloat16>(w_bits);  // w coordinate
+                        } else {
+                            // Store sentinel value for invalid coordinates (use -1)
+                            uint16_t invalid_sentinel = static_cast<uint16_t>(-1);
+                            output_buffer[output_base + 0] = std::bit_cast<bfloat16>(invalid_sentinel);  // invalid h
+                            output_buffer[output_base + 1] = std::bit_cast<bfloat16>(invalid_sentinel);  // invalid w
+                        }
+                    } else {
+                        if (h_valid && w_valid) {
+                            output_buffer[output_base + 0] = static_cast<OutputType>(h_nearest);  // h coordinate
+                            output_buffer[output_base + 1] = static_cast<OutputType>(w_nearest);  // w coordinate
+                        } else {
+                            // Store sentinel value for invalid coordinates (use -1)
+                            output_buffer[output_base + 0] = static_cast<OutputType>(-1);  // invalid h
+                            output_buffer[output_base + 1] = static_cast<OutputType>(-1);  // invalid w
+                        }
+                    }
+                } else {  // bilinear mode
+                    // Get corner pixel coordinates (floor operation)
+                    int32_t h0 = static_cast<int32_t>(std::floor(h_coord_image));
+                    int32_t w0 = static_cast<int32_t>(std::floor(w_coord_image));
+                    int32_t h1 = h0 + 1;
+                    int32_t w1 = w0 + 1;
+
+                    // Boundary checks
+                    bool h0_valid = (h0 >= 0) && (h0 < static_cast<int32_t>(input_h));
+                    bool h1_valid = (h1 >= 0) && (h1 < static_cast<int32_t>(input_h));
+                    bool w0_valid = (w0 >= 0) && (w0 < static_cast<int32_t>(input_w));
+                    bool w1_valid = (w1 >= 0) && (w1 < static_cast<int32_t>(input_w));
+
+                    // Calculate interpolation weights
+                    float h_frac = h_coord_image - static_cast<float>(h0);
+                    float w_frac = w_coord_image - static_cast<float>(w0);
+                    float h_frac_inv = 1.0f - h_frac;
+                    float w_frac_inv = 1.0f - w_frac;
+
+                    // Compute bilinear weights with boundary conditions
+                    float weight_nw = (h0_valid && w0_valid) ? h_frac_inv * w_frac_inv : 0.0f;
+                    float weight_ne = (h0_valid && w1_valid) ? h_frac_inv * w_frac : 0.0f;
+                    float weight_sw = (h1_valid && w0_valid) ? h_frac * w_frac_inv : 0.0f;
+                    float weight_se = (h1_valid && w1_valid) ? h_frac * w_frac : 0.0f;
+
+                    // Clamp coordinates to 16-bit range for storing as bfloat16
+                    int16_t h0_clamped = static_cast<int16_t>(std::clamp(h0, -32768, 32767));
+                    int16_t w0_clamped = static_cast<int16_t>(std::clamp(w0, -32768, 32767));
+
+                    // Calculate output indices for bilinear mode (6 values per point)
+                    uint32_t base_idx = ((n * grid_h + h) * grid_w + w) * 6;
+
+                    // Store results
+                    if constexpr (std::is_same_v<OutputType, bfloat16>) {
+                        // Reinterpret int16 bits as bfloat16 for coordinates
+                        uint16_t h0_bits = static_cast<uint16_t>(h0_clamped);
+                        uint16_t w0_bits = static_cast<uint16_t>(w0_clamped);
+                        output_buffer[base_idx + 0] = std::bit_cast<bfloat16>(h0_bits);
+                        output_buffer[base_idx + 1] = std::bit_cast<bfloat16>(w0_bits);
+                        // Convert weights to bfloat16
+                        output_buffer[base_idx + 2] = bfloat16(weight_nw);
+                        output_buffer[base_idx + 3] = bfloat16(weight_ne);
+                        output_buffer[base_idx + 4] = bfloat16(weight_sw);
+                        output_buffer[base_idx + 5] = bfloat16(weight_se);
+                    }
+                }
+            }
+        }
+    }
+
+    return tt::tt_metal::HostBuffer(std::move(output_buffer));
+}
+
+// Template function to convert tensor based on input and output types
+template <typename InputType, typename OutputType>
+Tensor convert_grid_tensor(
+    const Tensor& input_tensor,
+    const std::string& mode,
+    bool align_corners,
+    const ttnn::Shape& output_shape,
+    const std::vector<uint32_t>& tensor_input_shape,
+    DataType output_dtype) {
+    auto compute = [&](const tt::tt_metal::HostBuffer& /*input_host_buffer*/) {
+        return create_host_buffer_for_grid_preprocessing<InputType, OutputType>(
+            input_tensor, output_shape, mode, align_corners, tensor_input_shape);
+    };
+
+    const TensorSpec output_spec(
+        output_shape,
+        tt::tt_metal::TensorLayout(output_dtype, tt::tt_metal::PageConfig(Layout::ROW_MAJOR), MemoryConfig{}));
+
+    TT_FATAL(is_cpu_tensor(input_tensor), "Prepare_grid_sample_grid only supports host tensors");
+
+    auto transformed_buffer = input_tensor.host_storage().buffer().transform(
+        compute, tt::tt_metal::DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
+    return Tensor(tt::tt_metal::HostTensor::from_buffer(
+        std::move(transformed_buffer), output_spec, input_tensor.tensor_topology()));
+}
+
+}  // anonymous namespace
+
+ttnn::Tensor prepare_grid_sample_grid(
+    const ttnn::Tensor& grid,
+    const std::vector<uint32_t>& input_shape,
+    const std::string& mode,
+    const std::string& padding_mode,
+    bool align_corners,
+    const std::optional<DataType>& output_dtype) {
+    // Validate inputs
+    TT_FATAL(is_cpu_tensor(grid), "Grid tensor must be on host");
+    TT_FATAL(grid.layout() == Layout::ROW_MAJOR, "Grid tensor must be in row major layout");
+    TT_FATAL(grid.logical_shape().rank() == 4, "Grid tensor must be 4D");
+    TT_FATAL(grid.logical_shape()[-1] == 2, "Grid tensor last dimension must be 2 (x, y coordinates)");
+    TT_FATAL(padding_mode == "zeros", "Currently only 'zeros' padding mode is supported");
+    TT_FATAL(input_shape.size() == 4, "Input shape must have 4 dimensions [N, H, W, C]");
+    TT_FATAL(
+        output_dtype == DataType::BFLOAT16 || !output_dtype.has_value(),
+        "Currently only BFLOAT16 is supported for the grid output dtype");
+
+    // Determine output data type
+    DataType out_dtype = output_dtype.value_or(DataType::BFLOAT16);
+
+    // Validate input grid data type
+    TT_FATAL(grid.dtype() == DataType::FLOAT32, "Currently only float32 input grid is supported");
+
+    // Calculate output shape: (N, H_out, W_out, 6) for bilinear, (N, H_out, W_out, 2) for nearest
+    auto grid_shape = grid.logical_shape();
+    uint32_t elements_per_point = (mode == "nearest") ? 2 : 6;
+    ttnn::Shape output_shape({grid_shape[0], grid_shape[1], grid_shape[2], elements_per_point});
+
+    // Dispatch based on output data type
+    switch (out_dtype) {
+        case DataType::BFLOAT16:
+            return convert_grid_tensor<float, bfloat16>(
+                grid, mode, align_corners, output_shape, input_shape, out_dtype);
+        default: TT_THROW("Unsupported output data type for prepare_grid_sample_grid: {}", out_dtype);
+    }
+}
+
+}  // namespace ttnn::operations::grid_sample

--- a/tt-metal/ops/grid_sample/grid_sample_prepare_grid.hpp
+++ b/tt-metal/ops/grid_sample/grid_sample_prepare_grid.hpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+#include <vector>
+#include <optional>
+
+namespace ttnn::operations::grid_sample {
+
+/**
+ * Precomputes grid sample data for optimized kernel execution.
+ *
+ * This function takes a normalized grid tensor and precomputes the pixel coordinates
+ * and bilinear interpolation weights needed for grid sampling. This preprocessing
+ * allows for more efficient kernel execution by avoiding repeated coordinate
+ * transformations during the actual sampling operation.
+ *
+ * @param grid Grid tensor of shape (N, H_out, W_out, 2) with normalized coordinates in [-1, 1]
+ * @param input_shape Array containing input tensor dimensions [N, H_in, W_in, C] in NHWC format
+ * @param mode Nearest or bilinear operation
+ * @param padding_mode How to handle out-of-bounds coordinates (currently only "zeros" supported)
+ * @param align_corners Whether to align corners when sampling (default: false)
+ * @param output_dtype Data type for the output tensor (default: bfloat16)
+ *
+ * @return Precomputed grid tensor of shape (N, H_out, W_out, 6) where:
+ *         - [:, :, :, 0]: North-west height coordinate (as integer stored in bfloat16)
+ *         - [:, :, :, 1]: North-west width coordinate (as integer stored in bfloat16)
+ *         - [:, :, :, 2]: Weight for north-west pixel
+ *         - [:, :, :, 3]: Weight for north-east pixel
+ *         - [:, :, :, 4]: Weight for south-west pixel
+ *         - [:, :, :, 5]: Weight for south-east pixel
+ *
+ * The function expects the input grid to be on host with float32 data type and
+ * returns a tensor on host with the specified output data type.
+ */
+ttnn::Tensor prepare_grid_sample_grid(
+    const ttnn::Tensor& grid,
+    const std::vector<uint32_t>& input_shape,
+    const std::string& mode = "bilinear",
+    const std::string& padding_mode = "zeros",
+    bool align_corners = false,
+    const std::optional<DataType>& output_dtype = std::nullopt);
+
+}  // namespace ttnn::operations::grid_sample

--- a/tt-metal/ops/grouped_weighted_sum/device/kernels/compute/compute_grouped_weighted_sum.cpp
+++ b/tt-metal/ops/grouped_weighted_sum/device/kernels/compute/compute_grouped_weighted_sum.cpp
@@ -26,28 +26,35 @@ void kernel_main() {
     uint32_t total_clp   = get_arg_val<uint32_t>(2);
 
     if constexpr (RM_MODE) {
-        // Initialize tilize pipeline first
+        // Configure BOTH pipelines up front. The loop below alternates between tilize and
+        // bcast, and without this the first iteration ran the bcast half with whatever the
+        // PREVIOUSLY EXECUTED OP left in the unpacker/packer config. That made gws correct
+        // on every repeat call but wrong on the first call after any other op had run —
+        // silently, and only in RM_MODE. See debug/verify_gws_determinism.py.
+        binary_op_init_common(tile_cb, wt_cb, out_cb);
+        mul_bcast_cols_init_short(tile_cb, wt_cb);
         tilize_init(feat_cb, G, tile_cb);
 
         for (uint32_t wu = 0; wu < num_wus; wu++) {
             cb_reserve_back(out_cb, G);
 
             for (uint32_t clp = 0; clp < chunk_size; clp++) {
-                // 1. Tilize RM→TILE
+                // 1. Tilize RM→TILE.
                 // L1 accumulate must be OFF here: tile_cb is only G pages deep, so every
                 // iteration packs to the same L1 address. With acc still enabled from the
                 // previous iteration's output pack, the tilized features would be summed
                 // into the previous iteration's, making clp i contribute i times.
                 pack_reconfig_l1_acc(0);
+                tilize_init(feat_cb, G, tile_cb);
                 cb_wait_front(feat_cb, G);  // G pages = 16KB of RM data
                 cb_reserve_back(tile_cb, G);
                 tilize_block(feat_cb, G, tile_cb);
                 cb_push_back(tile_cb, G);
                 cb_pop_front(feat_cb, G);
 
-                // 2. Switch to bcast mode
+                // 2. Switch back to bcast. Only the short init is needed: the full
+                // hw configure was already done once before the loop.
                 tilize_uninit(feat_cb, tile_cb);
-                binary_op_init_common(tile_cb, wt_cb, out_cb);
                 mul_bcast_cols_init_short(tile_cb, wt_cb);
 
                 // 3. Multiply + accumulate
@@ -66,9 +73,6 @@ void kernel_main() {
 
                 cb_pop_front(tile_cb, G);
                 cb_pop_front(wt_cb, G);
-
-                // 4. Switch back to tilize for next CLP
-                tilize_init(feat_cb, G, tile_cb);
             }
 
             pack_reconfig_l1_acc(0);

--- a/tt-metal/ops/grouped_weighted_sum/device/kernels/dataflow/reader_grouped_weighted_sum.cpp
+++ b/tt-metal/ops/grouped_weighted_sum/device/kernels/dataflow/reader_grouped_weighted_sum.cpp
@@ -43,6 +43,20 @@ void kernel_main() {
     constexpr uint32_t feat_tpb = N_TR * FEAT_TC;  // tiles per batch (TILE mode only)
     constexpr uint32_t wt_tpb = N_TR;
 
+    // The last tile row covers anchors past the end of the tensor (900..927 of 928), which
+    // the loop below never reads. tilize still consumes all 32 rows, so zero the buffer once
+    // here rather than leaving stale L1: those rows are sliced off the output, but they must
+    // not be able to carry a NaN into the accumulation. Once is enough — nothing ever writes
+    // to the tail sticks, so they stay zero for the life of the kernel. Doing this per
+    // iteration instead cost 3.4 ms/frame, since it re-zeroed the same addresses 78 times.
+    if constexpr (RM_MODE) {
+        volatile tt_l1_ptr uint32_t* z =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(feat_cb));
+        for (uint32_t i = 0; i < (NUM_GROUPS * 2 * feat_page_bytes) / 4; i++) {
+            z[i] = 0;
+        }
+    }
+
     for (uint32_t wu = 0; wu < num_wus; wu++) {
         uint32_t wu_id = start_wu + wu;
         uint32_t n_tr = wu_id % N_TR_TOTAL;

--- a/tt-metal/ops/transposed_s2i/device/kernels/dataflow/transposed_s2i.cpp
+++ b/tt-metal/ops/transposed_s2i/device/kernels/dataflow/transposed_s2i.cpp
@@ -9,6 +9,24 @@
 #include "api/compile_time_args.h"
 #include "api/dataflow/dataflow_api.h"
 
+// The index accessor's compile-time args only EXIST when index-driven mode is on, so
+// this has to be a template: `if constexpr` inside kernel_main() would not discard the
+// branch (kernel_main is not a template) and TensorAccessorArgs<OFF> would still be
+// instantiated past the end of the arg list.
+template <bool USE_INDEX, uint32_t OFF, uint32_t IDX_CB, uint32_t IDX_COUNT>
+FORCE_INLINE volatile tt_l1_ptr uint32_t* load_index(uint32_t idx_addr) {
+    if constexpr (USE_INDEX) {
+        constexpr auto idx_ta = TensorAccessorArgs<OFF>();
+        const auto idx_acc = TensorAccessor(idx_ta, idx_addr, IDX_COUNT * 4);
+        const uint32_t idx_l1 = get_write_ptr(IDX_CB);
+        noc_async_read(idx_acc.get_noc_addr(0), idx_l1, IDX_COUNT * 4);
+        noc_async_read_barrier();
+        return reinterpret_cast<volatile tt_l1_ptr uint32_t*>(idx_l1);
+    } else {
+        return nullptr;
+    }
+}
+
 void kernel_main() {
     uint32_t out_addr       = get_arg_val<uint32_t>(0);
     uint32_t num_sticks     = get_arg_val<uint32_t>(1);
@@ -21,10 +39,22 @@ void kernel_main() {
     constexpr uint32_t NC         = get_compile_time_arg_val(3);  // 3
     constexpr uint32_t NL         = get_compile_time_arg_val(4);  // 4
     constexpr uint32_t LEVEL      = get_compile_time_arg_val(5);  // 0-3
+    // Index-driven mode: the input rows are a COMPACTED grid, so a stick's
+    // (camera, anchor) can no longer be derived from its position — it comes from
+    // idx[]. SENTINEL rows are capacity padding and must not be scattered, or they
+    // would overwrite live anchors with stale samples.
+    constexpr uint32_t USE_INDEX  = get_compile_time_arg_val(6);
+    constexpr uint32_t IDX_CB     = get_compile_time_arg_val(7);
+    constexpr uint32_t IDX_COUNT  = get_compile_time_arg_val(8);
+    constexpr uint32_t SENTINEL   = 0xFFFFFFFFu;
 
-    constexpr uint32_t TA_OFFSET = 6;
+    constexpr uint32_t TA_OFFSET = 9;
     constexpr auto out_ta = TensorAccessorArgs<TA_OFFSET>();
     const auto out_acc = TensorAccessor(out_ta, out_addr, stick_size);
+
+    volatile tt_l1_ptr uint32_t* idx =
+        load_index<USE_INDEX != 0, out_ta.next_compile_time_args_offset(), IDX_CB, IDX_COUNT>(
+            get_arg_val<uint32_t>(4));
 
     // Input stick ordering: cam0_anc0_pt0..pt12, cam0_anc1_pt0..., cam1_anc0_pt0...
     // Global stick i → cam = i / (N*K), anchor = (i % (N*K)) / K, pt = i % K
@@ -33,10 +63,21 @@ void kernel_main() {
 
     for (uint32_t s = 0; s < num_sticks; s++) {
         uint32_t global_stick = stick_offset + s;
-        uint32_t cam = global_stick / (N * K);
-        uint32_t rem = global_stick % (N * K);
-        uint32_t anchor = rem / K;
-        uint32_t pt = rem % K;
+        uint32_t cam, anchor, pt;
+        if constexpr (USE_INDEX) {
+            pt = global_stick % K;
+            const uint32_t src_row = idx[global_stick / K];
+            if (src_row == SENTINEL) {
+                continue;  // capacity padding: no anchor owns this sample
+            }
+            cam = src_row / N;
+            anchor = src_row % N;
+        } else {
+            cam = global_stick / (N * K);
+            const uint32_t rem = global_stick % (N * K);
+            anchor = rem / K;
+            pt = rem % K;
+        }
 
         uint32_t clp = cam * NL * K + LEVEL * K + pt;
         uint32_t page_id = clp * N + anchor;

--- a/tt-metal/ops/transposed_s2i/device/transposed_s2i_device_operation.cpp
+++ b/tt-metal/ops/transposed_s2i/device/transposed_s2i_device_operation.cpp
@@ -35,16 +35,18 @@ Tensor TransposedS2iOperation::create_output_tensors(
 void transposed_s2i(
     const Tensor& input, Tensor& output,
     uint32_t num_cams, uint32_t num_pts, uint32_t num_anchors,
-    uint32_t num_levels, uint32_t level) {
+    uint32_t num_levels, uint32_t level,
+    const std::optional<Tensor>& index, uint32_t capacity) {
     using Op = TransposedS2iOperation;
     ttnn::device_operation::launch<Op>(
         Op::operation_attributes_t{
             .num_cams = num_cams, .num_pts = num_pts,
             .num_anchors = num_anchors, .num_levels = num_levels,
             .level = level,
+            .capacity = capacity,
             .output_mem_config = output.memory_config(),
         },
-        Op::tensor_args_t{.input = input, .output = output});
+        Op::tensor_args_t{.input = input, .output = output, .index = index});
 }
 
 }  // namespace ttnn::prim

--- a/tt-metal/ops/transposed_s2i/device/transposed_s2i_device_operation.hpp
+++ b/tt-metal/ops/transposed_s2i/device/transposed_s2i_device_operation.hpp
@@ -32,6 +32,8 @@ void transposed_s2i(
     const tt::tt_metal::Tensor& input,
     tt::tt_metal::Tensor& output,
     uint32_t num_cams, uint32_t num_pts, uint32_t num_anchors,
-    uint32_t num_levels, uint32_t level);
+    uint32_t num_levels, uint32_t level,
+    const std::optional<tt::tt_metal::Tensor>& index = std::nullopt,
+    uint32_t capacity = 0);
 
 }  // namespace ttnn::prim

--- a/tt-metal/ops/transposed_s2i/device/transposed_s2i_device_operation_types.hpp
+++ b/tt-metal/ops/transposed_s2i/device/transposed_s2i_device_operation_types.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 #include <tt-metalium/constants.hpp>
+#include <optional>
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
@@ -14,12 +15,14 @@ struct TransposedS2iParams {
     uint32_t num_anchors;   // N
     uint32_t num_levels;    // NL
     uint32_t level;         // current level index
+    uint32_t capacity;      // compacted rows per camera; 0 = dense (no index)
     tt::tt_metal::MemoryConfig output_mem_config;
 };
 
 struct TransposedS2iInputs {
     const tt::tt_metal::Tensor& input;   // L1 HEIGHT_SHARDED [nc, N, K, C]
     const tt::tt_metal::Tensor& output;  // pre-allocated DRAM [CLP, N, C]
+    std::optional<tt::tt_metal::Tensor> index;  // compacted-row -> source row
 };
 
 }  // namespace ttnn::prim

--- a/tt-metal/ops/transposed_s2i/device/transposed_s2i_program_factory.cpp
+++ b/tt-metal/ops/transposed_s2i/device/transposed_s2i_program_factory.cpp
@@ -36,7 +36,20 @@ TransposedS2iProgramFactory::cached_program_t TransposedS2iProgramFactory::creat
     auto logical_cores = corerange_to_cores(core_range, std::nullopt, true);
     const uint32_t num_cores = logical_cores.size();
 
-    const uint32_t total_sticks = NC * N * K;
+    // With an index, `capacity` is the TOTAL number of compacted rows, not a per-camera
+    // count: a pooled compaction has no per-camera structure left to multiply by.
+    const bool use_index = t.index.has_value();
+    const uint32_t total_rows = use_index ? attrs.capacity : NC * N;
+    const uint32_t total_sticks = total_rows * K;
+    const uint32_t idx_count = total_rows;
+
+    constexpr uint32_t IDX_CB = tt::CBIndex::c_0;
+    if (use_index) {
+        const uint32_t idx_bytes = idx_count * sizeof(uint32_t);
+        auto idx_cb_cfg = CircularBufferConfig(idx_bytes, {{IDX_CB, DataFormat::UInt32}})
+                              .set_page_size(IDX_CB, idx_bytes);
+        CreateCircularBuffer(program, core_range, idx_cb_cfg);
+    }
 
     // Compile-time args
     std::vector<uint32_t> ct_args = {
@@ -46,8 +59,14 @@ TransposedS2iProgramFactory::cached_program_t TransposedS2iProgramFactory::creat
         NC,                 // 3
         attrs.num_levels,   // 4: NL
         attrs.level,        // 5: LEVEL
+        use_index ? 1u : 0u,// 6
+        IDX_CB,             // 7
+        idx_count,          // 8
     };
     TensorAccessorArgs(*output_tensor.buffer()).append_to(ct_args);
+    if (use_index) {
+        TensorAccessorArgs(*t.index->buffer()).append_to(ct_args);
+    }
 
     KernelHandle kernel_id = CreateKernel(
         program,
@@ -67,7 +86,8 @@ TransposedS2iProgramFactory::cached_program_t TransposedS2iProgramFactory::creat
             output_tensor.buffer()->address(),
             sticks_this_core,
             stick_offset,
-            in_buffer.address()});
+            in_buffer.address(),
+            use_index ? t.index->buffer()->address() : 0u});
         stick_offset += shard_h;
     }
 
@@ -91,6 +111,9 @@ void TransposedS2iProgramFactory::override_runtime_arguments(
         auto& r = GetRuntimeArgs(prog, sv.kernel_id, sv.logical_cores[i]);
         r[0] = output_tensor.buffer()->address();
         r[3] = t.input.buffer()->address();
+        if (t.index.has_value()) {
+            r[4] = t.index->buffer()->address();
+        }
     }
 }
 

--- a/tt-metal/ops/transposed_s2i/transposed_s2i.cpp
+++ b/tt-metal/ops/transposed_s2i/transposed_s2i.cpp
@@ -9,8 +9,9 @@ namespace ttnn::operations::transposed_s2i {
 void transposed_s2i(
     const tt::tt_metal::Tensor& input, tt::tt_metal::Tensor& output,
     uint32_t num_cams, uint32_t num_pts, uint32_t num_anchors,
-    uint32_t num_levels, uint32_t level) {
-    ttnn::prim::transposed_s2i(input, output, num_cams, num_pts, num_anchors, num_levels, level);
+    uint32_t num_levels, uint32_t level,
+    const std::optional<tt::tt_metal::Tensor>& index, uint32_t capacity) {
+    ttnn::prim::transposed_s2i(input, output, num_cams, num_pts, num_anchors, num_levels, level, index, capacity);
 }
 
 }  // namespace ttnn::operations::transposed_s2i

--- a/tt-metal/ops/transposed_s2i/transposed_s2i.hpp
+++ b/tt-metal/ops/transposed_s2i/transposed_s2i.hpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <optional>
 #include "ttnn/types.hpp"
 
 namespace ttnn {
@@ -10,7 +11,9 @@ namespace operations::transposed_s2i {
 void transposed_s2i(
     const ttnn::Tensor& input, ttnn::Tensor& output,
     uint32_t num_cams, uint32_t num_pts, uint32_t num_anchors,
-    uint32_t num_levels, uint32_t level);
+    uint32_t num_levels, uint32_t level,
+    const std::optional<ttnn::Tensor>& index = std::nullopt,
+    uint32_t capacity = 0);
 
 }  // namespace operations::transposed_s2i
 using ttnn::operations::transposed_s2i::transposed_s2i;

--- a/tt-metal/ops/transposed_s2i/transposed_s2i_nanobind.cpp
+++ b/tt-metal/ops/transposed_s2i/transposed_s2i_nanobind.cpp
@@ -16,7 +16,8 @@ void bind_transposed_s2i(nb::module_& mod) {
         &ttnn::transposed_s2i,
         nb::arg("input"), nb::arg("output"),
         nb::arg("num_cams"), nb::arg("num_pts"), nb::arg("num_anchors"),
-        nb::arg("num_levels"), nb::arg("level"));
+        nb::arg("num_levels"), nb::arg("level"),
+        nb::arg("index") = std::nullopt, nb::arg("capacity") = 0);
 }
 
 }  // namespace ttnn::operations::transposed_s2i


### PR DESCRIPTION
## Summary
**Performance**
- row-major image upload / input path to `row_major`
- drop useless `to_layout` before `grouped_weighted_sum`
- upload image as 1KB pages instead of 8B rows
- pooled OOB compaction in DFA

**Features**
- `transposed_s2i` index-driven scatter
- `grid_compact` op
- `grid_sample` optional `batch_index`

**Fixes**
- `gws` RM_MODE
- `grid_sample` padding clamp used the input batch, not the grid's
- scale the compaction budget with the camera count

**Docs**
- install steps for `grid_compact` & `grid_sample` patch
- README v2 update
- corrected claims contradicted by measurement

Related #12
