### PR TITLE
perf/fix: compact DFA attention-weight layout + fixed-point grid, rebalance precision hotspots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ debug/
 # AI
 .claude/
 logs/
+*.swp
+*.swo

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sparse4D on Tenstorrent
 
-Porting the Sparse4D v3 3D object detection model to Tenstorrent devices (Wormhole/Blackhole).
+Sparse4D v3 3D object detection, ported to Tenstorrent (Wormhole/Blackhole).
 
 ## Overview
 
@@ -18,61 +18,73 @@ Porting the Sparse4D v3 3D object detection model to Tenstorrent devices (Wormho
 
 ### Speed
 
-|  | PyTorch | TT-NN Pure (N300) | ~~Custom Kernels v1~~ | **Custom Kernels v2 (N300)** |
-| :--- | :---: | :---: | :---: | :---: |
-| **Latency / sample** | ~95 ms | 235 ms | ~~122 ms~~ | **95.2 ms** |
-| **FPS** | 10.5 | 4.2 | ~~8.2~~ | **10.51** |
+|  | PyTorch | TT-NN Pure (N300) | ~~v1~~ | ~~v2~~ | **Custom Kernels v3 (N300)** |
+| :--- | :---: | :---: | :---: | :---: | :---: |
+| **Latency / sample** | ~95 ms | 235 ms | ~~122 ms~~ | ~~95.2 ms~~ | **90.7 ms** |
+| **FPS** | 10.5 | 4.2 | ~~8.2~~ | ~~10.51~~ | **11.02** |
 
-Latency is `model.forward` on one 6-camera sample, median of 20 frames after warmup.
-At 95.2 ms the accelerator matches the CUDA reference on this model.
+- Metric: `model.forward` on one 6-camera sample
+- v3: median of 200 frames in scene order after 20 warmup — mean 90.8, p90 91.2
+- Scene choice matters: anchors surviving the OOB compaction vary by scene, and one scene
+  replayed reads 99.9 ms on the same build
+- v1/v2 were taken on a single scene — history, not a controlled baseline
 
-- **Pure TT-NN**: Standard ttnn ops only, no custom kernel build required. Automatically used as fallback when custom kernels are not built.
-- **Custom Kernels** (recommended): 4 custom Metalium kernels (`kps_project_fused`, `transposed_s2i`, `grouped_weighted_sum`, `grid_compact`) plus a patch to upstream `grid_sample` — see [docs/INSTALL.md](docs/INSTALL.md)
+Build modes:
 
-**What changed in v2.** The three items below were each measured on this machine; the v1
-figure is the previously published one from an earlier state of the tree, so the two
-columns are a before/after, not a controlled A/B of a single change.
+- **Pure TT-NN** — stock ttnn ops only, no custom build; automatic fallback
+- **Custom Kernels** (recommended) — 4 Metalium kernels (`kps_project_fused`,
+  `transposed_s2i`, `grouped_weighted_sum`, `grid_compact`) + a patch to upstream
+  `grid_sample`; see [docs/INSTALL.md](docs/INSTALL.md)
 
-| Change | Measured effect |
-| :--- | :--- |
-| 1 KB upload pages — a ROW_MAJOR row is one page, so 4-channel rows made h2d 540,672 transfers of 8 B against 0.13 ms of actual data | h2d 41.0 -> 0.55 ms |
-| Pooled OOB compaction — drop the anchors that project outside every camera before `grid_sample` sees them, pooling the survivors across cameras so the fixed budget covers the busiest *frame* rather than the busiest *camera* | 103.7 -> 95.2 ms, bit-identical output |
-| `grouped_weighted_sum` RM mode inherited the previous op's compute-pipeline configuration, so it was wrong on its first call after any other op — silently, and only in that mode | mAP 0.3933 -> 0.3968, no speed cost |
+Per-change measurements: **[docs/CHANGELOG.md](docs/CHANGELOG.md)**
 
 ### Accuracy
 
 Full nuScenes val, 6019 samples.
 
-|  | PyTorch (CUDA) | ~~TT-NN v1~~ | **TT-NN v2 (N300)** | Gap (v2) |
+|  | PyTorch (CUDA) | ~~TT-NN v2~~ | **TT-NN v3 (N300)** | Gap (v3) |
 | :--- | :---: | :---: | :---: | :---: |
-| **mAP** | 0.4529 | ~~0.3968~~ | **0.3974** | -0.0555 |
-| **NDS** | 0.5602 | ~~0.5192~~ | **0.5190** | -0.0412 |
-| **mATE** | 0.5455 | ~~0.6163~~ | **0.6173** | +0.0718 |
-| **mASE** | 0.2622 | ~~0.2689~~ | **0.2693** | +0.0071 |
-| **mAOE** | 0.4373 | ~~0.4693~~ | **0.4730** | +0.0357 |
-| **mAVE** | 0.2195 | ~~0.2590~~ | **0.2624** | +0.0429 |
-| **mAAE** | 0.1987 | ~~0.1790~~ | **0.1747** | -0.0240 |
+| **mAP** | 0.4529 | ~~0.3974~~ | **0.4476** | -0.0053 |
+| **NDS** | 0.5602 | ~~0.5190~~ | **0.5534** | -0.0068 |
+| **mATE** | 0.5455 | ~~0.6173~~ | **0.5532** | +0.0077 |
+| **mASE** | 0.2622 | ~~0.2693~~ | **0.2608** | -0.0014 |
+| **mAOE** | 0.4373 | ~~0.4730~~ | **0.4686** | +0.0313 |
+| **mAVE** | 0.2195 | ~~0.2624~~ | **0.2135** | -0.0060 |
+| **mAAE** | 0.1987 | ~~0.1747~~ | **0.2073** | +0.0086 |
 
-v2 is faster *and* slightly more accurate. The gain came from fixing
-`grouped_weighted_sum`, not from tuning: mAP 0.3933 -> 0.3968 for the fix, and a further
-+0.0006 from compaction, which is noise-level and in the favourable direction.
+Comparability:
 
-**On the remaining -0.056 mAP:** it is not bf16 storage. PyTorch bf16 keeps a
-full-precision multiply and accumulates in fp32; two Wormhole settings break both halves
-of that, and both are tunable:
+- Controlled pair either side of the fix — **0.4019 -> 0.4476 mAP**, same checkpoint
+  (`sparse4dv3_r50.pth`), same tree, one changed function
+- v2 column: several changes older, checkpoint not recorded — history
+- PyTorch column: carried from earlier in this file, not re-run here
 
-- **Math fidelity.** The multiplier is physically 5b x 7b, and `MathFidelity` sets how many
-  passes it takes to consume the inputs. At `LoFi` — one pass, and what the backbone and
-  FPN currently use — srcA contributes its hidden bit plus only the top 4 mantissa bits, so
-  a bf16 operand is truncated to 5 of its 8 bits. That is coarser than bf16, not equal to it.
-- **Accumulator width.** With `fp32_dest_acc_en=False` (the default here, everywhere) the
-  FPU accumulates in 16-bit rather than fp32.
+**Root cause — the softmax normalised over the wrong set.**
 
-Measured directly in this project: the same key-point projection written as ttnn
-element-wise ops produced errors quantised to 2^-11 / 2^-10 — the fp16 DEST signature —
-costing 0.042 mAP, while the identical arithmetic in a custom kernel doing fp32 soft-float
-had a maximum error of 5e-8. Input and output dtypes were fp32 in both cases; only the
-accumulator differed.
+- SPMD gives each device 3 of 6 cameras, so its sampling-point axis is 156 of 312
+- `_softmax_clp` built the denominator from its own 156
+- Each device's weights summed to 1 alone — row sums 1.0063 each, 2.01 together
+- So the post-fusion `all_reduce` added two complete distributions
+
+**Fix** — reduce the denominator across devices, and the max shift with it.
+
+- `exp(l - m0)` and `exp(l - m1)` are not summable — both devices must subtract the same
+  constant; any common constant is exact
+- `ttnn.all_reduce` is Sum-only, so it uses the mean of the per-device maxima
+- Both tensors are per-anchor — the collectives cost nothing measurable
+- DFA output PCC 0.9883 -> 0.9999, identical on the pure-TT-NN fallback path
+
+**Correction** — this section previously blamed `MathFidelity` and `fp32_dest_acc_en`. The
+hardware claims were right, the diagnosis was not: all three settings **cost** mAP when
+measured. No precision knob repairs a wrong formula. Figures in
+[docs/CHANGELOG.md](docs/CHANGELOG.md#rejected-by-measurement).
+
+Cleared by measurement, and still clear:
+
+- backbone/FPN 0.9998 vs PyTorch fp32
+- sampling grid 0.999997, sampled features 0.999975
+- compaction mask lossless — 0 of 223,496 zeroed rows has a non-zero feature
+- gws bf16 accumulator 0.99994
 
 ### Inference video
 
@@ -105,9 +117,10 @@ pip install -r Sparse4D-tt/requirement.txt
 
 ### tt-metal Custom Kernel Build
 
-This project uses 4 custom TT-Metal kernels (`kps_project_fused`, `grouped_weighted_sum`, `transposed_s2i`, `grid_compact`) plus one patch to the upstream `grid_sample`, all of which must be built into the tt-metal library.
-
-See **[docs/INSTALL.md](docs/INSTALL.md)** for detailed build instructions.
+- 4 custom kernels — `kps_project_fused`, `grouped_weighted_sum`, `transposed_s2i`,
+  `grid_compact`
+- 1 patch to upstream `grid_sample`
+- All must be built into the tt-metal library — see **[docs/INSTALL.md](docs/INSTALL.md)**
 
 ### Running
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,97 @@
+# Update log
+
+Per-change measurements. Figures are from this machine unless stated otherwise; "no change"
+means measured and found within noise, not unmeasured.
+
+Headline results live in the [README](../README.md); this file records how they were reached.
+
+---
+
+## v3
+
+Full val, 6019 samples, `sparse4dv3_r50.pth`: mAP 0.4019 -> **0.4476**, NDS 0.5186 ->
+**0.5534**, mATE 0.5947 -> **0.5532**. Latency 90.7 ms/sample.
+
+### Accuracy
+
+**`42a847b` — all-reduce the softmax denominator across the mesh**
+
+- SPMD gives each device 3 of 6 cameras, so its sampling-point axis is 156 of 312, and
+  `_softmax_clp` built the denominator from its own 156
+- Each device's weights summed to 1 alone (row sums 1.0063 each, 2.01 together), so the
+  post-fusion `all_reduce` added two complete distributions
+- Fix reduces the denominator across devices **and** the max shift with it — `exp(l - m0)`
+  and `exp(l - m1)` are not summable, so both devices must subtract the same constant.
+  `ttnn.all_reduce` is Sum-only, so it uses the mean of the per-device maxima; any common
+  constant is exact
+- **mAP 0.4019 -> 0.4476**, DFA output PCC 0.9883 -> 0.9999, no measurable speed cost
+- Verified identical on the pure-TT-NN fallback path (`TT_WT_COMPACT=0`)
+
+**`8ba12e4` — keep the projection matrix in fp32**
+
+- The cache did `pad -> typecast(float32) -> slice` with the typecast **last**, so pages
+  said fp32 while the values had already been rounded to bf16
+- Matrix entries reach 667, where bf16 leaves 1.3 of absolute error, and the kernel divides
+  by depth — the largest single term in the grid's disagreement with PyTorch
+- Sampling grid error **0.179 -> 0.035 px** (level 0)
+- **mAP unchanged** (0.4023 -> 0.4019, noise). The sampling path was already PCC 0.99998, so
+  the correctness matters but the accuracy did not move
+- Only the camera encoder keeps a bf16 view — a matmul chain that never reaches a pixel
+
+**`33778e7` — widen the anchor accumulator to fp32**
+
+- The anchor is a residual stream (`anchor + delta` at every layer), so it accumulates
+  absolute error; bf16 gives constant *relative* error
+- mAP 0.4008 -> 0.4023
+- Weight upload moved to host-side bf16 in the same commit: bit-identical, -0.15 ms/frame,
+  -53 ms startup
+
+**`ca4f025` — scale the compaction budget with the camera count**
+
+**`d5b833a` — grid_sample padding clamp used the input batch, not the grid's**
+
+### Speed
+
+**`93f3f3f` — parallelise `grid_compact`, store the grid as Q14 fixed point**
+
+- Was 1 core. Split across 63: each core tests its own row slice, writes one mask byte per
+  row, relays its block to core 0 over the NOC and bumps a semaphore; core 0 walks the mask
+  and emits the kept rows
+- **762.9 -> 189.8 us/call, 4.58 -> 1.14 ms/frame**, bit-identical on 10 cases
+- Grid stored Q14 in a `UINT16` container: coordinates are clamped to [-2, 2], so bf16 spent
+  an exponent on a range that never varies. mAP 0.4000 -> 0.4008
+
+**`284f1d7` — keep the attention weights in the compact `[N, CLP*G]` layout**
+
+- The linear already produces that layout; it was being reshaped and transposed into
+  `[N, CLP, G]` for the softmax and the fusion
+- ReshapeView 11.84 -> 8.39, Transpose 1.90 -> 0.10, Softmax 0.83 -> 0.00 ms/frame
+- Net **-4.39 ms/frame**
+
+### Rejected by measurement
+
+Recorded so they are not retried. Baseline mAP 0.4311, 1500 val samples.
+
+| Setting | Effect on mAP |
+| :--- | :---: |
+| `MathFidelity.HiFi2` | -0.024 |
+| `fp32_dest_acc_en=True` | -0.005 |
+| `HiFi4` + `fp32_dest_acc_en=True` | -0.009 |
+
+- All three raise mAOE while lowering mAP
+- The earlier diagnosis that the accuracy gap came from math fidelity and accumulator width
+  was wrong: no precision knob repairs a wrong formula
+- Simulating "every intermediate is bf16" in PyTorch (`TorchFunctionMode`) reaches PCC
+  0.9928 against the 0.907 that needed explaining — bf16 storage was never the cause
+
+---
+
+## v2
+
+Full val: mAP 0.3974, NDS 0.5190. Latency 95.2 ms/sample (single scene).
+
+| Change | Measured effect |
+| :--- | :--- |
+| **`74b1c7e`** 1 KB upload pages — a ROW_MAJOR row is one page, so 4-channel rows made h2d 540,672 transfers of 8 B against 0.13 ms of actual data | h2d 41.0 -> 0.55 ms |
+| **`199c2f7`** Pooled OOB compaction — drop anchors that project outside every camera before `grid_sample` sees them, pooling survivors across cameras so the fixed budget covers the busiest *frame* rather than the busiest *camera* | 103.7 -> 95.2 ms, bit-identical |
+| **`659e356`** `grouped_weighted_sum` RM mode inherited the previous op's compute-pipeline configuration, so it was wrong on its first call after any other op — silently, and only in that mode | mAP 0.3933 -> 0.3968, no speed cost |

--- a/model/asymmetric_ffn.py
+++ b/model/asymmetric_ffn.py
@@ -85,7 +85,7 @@ class AsymmetricFFN:
         kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
         if self._mesh_device is not None:
             kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
-        return ttnn.from_torch(tensor.float(), **kwargs)
+        return ttnn.from_torch(tensor.bfloat16(), **kwargs)
 
     def _to_device_bias(self, tensor: torch.Tensor) -> ttnn.Tensor:
         if tensor.dim() == 1:
@@ -93,7 +93,7 @@ class AsymmetricFFN:
         kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
         if self._mesh_device is not None:
             kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
-        return ttnn.from_torch(tensor.float(), **kwargs)
+        return ttnn.from_torch(tensor.bfloat16(), **kwargs)
 
     def _to_device_1d(self, tensor: torch.Tensor) -> ttnn.Tensor:
         if tensor.dim() == 1:
@@ -101,7 +101,7 @@ class AsymmetricFFN:
         kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
         if self._mesh_device is not None:
             kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
-        return ttnn.from_torch(tensor.float(), **kwargs)
+        return ttnn.from_torch(tensor.bfloat16(), **kwargs)
 
     def run(
         self,

--- a/model/deformable_feature_aggregation.py
+++ b/model/deformable_feature_aggregation.py
@@ -503,6 +503,10 @@ class DeformableFeatureAggregation:
             camera_embed: [bs, num_cams, 256] on device (TILE)
         """
         # Extract first 3 rows of 4x4: [bs, num_cams, 3, 4] -> [bs, num_cams, 12]
+        # The matrix is fp32 for the projection kernel's sake; this path is a matmul chain
+        # whose error never reaches a pixel, so it takes the bf16 view.
+        if projection_mat.dtype != ttnn.bfloat16:
+            projection_mat = ttnn.typecast(projection_mat, ttnn.bfloat16)
         cam_input = ttnn.slice(projection_mat, [0, 0, 0, 0], [bs, self.num_cams, 3, 4])
         cam_input = ttnn.reshape(cam_input, (1, 1, bs * self.num_cams, 12))
 
@@ -820,6 +824,10 @@ class DeformableFeatureAggregation:
             camera_embed: [bs, num_cams, 256] on device (TILE)
         """
         # Extract first 3 rows of 4x4: [bs, num_cams, 3, 4] -> [bs, num_cams, 12]
+        # The matrix is fp32 for the projection kernel's sake; this path is a matmul chain
+        # whose error never reaches a pixel, so it takes the bf16 view.
+        if projection_mat.dtype != ttnn.bfloat16:
+            projection_mat = ttnn.typecast(projection_mat, ttnn.bfloat16)
         cam_input = ttnn.slice(projection_mat, [0, 0, 0, 0], [bs, self.num_cams, 3, 4])
         cam_input = ttnn.reshape(cam_input, (1, 1, bs * self.num_cams, 12))
 

--- a/model/deformable_feature_aggregation.py
+++ b/model/deformable_feature_aggregation.py
@@ -312,7 +312,7 @@ class DeformableFeatureAggregation:
         kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
         if self._mesh_device is not None:
             kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
-        return ttnn.from_torch(tensor.float(), **kwargs)
+        return ttnn.from_torch(tensor.bfloat16(), **kwargs)
 
     def _to_device_bias(self, tensor: torch.Tensor) -> ttnn.Tensor:
         """Move bias tensor to device as [1, 1, 1, N] in TILE layout."""
@@ -321,7 +321,7 @@ class DeformableFeatureAggregation:
         kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
         if self._mesh_device is not None:
             kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
-        return ttnn.from_torch(tensor.float(), **kwargs)
+        return ttnn.from_torch(tensor.bfloat16(), **kwargs)
 
     def _to_device_1d(self, tensor: torch.Tensor) -> ttnn.Tensor:
         """Move 1D tensor (LayerNorm weight/bias) to device as [1, 1, 1, N]."""
@@ -330,7 +330,7 @@ class DeformableFeatureAggregation:
         kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
         if self._mesh_device is not None:
             kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
-        return ttnn.from_torch(tensor.float(), **kwargs)
+        return ttnn.from_torch(tensor.bfloat16(), **kwargs)
 
 
     # === Fallback methods (pure ttnn ops, no custom kernels) ===

--- a/model/deformable_feature_aggregation.py
+++ b/model/deformable_feature_aggregation.py
@@ -892,9 +892,12 @@ class DeformableFeatureAggregation:
             # Rows past a camera's kept count are never written, so seed them far out
             # of bounds: grid_sample still samples them (their index entry is SENTINEL,
             # so transposed_s2i discards the result) and must not read a stale NaN.
+            # Q14 fixed point in a uint16 container, matching kps_project_fused. The seed
+            # is the saturated value, which decodes to just under 2.0 — far outside the
+            # bounds test, so a slot that is never written can only ever be discarded.
             self._cgrid = ttnn.from_torch(
-                torch.full((1, self._oob_cap, 1, self.num_pts * 2), 9.0),
-                dtype=ttnn.float32, **_kw,
+                torch.full((1, self._oob_cap, 1, self.num_pts * 2), 32767, dtype=torch.int32),
+                dtype=ttnn.uint16, **_kw,
             )
             self._cindex = ttnn.from_torch(
                 torch.zeros(1, 1, 1, self._oob_cap, dtype=torch.int32),
@@ -970,9 +973,17 @@ class DeformableFeatureAggregation:
         )
 
         # 2. Pre-rotation key points + fused KPS projection (overlaps with weight compute on device)
+        # Key points stay bf16: the kernel reads them as bf16 pages, and they are OFFSETS
+        # of object size (1-5 m) rather than positions, so their absolute error is an order
+        # of magnitude below the centre's. Only the anchor keeps the extra width.
+        anchor_bf16 = anchor
+        if anchor.dtype != ttnn.bfloat16:
+            anchor_bf16 = ttnn.typecast(anchor, ttnn.bfloat16)
         key_points = self._kps_generator_pre_rotation(
-            anchor, instance_feature, bs, num_anchor
+            anchor_bf16, instance_feature, bs, num_anchor
         )
+        if anchor_bf16 is not anchor:
+            ttnn.deallocate(anchor_bf16)
         # the kernel reads the anchor as row-major pages
         anchor_rm = ttnn.reshape(anchor, (n, 1, 11))
         anchor_rm = ttnn.to_layout(anchor_rm, ttnn.ROW_MAJOR_LAYOUT)

--- a/model/deformable_feature_aggregation.py
+++ b/model/deformable_feature_aggregation.py
@@ -940,14 +940,47 @@ class DeformableFeatureAggregation:
         if return_logits:
             return weights  # pre-softmax logits
 
-        weights = ttnn.softmax(
-            weights,
-            dim=1,
-            numeric_stable=True,
-            compute_kernel_config=self._hifi_compute_config,
-        )
+        if self._mesh_device is not None:
+            # Same subset problem as _softmax_clp, and stock softmax gives no access to
+            # its denominator, so the reduction is written out.
+            weights = self._softmax_clp_dense(weights)
+        else:
+            weights = ttnn.softmax(
+                weights,
+                dim=1,
+                numeric_stable=True,
+                compute_kernel_config=self._hifi_compute_config,
+            )
 
         return weights
+
+    def _softmax_clp_dense(self, logits):
+        """Softmax over dim 1 of [N, CLP, G], denominator reduced across the mesh.
+
+        The compact path needs 0/1 matmuls because its CLP axis is strided inside the row;
+        here the axis is a real one, so ttnn's own reductions do the local part and all
+        that is added is the two cross-device sums. See _softmax_clp for why the shift is
+        reduced as well — exp(l - m0) and exp(l - m1) cannot be added.
+        """
+        cc = dict(num_links=1, memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                  topology=ttnn.Topology.Linear)
+        m = ttnn.max(logits, dim=1, keepdim=True)
+        tot = ttnn.all_reduce(m, **cc)
+        ttnn.deallocate(m)
+        m = ttnn.multiply(tot, 1.0 / self._mesh_device.get_num_devices())
+        ttnn.deallocate(tot)
+        shifted = ttnn.subtract(logits, m)
+        ttnn.deallocate(m)
+        e = ttnn.exp(shifted)
+        ttnn.deallocate(shifted)
+
+        s = ttnn.sum(e, dim=1, keepdim=True)
+        red = ttnn.all_reduce(s, **cc)
+        ttnn.deallocate(s)
+        w = ttnn.divide(e, red)
+        ttnn.deallocate(e)
+        ttnn.deallocate(red)
+        return w
 
     def _softmax_clp(self, logits):
         """Softmax over the CLP entries while they stay strided by G inside each row.
@@ -962,8 +995,31 @@ class DeformableFeatureAggregation:
         strided reduction being avoided. It is looser by whatever spread there is between
         groups in a row; debug/probe_clp_softmax.py measures that spread against the
         exponent range so the looseness stays checkable rather than assumed.
+
+        On a mesh the softmax is NOT local. Each device holds its own cameras, so its CLP
+        axis is a subset of the one the softmax is defined over — 156 of 312 on a 3/3
+        split — and normalising over the subset makes each device's weights sum to 1 on
+        their own, so the all_reduce after the fusion adds two complete distributions
+        instead of one. Measured, that alone is the whole of the DFA's error: replaying
+        the per-device normalisation on exact reference logits reproduces PCC 0.952, and
+        scoring the device against a per-device reference gives 0.999989. So the
+        denominator is reduced across devices here.
+
+        The shift has to be reduced with it. exp(l - m0) and exp(l - m1) are not summable,
+        so both devices must subtract the same constant; any common constant is exact, and
+        the mean of the per-device maxima is one both can reach with the Sum all_reduce
+        this file already uses. It sits within half the spread of the true global maximum,
+        which is what stabilisation actually needs.
         """
         m = ttnn.max(logits, dim=-1, keepdim=True)
+        if self._mesh_device is not None:
+            tot = ttnn.all_reduce(
+                m, num_links=1, memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                topology=ttnn.Topology.Linear,
+            )
+            ttnn.deallocate(m)
+            m = ttnn.multiply(tot, 1.0 / self._mesh_device.get_num_devices())
+            ttnn.deallocate(tot)
         shifted = ttnn.subtract(logits, m)
         ttnn.deallocate(m)
         e = ttnn.exp(shifted)
@@ -971,6 +1027,14 @@ class DeformableFeatureAggregation:
 
         s = ttnn.matmul(e, self._clp_gather,
                         compute_kernel_config=self._exact_compute_config)
+        if self._mesh_device is not None:
+            # The gather's padding columns are zero on every device, so they stay zero.
+            red = ttnn.all_reduce(
+                s, num_links=1, memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                topology=ttnn.Topology.Linear,
+            )
+            ttnn.deallocate(s)
+            s = red
         sb = ttnn.matmul(s, self._clp_scatter,
                          compute_kernel_config=self._exact_compute_config)
         ttnn.deallocate(s)

--- a/model/deformable_feature_aggregation.py
+++ b/model/deformable_feature_aggregation.py
@@ -72,6 +72,27 @@ else:
 # writing past the budget and every stage walks the same number of rows regardless.
 _OOB_CAP_ENV = _os.environ.get("TT_OOB_CAP")
 
+# COMPACT attention weights: keep them as [N, CLP*G] all the way into
+# grouped_weighted_sum instead of reshaping to [N, CLP, G] and transposing to [CLP, N, G].
+#
+# G is 8 and a tile is 32 wide, so the [.., G] layouts spend 24 of every 32 columns on
+# padding — the tensor, the transpose that follows it, and the mask multiply all move 4x
+# the numbers they need to. The compact layout is what weights_fc already produces, and a
+# tile of it holds 32 anchors x 4 consecutive CLP with nothing wasted.
+#
+# The cost is that softmax has to reduce over a stride-G axis, which no stock op does. It
+# is expressed here as exp, a 0/1 matmul for the per-group sums, a second to scatter them
+# back, and a divide. Measured against the reshape+softmax+transpose+mask chain it
+# replaces: 1151 -> ~220 us per DFA call.
+#
+# Needs the grouped_weighted_sum reader that accepts [N, CLP*G]; an older build of the op
+# raises on the shape rather than reading it wrong, so the failure is loud.
+_env = _os.environ.get("TT_WT_COMPACT")
+if _env is not None:
+    _WT_COMPACT = _env == "1"
+else:
+    _WT_COMPACT = _HAS_CUSTOM_KERNELS
+
 # Anchor box field indices (Sparse4D convention)
 X, Y, Z = 0, 1, 2
 W, L, H = 3, 4, 5
@@ -116,6 +137,45 @@ class DeformableFeatureAggregation:
             packer_l1_acc=False,
             math_approx_mode=False,
         )
+        # The softmax denominator is a sum of 156 terms and is the one place in this path
+        # where the accumulator width shows, so the 0/1 matmuls that compute and scatter it
+        # run at full fidelity with an fp32 destination. They are 1-tile-wide matmuls, so
+        # the extra passes cost almost nothing.
+        self._exact_compute_config = ttnn.init_device_compute_kernel_config(
+            device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=False,
+            math_approx_mode=False,
+        )
+
+        # 0/1 matrices for the compact-layout softmax. In [N, CLP*G] the CLP axis is
+        # strided by G inside each row, so the per-group sum is a matmul by a matrix that
+        # selects every G-th column, and putting it back is the transpose of that.
+        # Both are padded to the tile width; the padding columns are zero and stay zero.
+        self._clp_gather = self._clp_scatter = self._cam_block = None
+        if _WT_COMPACT:
+            total_clp = num_cams * num_levels * num_pts
+            width = total_clp * num_groups
+            gp = ((num_groups + 31) // 32) * 32
+            gather = torch.zeros(width, gp)
+            for c in range(total_clp):
+                for g in range(num_groups):
+                    gather[c * num_groups + g, g] = 1.0
+            # One column block of CLP*G per camera, so a per-(camera, anchor) flag
+            # broadcasts across that camera's levels, points and groups in one multiply.
+            # Height is num_cams, not the padded tile height: matmul checks the LOGICAL
+            # inner dimension, and the flags come in as [N, num_cams].
+            block = torch.zeros(num_cams, width)
+            per_cam = width // num_cams
+            for c in range(num_cams):
+                block[c, c * per_cam:(c + 1) * per_cam] = 1.0
+            _kw = dict(dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=self.device)
+            if self._mesh_device is not None:
+                _kw["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+            self._clp_gather = ttnn.from_torch(gather, **_kw)
+            self._clp_scatter = ttnn.from_torch(gather.t().contiguous(), **_kw)
+            self._cam_block = ttnn.from_torch(block, **_kw)
 
         # Weight CLP reorder index: camera-major → level-major
         # Needed because transposed grid produces level-major feature ordering
@@ -562,8 +622,8 @@ class DeformableFeatureAggregation:
         # Pre-convert grid once (reused across all levels)
         grid = ttnn.to_layout(points_2d, ttnn.ROW_MAJOR_LAYOUT)
         grid = ttnn.to_memory_config(grid, ttnn.DRAM_MEMORY_CONFIG)
-        if grid.dtype != ttnn.float32:
-            grid = ttnn.typecast(grid, ttnn.float32)
+        # The grid is already the Q14 fixed-point uint16 the sampler decodes; a typecast
+        # here would reinterpret the bits as an unsigned integer and destroy them.
 
         # 1. grid_sample_lerp per level
         all_level_features = []
@@ -838,6 +898,10 @@ class DeformableFeatureAggregation:
 
         total_clp = self.num_cams * self.num_levels * self.num_pts
         if self.use_camera_embed:
+            # [1, 1, bs*N, CLP*G]. The camera came from the row axis and the linear's
+            # columns are (level, point, group), so the merged column index is exactly
+            # clp*G + g with clp = cam*L*K + level*K + point — the ordering the feature
+            # buffer and the mask both already use.
             weights = ttnn.reshape(
                 weights,
                 (
@@ -847,6 +911,16 @@ class DeformableFeatureAggregation:
                     self.num_cams * self.num_levels * self.num_pts * self.num_groups,
                 ),
             )
+
+        # Only the camera-embed path produces the compact layout for free: without it the
+        # linear has no camera axis to fold into the columns, so CLP*G would not be the
+        # row width and the reshape below is a real one either way.
+        if _WT_COMPACT and self.use_camera_embed:
+            if return_logits:
+                return weights
+            return self._softmax_clp(weights)
+
+        if self.use_camera_embed:
             weights = ttnn.reshape(
                 weights, (bs * num_anchor, total_clp, self.num_groups)
             )
@@ -866,6 +940,58 @@ class DeformableFeatureAggregation:
         )
 
         return weights
+
+    def _softmax_clp(self, logits):
+        """Softmax over the CLP entries while they stay strided by G inside each row.
+
+        No stock op reduces a strided axis, so the sum is a matmul by a 0/1 matrix that
+        picks every G-th column, and a second one puts the per-group denominator back
+        under every column it belongs to. Everything else is elementwise on the compact
+        tensor, which is a quarter the size of the [N, CLP, G] one this replaces.
+
+        Subtracting the row maximum rather than the per-group maximum still stabilises
+        the exponential — any constant does — and the per-group one would need the very
+        strided reduction being avoided. It is looser by whatever spread there is between
+        groups in a row; debug/probe_clp_softmax.py measures that spread against the
+        exponent range so the looseness stays checkable rather than assumed.
+        """
+        m = ttnn.max(logits, dim=-1, keepdim=True)
+        shifted = ttnn.subtract(logits, m)
+        ttnn.deallocate(m)
+        e = ttnn.exp(shifted)
+        ttnn.deallocate(shifted)
+
+        s = ttnn.matmul(e, self._clp_gather,
+                        compute_kernel_config=self._exact_compute_config)
+        sb = ttnn.matmul(s, self._clp_scatter,
+                         compute_kernel_config=self._exact_compute_config)
+        ttnn.deallocate(s)
+        # Divide rather than multiply by a reciprocal: this is the one rounding that
+        # softmax itself does, and doing it the same way keeps the two paths comparable.
+        w = ttnn.divide(e, sb)
+        ttnn.deallocate(e)
+        ttnn.deallocate(sb)
+        return w
+
+    def _mask_weights_compact(self, weights, n, nc):
+        """Zero the compact weights of the rows compaction dropped.
+
+        Same job as _mask_weights, in the [N, CLP*G] layout: a camera owns one contiguous
+        block of CLP*G/nc columns, so the per-(camera, anchor) flag becomes a mask over
+        the full row via one matmul against the block matrix. Multiplying by exactly
+        0.0/1.0 is exact in every float format, so the kept rows are untouched.
+        """
+        f = ttnn.to_layout(self._cflags, ttnn.TILE_LAYOUT)  # [nc, 1, 1, n]
+        f2 = ttnn.reshape(f, (nc, n))
+        ttnn.deallocate(f)
+        ft = ttnn.transpose(f2, -2, -1)                     # [n, nc]
+        ttnn.deallocate(f2)
+        mask = ttnn.matmul(ft, self._cam_block, compute_kernel_config=self._hifi_compute_config)
+        ttnn.deallocate(ft)
+        out = ttnn.multiply(weights, mask)
+        ttnn.deallocate(mask)
+        ttnn.deallocate(weights)
+        return out
 
     def _compact_grid(self, points_2d, n, nc, spatial_shapes):
         """Compact the sampling grid to the rows that actually hit an image.
@@ -1044,9 +1170,17 @@ class DeformableFeatureAggregation:
                 points_2d_sh = ttnn.to_memory_config(points_2d, self._grid_sharded_mem)
             ttnn.deallocate(points_2d)
 
-            weights_t = ttnn.transpose(weights, 0, 1)
-            if _OOB_COMPACT:
-                weights_t = self._mask_weights(weights_t, n, nc)
+            if _WT_COMPACT and self.use_camera_embed:
+                # Already [1, 1, N, CLP*G] — the layout grouped_weighted_sum reads
+                # directly, so neither the reshape into [N, CLP, G] nor the transpose
+                # that followed it happens at all.
+                weights_t = weights
+                if _OOB_COMPACT:
+                    weights_t = self._mask_weights_compact(weights_t, n, nc)
+            else:
+                weights_t = ttnn.transpose(weights, 0, 1)
+                if _OOB_COMPACT:
+                    weights_t = self._mask_weights(weights_t, n, nc)
 
             for level_idx, fm_tt in enumerate(feature_maps):
                 sampled = ttnn.grid_sample(

--- a/model/instance_bank.py
+++ b/model/instance_bank.py
@@ -22,6 +22,11 @@ import numpy as np
 import torch
 import ttnn
 
+import os as _os
+
+# TT_ANCHOR_FP32=0 puts the anchor back in bf16 for an A/B.
+_ANCHOR_DTYPE = ttnn.bfloat16 if _os.environ.get("TT_ANCHOR_FP32") == "0" else ttnn.float32
+
 # Anchor box field indices
 X, Y, Z = 0, 1, 2
 W, L, H = 3, 4, 5
@@ -64,17 +69,24 @@ class InstanceBank:
         # Pre-cache constant anchor/feature on device (avoid repeated host→device upload)
         anchor_tiled = anchor_data.float().unsqueeze(0).contiguous()  # [1, num_anchor, 11]
         feature_tiled = instance_feature_data.float().unsqueeze(0).contiguous()  # [1, num_anchor, embed_dims]
-        self._dev_anchor = self._to_dev(anchor_tiled)
+        # The anchor is fp32, not bf16, and it is the one tensor in the head where that is
+        # worth it. Its x and y reach +-60 m, so bf16's relative error becomes 0.03 m of
+        # absolute error, and the projection divides by depth — which cancels the distance
+        # and leaves a flat 0.081 px of grid error on the finest FPN level (measured).
+        # It is also [900, 11], so fp32 costs 20 KB a frame.
+        self._dev_anchor = self._to_dev(anchor_tiled, _ANCHOR_DTYPE)
         self._dev_feature = self._to_dev(feature_tiled)
 
         self.reset()
 
-    def _to_dev(self, tensor: torch.Tensor) -> ttnn.Tensor:
+    def _to_dev(self, tensor: torch.Tensor, dtype=None) -> ttnn.Tensor:
         """Helper: from_torch with mesh_mapper if mesh mode."""
-        kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
+        dtype = dtype or ttnn.bfloat16
+        kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=dtype)
         if self._mesh_device is not None:
             kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
-        return ttnn.from_torch(tensor.float(), **kwargs)
+        host = tensor.float() if dtype == ttnn.float32 else tensor.bfloat16()
+        return ttnn.from_torch(host, **kwargs)
 
     def _from_dev(self, tensor: ttnn.Tensor) -> torch.Tensor:
         """Helper: to_torch with mesh_composer if mesh mode."""
@@ -126,7 +138,9 @@ class InstanceBank:
                 dtype=torch.float32,
             ).bfloat16()
 
-            _kw = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
+            # The rotation matrices multiply the anchor, so they follow its dtype — a
+            # mixed-dtype matmul is not what we want here and ttnn would reject it anyway.
+            _kw = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=_ANCHOR_DTYPE)
             if self._mesh_device is not None:
                 _kw["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
 
@@ -161,7 +175,7 @@ class InstanceBank:
             cached_anchor = ttnn.concat([center, size, yaw_out, vel_out], dim=-1)
             ttnn.deallocate(center); ttnn.deallocate(size)
             ttnn.deallocate(yaw_out); ttnn.deallocate(vel_out)
-            self.cached_anchor = cached_anchor
+            self.cached_anchor = self._as_bank_dtype(cached_anchor)
 
             time_interval_pt = torch.where(
                 torch.logical_and(time_interval_pt != 0, self.mask),
@@ -182,6 +196,18 @@ class InstanceBank:
         time_interval = ttnn.reshape(time_interval, (bs,))
 
         return instance_feature, anchor, cached_feature, cached_anchor, time_interval
+
+    def _as_bank_dtype(self, anchor: ttnn.Tensor) -> ttnn.Tensor:
+        """The bank stores anchors in one dtype, whatever route they arrived by.
+
+        The anchor reaches update()/cache() from the refinement, and reaches the temporal
+        path from a chain of slices and matmuls; keeping the invariant here rather than
+        chasing every producer is what stops a concat between the two from failing on a
+        dtype mismatch. Widening a bf16 value costs nothing — it is already rounded.
+        """
+        if anchor.dtype != _ANCHOR_DTYPE:
+            return ttnn.typecast(anchor, _ANCHOR_DTYPE)
+        return anchor
 
     def update(
         self,
@@ -205,6 +231,7 @@ class InstanceBank:
         if self.cached_feature is None:
             return instance_feature, anchor
 
+        anchor = self._as_bank_dtype(anchor)
         N = self.num_anchor - self.num_temp_instances  # 300
 
         # Device-side topk (no host roundtrip)
@@ -313,7 +340,7 @@ class InstanceBank:
 
         anch_dim = anchor.shape[-1]
         idx_anch = ttnn.repeat_interleave(top_idx, anch_dim, dim=-1)
-        self.cached_anchor = ttnn.gather(anchor, 1, idx_anch)
+        self.cached_anchor = ttnn.gather(self._as_bank_dtype(anchor), 1, idx_anch)
         ttnn.deallocate(idx_anch); ttnn.deallocate(top_idx)
 
         self.confidence = ttnn.reshape(top_conf, (1, 1, bs, K))

--- a/model/multihead_attention.py
+++ b/model/multihead_attention.py
@@ -88,7 +88,7 @@ class MultiheadAttention:
         kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
         if self._mesh_device is not None:
             kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
-        return ttnn.from_torch(tensor.float(), **kwargs)
+        return ttnn.from_torch(tensor.bfloat16(), **kwargs)
 
     def _to_device_bias(self, tensor: torch.Tensor) -> ttnn.Tensor:
         if tensor.dim() == 1:
@@ -96,7 +96,7 @@ class MultiheadAttention:
         kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
         if self._mesh_device is not None:
             kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
-        return ttnn.from_torch(tensor.float(), **kwargs)
+        return ttnn.from_torch(tensor.bfloat16(), **kwargs)
 
     def run(
         self,

--- a/model/refinement_module.py
+++ b/model/refinement_module.py
@@ -97,7 +97,7 @@ class SparseBox3DRefinementModule:
         kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
         if self._mesh_device is not None:
             kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
-        return ttnn.from_torch(tensor.float(), **kwargs)
+        return ttnn.from_torch(tensor.bfloat16(), **kwargs)
 
     def _to_device_bias(self, tensor: torch.Tensor) -> ttnn.Tensor:
         if tensor.dim() == 1:
@@ -105,7 +105,7 @@ class SparseBox3DRefinementModule:
         kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
         if self._mesh_device is not None:
             kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
-        return ttnn.from_torch(tensor.float(), **kwargs)
+        return ttnn.from_torch(tensor.bfloat16(), **kwargs)
 
     def _to_device_1d(self, tensor: torch.Tensor) -> ttnn.Tensor:
         if tensor.dim() == 1:
@@ -113,7 +113,7 @@ class SparseBox3DRefinementModule:
         kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
         if self._mesh_device is not None:
             kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
-        return ttnn.from_torch(tensor.float(), **kwargs)
+        return ttnn.from_torch(tensor.bfloat16(), **kwargs)
 
     def _run_layers(self, x: ttnn.Tensor, layers: list) -> ttnn.Tensor:
         for idx, entry in enumerate(layers):
@@ -177,6 +177,13 @@ class SparseBox3DRefinementModule:
         refined = ttnn.multiply(refined, self.refine_scale)
         ttnn.deallocate(refined_pre_scale)
         refined = ttnn.reshape(refined, (bs, num_anchor, self.output_dim))
+        # The anchor is the accumulator: it is added to at every layer, so it carries the
+        # width, while the delta this linear produced stays bf16. Wide accumulator, narrow
+        # increment — the same reason mixed-precision training keeps fp32 master weights.
+        if refined.dtype != anchor.dtype:
+            _pre = refined
+            refined = ttnn.typecast(refined, anchor.dtype)
+            ttnn.deallocate(_pre)
 
         # Residual refinement
         if self.refine_yaw:

--- a/model/sparse4d_head.py
+++ b/model/sparse4d_head.py
@@ -321,11 +321,18 @@ class Sparse4DHead:
             num_temp = 0
 
         # 3. Pre-allocate projection_mat and image_wh on device
+        # The projection matrix stays fp32. Its entries reach 667, so bf16's relative
+        # precision becomes 1.3 of absolute error there, and the DFA's kernel multiplies a
+        # 3D point by it and divides by depth — measured, that is 0.172 px of sampling-grid
+        # error on the finest FPN level, the single largest term in the grid's disagreement
+        # with PyTorch and twice what the anchor centre contributed. It is [6, 4, 4] = 384 B
+        # and never accumulates, so the width is free; only the camera encoder, which is a
+        # matmul chain that never reaches a pixel, takes a bf16 view of it.
         proj_pt = metas["projection_mat"].float()
         if self._mesh_device is not None:
             proj_tt = ttnn.from_torch(
                 proj_pt,
-                layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32,
                 mesh_mapper=ttnn.ShardTensorToMesh(self._mesh_device, dim=1),
             )
             # image_wh is constant across frames — cache on device
@@ -339,7 +346,7 @@ class Sparse4DHead:
             wh_tt = self._cached_wh_tt
         else:
             proj_tt = ttnn.from_torch(
-                proj_pt, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16,
+                proj_pt, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.float32,
             )
             if not hasattr(self, '_cached_wh_tt') or self._cached_wh_tt is None:
                 wh_pt = metas["image_wh"].float()

--- a/model/sparse4d_head.py
+++ b/model/sparse4d_head.py
@@ -201,7 +201,7 @@ class Sparse4DHead:
         kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
         if self._mesh_device is not None:
             kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
-        return ttnn.from_torch(tensor.float(), **kwargs)
+        return ttnn.from_torch(tensor.bfloat16(), **kwargs)
 
     def _to_device_1d(self, tensor: torch.Tensor) -> ttnn.Tensor:
         if tensor.dim() == 1:
@@ -209,7 +209,7 @@ class Sparse4DHead:
         kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
         if self._mesh_device is not None:
             kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
-        return ttnn.from_torch(tensor.float(), **kwargs)
+        return ttnn.from_torch(tensor.bfloat16(), **kwargs)
 
     def _graph_model(
         self,

--- a/model/sparse_box3d_encoder.py
+++ b/model/sparse_box3d_encoder.py
@@ -140,7 +140,7 @@ class SparseBox3DEncoder:
         kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
         if self._mesh_device is not None:
             kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
-        return ttnn.from_torch(tensor.float(), **kwargs)
+        return ttnn.from_torch(tensor.bfloat16(), **kwargs)
 
     def _to_device_bias(self, tensor: torch.Tensor) -> ttnn.Tensor:
         if tensor.dim() == 1:
@@ -148,7 +148,7 @@ class SparseBox3DEncoder:
         kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
         if self._mesh_device is not None:
             kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
-        return ttnn.from_torch(tensor.float(), **kwargs)
+        return ttnn.from_torch(tensor.bfloat16(), **kwargs)
 
     def _to_device_1d(self, tensor: torch.Tensor) -> ttnn.Tensor:
         if tensor.dim() == 1:
@@ -156,7 +156,7 @@ class SparseBox3DEncoder:
         kwargs = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
         if self._mesh_device is not None:
             kwargs["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
-        return ttnn.from_torch(tensor.float(), **kwargs)
+        return ttnn.from_torch(tensor.bfloat16(), **kwargs)
 
     def _run_layers(self, x: ttnn.Tensor, layers: list, name: str = "") -> ttnn.Tensor:
         """Run Linear+ReLU (→LN) chain with fused activation."""
@@ -193,6 +193,10 @@ class SparseBox3DEncoder:
         Returns:
             output: [bs, num_anchor, output_dims] on device (TILE)
         """
+        # The anchor may be fp32 for the projection's sake; this path is a matmul chain
+        # whose error never reaches a pixel, so it takes the bf16 view.
+        if box_3d.dtype != ttnn.bfloat16:
+            box_3d = ttnn.typecast(box_3d, ttnn.bfloat16)
         # Extract components via device slice (no host roundtrip)
         n = bs * num_anchor
 

--- a/test/sparse4d_nuscenes_val.py
+++ b/test/sparse4d_nuscenes_val.py
@@ -29,6 +29,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 import numpy as np
 import torch
 import torch.nn as nn
+import os as _os
 import ttnn
 from PIL import Image
 from nuscenes.utils.data_classes import Box as NuScenesBox
@@ -415,18 +416,37 @@ def load_model(ckpt_path, device, mesh_device=None, backbone_batch_size=None, fp
     head = _build_head_from_sd(sd, device, mesh_device=mesh_device)
 
     # Override math fidelity for all head modules
+    # TT_FP32_ACC=1 widens the DESTINATION register without touching math fidelity. The
+    # two are separate halves of what makes TT's bf16 differ from PyTorch's — the multiply
+    # truncation and the 16-bit accumulate — and --fidelity hifi4 changes both at once, so
+    # a loss there cannot be attributed. Measured separately, raising fidelity costs mAP
+    # (HiFi2 -0.024, HiFi4 -0.009) while improving mATE/mAOE, so the halves may not point
+    # the same way.
+    _fp32_acc_only = _os.environ.get("TT_FP32_ACC") == "1"
+    if _fp32_acc_only and not fidelity_override:
+        fidelity_override = "keep"
+
     if fidelity_override:
         fidelity_map = {
             "lofi": ttnn.MathFidelity.LoFi,
             "hifi2": ttnn.MathFidelity.HiFi2,
             "hifi4": ttnn.MathFidelity.HiFi4,
         }
-        fidelity = fidelity_map[fidelity_override]
-        fp32_acc = (fidelity_override == "hifi4")
-        new_config = ttnn.init_device_compute_kernel_config(
-            device.arch(), math_fidelity=fidelity,
-            fp32_dest_acc_en=fp32_acc, packer_l1_acc=fp32_acc, math_approx_mode=False,
-        )
+        # "keep" leaves the fidelity each module already chose and only widens the
+        # accumulator, which is the half this run is trying to isolate.
+        keep_fidelity = fidelity_override == "keep"
+        fidelity = None if keep_fidelity else fidelity_map[fidelity_override]
+        fp32_acc = _fp32_acc_only or (fidelity_override == "hifi4")
+        def _cfg(existing_fidelity):
+            return ttnn.init_device_compute_kernel_config(
+                device.arch(),
+                math_fidelity=existing_fidelity if keep_fidelity else fidelity,
+                fp32_dest_acc_en=fp32_acc, packer_l1_acc=fp32_acc, math_approx_mode=False,
+            )
+        # Modules that carry their own config keep its fidelity under "keep"; the ones that
+        # never had one were on the ttnn default, which is HiFi4.
+        _DEF = ttnn.MathFidelity.HiFi4
+        new_config = _cfg(ttnn.MathFidelity.HiFi2 if keep_fidelity else _DEF)
         # Apply to all head sub-modules
         head._hifi_compute_config = new_config
         for layer in head.layers:

--- a/tt-metal/ops/grid_compact/device/grid_compact_device_operation.cpp
+++ b/tt-metal/ops/grid_compact/device/grid_compact_device_operation.cpp
@@ -17,8 +17,10 @@ GridCompactOperation::program_factory_t GridCompactOperation::select_program_fac
 
 void GridCompactOperation::validate_on_program_cache_miss(
     const operation_attributes_t& a, const tensor_args_t& t) {
-    TT_FATAL(t.grid.dtype() == DataType::FLOAT32, "grid must be FLOAT32");
-    TT_FATAL(t.cgrid.dtype() == DataType::FLOAT32, "cgrid must be FLOAT32");
+    // Q14 fixed point in a UINT16 container — see kps_project_fused for why the
+    // coordinate is fixed point and not bf16. ttnn has no INT16; the kernel reinterprets.
+    TT_FATAL(t.grid.dtype() == DataType::UINT16, "grid must be UINT16 (Q14 fixed point)");
+    TT_FATAL(t.cgrid.dtype() == t.grid.dtype(), "cgrid must match the grid dtype");
     TT_FATAL(t.index.dtype() == DataType::UINT32, "index must be UINT32");
     TT_FATAL(t.flags.dtype() == DataType::BFLOAT16, "flags must be BFLOAT16");
     TT_FATAL(t.grid.layout() == Layout::ROW_MAJOR, "grid must be ROW_MAJOR");
@@ -62,9 +64,23 @@ void grid_compact(
     for (int i = 0; i < gs.rank() - 1; i++) {
         num_rows *= gs[i];
     }
-    uint32_t thr_x_bits = 0, thr_y_bits = 0;
-    std::memcpy(&thr_x_bits, &threshold_x, sizeof(thr_x_bits));
-    std::memcpy(&thr_y_bits, &threshold_y, sizeof(thr_y_bits));
+    // The kernel compares Q14 fixed point, so the threshold becomes an integer. Round it
+    // UP: the test is a strict `<`, and rounding down would move the boundary inwards and
+    // drop rows whose only in-bounds point sits between two representable coordinates.
+    constexpr int32_t GRID_FIXED_SHIFT = 14;  // must match kps_project_fused and grid_sample
+    auto to_fixed_ceil = [](float v) -> uint32_t {
+        const float s = v * (float)(1 << GRID_FIXED_SHIFT);
+        int32_t q = (int32_t)s;
+        if ((float)q < s) {
+            q += 1;
+        }
+        if (q > 32767) {
+            q = 32767;
+        }
+        return (uint32_t)q;
+    };
+    const uint32_t thr_x_bits = to_fixed_ceil(threshold_x);
+    const uint32_t thr_y_bits = to_fixed_ceil(threshold_y);
 
     using Op = GridCompactOperation;
     ttnn::device_operation::launch<Op>(

--- a/tt-metal/ops/grid_compact/device/grid_compact_program_factory.cpp
+++ b/tt-metal/ops/grid_compact/device/grid_compact_program_factory.cpp
@@ -1,22 +1,25 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
 #include <cstdint>
 #include "tt-metalium/tensor_accessor_args.hpp"
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/math.hpp>
+#include <tt-metalium/work_split.hpp>
 #include "grid_compact_program_factory.hpp"
 
 namespace ttnn::prim {
 using namespace tt;
 using namespace tt::tt_metal;
 
-// Single core on purpose: the pass is a sequential scan with a running output
-// counter, which across cores would need a prefix sum. Measured alternative --
-// giving each core its own fixed slot budget so no core has to talk -- has to size
-// for the busiest core and compacts far worse than pooling across cameras does.
+// The bounds test runs on every core, the writes on one. The test is ~58% of the runtime
+// at the production shape and has no ordering dependency; the writes need a running slot
+// counter, which across cores would need a prefix sum. Giving each core its own fixed slot
+// budget instead -- so no core has to talk -- was measured and rejected: it has to size for
+// the busiest core, which is most of what pooling across cameras exists to avoid.
 GridCompactProgramFactory::cached_program_t GridCompactProgramFactory::create(
     const GridCompactParams& attrs,
     const GridCompactInputs& t,
@@ -24,40 +27,68 @@ GridCompactProgramFactory::cached_program_t GridCompactProgramFactory::create(
 
     Program program{};
     const CoreCoord core{0, 0};
-    const CoreRange core_range(core, core);
 
     constexpr uint32_t BATCH = 64;   // rows fetched per barrier
-    const uint32_t row_bytes = attrs.row_width * sizeof(float);
+    const uint32_t row_bytes = attrs.row_width * t.grid.element_size();
     // L1 strides, 32 B aligned: NOC endpoints must be, and a 26-float row is not.
     const uint32_t row_stride = ((row_bytes + 31) / 32) * 32;
     const uint32_t num_cams = attrs.num_rows / attrs.anchors;
 
+    // Phase-1 fan-out. Fewer rows per core than 8 is not worth the relay, and the mask
+    // block is padded to 32 B so each core's relay lands on a NOC-legal boundary.
+    const auto grid_size = t.grid.device()->compute_with_storage_grid_size();
+    const uint32_t max_cores = grid_size.x * grid_size.y;
+    uint32_t num_cores = std::min<uint32_t>(max_cores, (attrs.num_rows + 7) / 8);
+    if (num_cores == 0) {
+        num_cores = 1;
+    }
+    const uint32_t rows_per_core = (attrs.num_rows + num_cores - 1) / num_cores;
+    // Recompute: ceil division can leave the last cores with no rows at all.
+    num_cores = (attrs.num_rows + rows_per_core - 1) / rows_per_core;
+    const uint32_t mask_blk = ((rows_per_core + 31) / 32) * 32;
+    const CoreRangeSet core_range = num_cores_to_corerangeset(num_cores, grid_size, true);
+    const auto c0_physical = t.grid.device()->worker_core_from_logical_core(core);
+    // ROW_CB has to hold whichever pass fetches more rows at once.
+    const uint32_t row_cb_rows = std::max<uint32_t>(BATCH, rows_per_core);
+
     const bool pooled = t.bidx.has_value();
     const uint32_t idx_bytes = (pooled ? attrs.capacity : num_cams * attrs.capacity) * sizeof(uint32_t);
     const uint32_t bidx_stride = pooled ? attrs.bidx_width * sizeof(uint32_t) : 0;
-    const uint32_t bidx_bytes = pooled ? attrs.capacity * bidx_stride : 0;
 
-    constexpr uint32_t ROW_CB = tt::CBIndex::c_0;
-    constexpr uint32_t IDX_CB = tt::CBIndex::c_1;
-    constexpr uint32_t FLG_CB = tt::CBIndex::c_2;
+    // Indices are ordered so the two buffers every core needs come first. CB addresses are
+    // packed per core by index, so ROW_CB and MASK_CB land at the same L1 offset on every
+    // core — which is what lets a worker relay its mask block to core 0 by address.
+    constexpr uint32_t ROW_CB  = tt::CBIndex::c_0;
+    constexpr uint32_t MASK_CB = tt::CBIndex::c_1;
+    constexpr uint32_t IDX_CB  = tt::CBIndex::c_2;
+    constexpr uint32_t FLG_CB  = tt::CBIndex::c_3;
+    constexpr uint32_t BIDX_CB = tt::CBIndex::c_4;
     const uint32_t flag_stride = ((attrs.flag_width * 2 + 31) / 32) * 32;
     const uint32_t flag_bytes = num_cams * flag_stride;
+    const uint32_t mask_bytes = num_cores * mask_blk;
 
-    auto row_cb_cfg = CircularBufferConfig(row_stride * BATCH, {{ROW_CB, DataFormat::Float32}})
+    auto row_cb_cfg = CircularBufferConfig(row_stride * row_cb_rows, {{ROW_CB, DataFormat::UInt16}})
                           .set_page_size(ROW_CB, row_stride);
     CreateCircularBuffer(program, core_range, row_cb_cfg);
+    auto mask_cb_cfg = CircularBufferConfig(mask_bytes, {{MASK_CB, DataFormat::UInt8}})
+                           .set_page_size(MASK_CB, mask_bytes);
+    CreateCircularBuffer(program, core_range, mask_cb_cfg);
     auto idx_cb_cfg = CircularBufferConfig(idx_bytes, {{IDX_CB, DataFormat::UInt32}})
                           .set_page_size(IDX_CB, idx_bytes);
     CreateCircularBuffer(program, core_range, idx_cb_cfg);
     auto flg_cb_cfg = CircularBufferConfig(flag_bytes, {{FLG_CB, DataFormat::Float16_b}})
                           .set_page_size(FLG_CB, flag_bytes);
     CreateCircularBuffer(program, core_range, flg_cb_cfg);
-    constexpr uint32_t BIDX_CB = tt::CBIndex::c_3;
     if (pooled) {
-        auto bidx_cb_cfg = CircularBufferConfig(bidx_bytes, {{BIDX_CB, DataFormat::UInt32}})
-                               .set_page_size(BIDX_CB, bidx_bytes);
+        // Only one staged row per camera, not the whole CAP x bidx_width buffer: every row
+        // is (camera, 0, 0, ...), so NUM_CAMS distinct rows cover every slot.
+        const uint32_t stage_bytes = num_cams * bidx_stride;
+        auto bidx_cb_cfg = CircularBufferConfig(stage_bytes, {{BIDX_CB, DataFormat::UInt32}})
+                               .set_page_size(BIDX_CB, stage_bytes);
         CreateCircularBuffer(program, core_range, bidx_cb_cfg);
     }
+
+    const uint32_t sem_id = CreateSemaphore(program, core_range, 0);
 
     std::vector<uint32_t> ct_args = {
         attrs.num_rows,    // 0
@@ -75,6 +106,13 @@ GridCompactProgramFactory::cached_program_t GridCompactProgramFactory::create(
         pooled ? 1u : 0u,  // 12
         BIDX_CB,           // 13
         attrs.bidx_width,  // 14
+        num_cores,         // 15
+        rows_per_core,     // 16
+        mask_blk,          // 17
+        MASK_CB,           // 18
+        sem_id,            // 19
+        static_cast<uint32_t>(c0_physical.x),  // 20
+        static_cast<uint32_t>(c0_physical.y),  // 21
     };
     TensorAccessorArgs(*t.grid.buffer()).append_to(ct_args);
     TensorAccessorArgs(*t.cgrid.buffer()).append_to(ct_args);
@@ -90,16 +128,25 @@ GridCompactProgramFactory::cached_program_t GridCompactProgramFactory::create(
         core_range,
         WriterDataMovementConfig(ct_args));
 
-    SetRuntimeArgs(program, kernel_id, core, {
+    // The addresses are identical on every core, so they are COMMON args — that keeps the
+    // per-dispatch rewrite at 5 words instead of 5 x num_cores. Only the core's own id is
+    // per-core, and it never changes.
+    SetCommonRuntimeArgs(program, kernel_id, {
         t.grid.buffer()->address(),
         t.cgrid.buffer()->address(),
         t.index.buffer()->address(),
         t.flags.buffer()->address(),
         pooled ? t.bidx->buffer()->address() : 0u});
 
+    // row_wise, so cores[0] is logical (0, 0) — the core the kernel writes from.
+    auto cores = corerange_to_cores(core_range, num_cores, true);
+    for (uint32_t i = 0; i < num_cores; i++) {
+        SetRuntimeArgs(program, kernel_id, cores[i], {i});
+    }
+
     return cached_program_t{
         std::move(program),
-        shared_variables_t{.kernel_id = kernel_id, .core = core}};
+        shared_variables_t{.kernel_id = kernel_id, .cores = std::move(cores)}};
 }
 
 void GridCompactProgramFactory::override_runtime_arguments(
@@ -109,7 +156,9 @@ void GridCompactProgramFactory::override_runtime_arguments(
     Tensor& /*output_tensor*/) {
     auto& prog = cached_program.program;
     const auto& sv = cached_program.shared_variables;
-    auto& r = GetRuntimeArgs(prog, sv.kernel_id, sv.core);
+    // One shared copy for every core: the per-core args hold only the core id, which the
+    // buffer addresses cannot change.
+    auto& r = GetCommonRuntimeArgs(prog, sv.kernel_id);
     r[0] = t.grid.buffer()->address();
     r[1] = t.cgrid.buffer()->address();
     r[2] = t.index.buffer()->address();

--- a/tt-metal/ops/grid_compact/device/grid_compact_program_factory.hpp
+++ b/tt-metal/ops/grid_compact/device/grid_compact_program_factory.hpp
@@ -10,7 +10,9 @@ namespace ttnn::prim {
 struct GridCompactProgramFactory {
     struct shared_variables_t {
         tt::tt_metal::KernelHandle kernel_id;
-        tt::tt_metal::CoreCoord core;
+        // Every core runs the bounds test and so holds the grid address; cores[0] is the
+        // one that also does the writes.
+        std::vector<tt::tt_metal::CoreCoord> cores;
     };
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/tt-metal/ops/grid_compact/device/kernels/dataflow/grid_compact.cpp
+++ b/tt-metal/ops/grid_compact/device/kernels/dataflow/grid_compact.cpp
@@ -1,21 +1,37 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
-// Grid compaction, single core.
+// Grid compaction.
 //
 // Walks every (camera, anchor) row of the DFA sampling grid and keeps only the rows
 // with at least one point inside the image. ~80% of rows project entirely outside
 // their camera; grid_sample skips their DRAM reads but still pays CB page, barrier
 // and reduce for each one, so removing them up front is what actually saves time.
 //
-// Bounds test is done on raw bits: for IEEE754, |v| < thr (thr > 0) is exactly
-// (bits(v) & 0x7FFFFFFF) < bits(thr). Two integer ops instead of a soft-float
-// compare, which on an FPU-less dataflow core is ~25 cycles.
+// The grid is Q14 fixed point (see kps_project_fused), so the bounds test is a plain
+// integer |v| < thr on int16 — no bit tricks and no soft-float compare, which on an
+// FPU-less dataflow core would be ~25 cycles per point.
 //
 // The two axes get their own threshold. With align_corners=False a point contributes
 // iff g is in [-1 - 1/S, 1 + 1/S), S being W on x and H on y -- and the coarsest FPN
 // level is 8 x 22, so one shared threshold would have to use 1 + 1/8 on BOTH axes and
 // would keep everything.
+//
+// TWO PHASES ACROSS CORES. The bounds test is the bulk of the work and has no ordering
+// dependency, so every core tests its own slice of the rows; the writes need a running
+// output counter, so one core does them. Measured on the production shape (2700 rows,
+// 13 points, ~80% dropped) the single-core version spent ~440 us of its 763 us in the
+// test alone, which is what phase 1 removes.
+//
+//   phase 1  core i tests rows [i*RPC, (i+1)*RPC) and leaves one byte per row in its
+//            slice of a shared mask buffer, then relays that slice into core 0's copy
+//            and bumps core 0's semaphore.
+//   phase 2  core 0 waits for all NUM_CORES-1 relays, then walks the mask in row order
+//            and emits the kept rows.
+//
+// Splitting the WRITES too would need a prefix sum over the per-core counts. It is
+// worth doing only after phase 2 stops dominating; the mask is already the hard part
+// of that change, since every core can derive its own slot range from it.
 //
 // Rows past the kept count are left untouched in cgrid — their index entry is
 // SENTINEL, and transposed_s2i skips those, so stale coordinates can never reach
@@ -39,79 +55,178 @@
 #include <stdint.h>
 #include "api/compile_time_args.h"
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/noc_semaphore.h"
 
-// bidx's accessor args only EXIST in pooled mode, so this has to be a template: an
-// `if constexpr` inside kernel_main() would not discard the branch (kernel_main is not a
-// template) and TensorAccessorArgs<OFF> would still be instantiated past the arg list.
-template <bool POOLED, uint32_t OFF, uint32_t BIDX_CB, uint32_t CAP, uint32_t BIDX_W>
-FORCE_INLINE void write_bidx(uint32_t bidx_addr) {
-    if constexpr (POOLED) {
-        constexpr auto bidx_args = TensorAccessorArgs<OFF>();
-        const auto bidx_acc = TensorAccessor(bidx_args, bidx_addr);
-        const uint32_t bidx_l1 = get_write_ptr(BIDX_CB);
-        for (uint32_t j = 0; j < CAP; j++) {  // one page per row
-            noc_async_write(bidx_l1 + j * BIDX_W * 4, bidx_acc.get_noc_addr(j), BIDX_W * 4);
+constexpr uint32_t NUM_ROWS  = get_compile_time_arg_val(0);
+constexpr uint32_t NUM_PTS   = get_compile_time_arg_val(1);
+constexpr uint32_t ROW_W     = get_compile_time_arg_val(2);
+constexpr uint32_t CAP       = get_compile_time_arg_val(3);
+constexpr uint32_t ANCHORS   = get_compile_time_arg_val(4);
+constexpr uint32_t THR_X     = get_compile_time_arg_val(5);
+constexpr uint32_t ROW_CB    = get_compile_time_arg_val(6);
+constexpr uint32_t IDX_CB    = get_compile_time_arg_val(7);
+constexpr uint32_t BATCH     = get_compile_time_arg_val(8);
+constexpr uint32_t FLG_CB    = get_compile_time_arg_val(9);
+constexpr uint32_t FLG_W     = get_compile_time_arg_val(10);
+constexpr uint32_t THR_Y     = get_compile_time_arg_val(11);
+// Pooled: one shared list of kept rows, each carrying its camera in bidx, instead of a
+// fixed block per camera. The cameras do not peak together, so the shared list needs
+// barely half the capacity for the same zero-loss guarantee.
+constexpr uint32_t POOLED    = get_compile_time_arg_val(12);
+constexpr uint32_t BIDX_CB   = get_compile_time_arg_val(13);
+constexpr uint32_t BIDX_W    = get_compile_time_arg_val(14);
+constexpr uint32_t NUM_CORES = get_compile_time_arg_val(15);
+constexpr uint32_t RPC       = get_compile_time_arg_val(16);  // rows per core, phase 1
+constexpr uint32_t MASK_BLK  = get_compile_time_arg_val(17);  // bytes per core in the mask
+constexpr uint32_t MASK_CB   = get_compile_time_arg_val(18);
+constexpr uint32_t SEM_ID    = get_compile_time_arg_val(19);
+constexpr uint32_t C0_X      = get_compile_time_arg_val(20);  // physical NOC coords of core 0
+constexpr uint32_t C0_Y      = get_compile_time_arg_val(21);
+
+constexpr uint32_t SENTINEL = 0xFFFFFFFFu;
+constexpr uint16_t BF16_ONE = 0x3F80u;  // 1.0f truncated to bfloat16 (flags are bf16)
+constexpr uint32_t row_bytes = ROW_W * 2;  // int16 fixed-point grid
+// NOC endpoints must be 32 B aligned, and a row is 26 floats = 104 B, so the L1
+// batch buffer is strided at the aligned size while only row_bytes is transferred.
+// Packing rows tight in L1 put every odd row at a misaligned address and the reads
+// came back as garbage — which read as in bounds and kept everything.
+constexpr uint32_t row_stride = ((row_bytes + 31) / 32) * 32;
+constexpr uint32_t NUM_CAMS = NUM_ROWS / ANCHORS;
+constexpr uint32_t idx_bytes = (POOLED ? CAP : NUM_CAMS * CAP) * 4;
+constexpr uint32_t flag_bytes = FLG_W * 2;
+constexpr uint32_t flag_stride = ((flag_bytes + 31) / 32) * 32;  // same, per camera
+constexpr uint32_t bidx_row_bytes = BIDX_W * 4;
+
+// The accessor args start after ALL of the scalars above. Adding a compile-time arg
+// ahead of this offset without moving it silently corrupts every accessor.
+constexpr auto grid_args  = TensorAccessorArgs<22>();
+constexpr auto cgrid_args = TensorAccessorArgs<grid_args.next_compile_time_args_offset()>();
+constexpr auto index_args = TensorAccessorArgs<cgrid_args.next_compile_time_args_offset()>();
+constexpr auto flags_args = TensorAccessorArgs<index_args.next_compile_time_args_offset()>();
+constexpr uint32_t BIDX_OFF = flags_args.next_compile_time_args_offset();
+
+// bidx's accessor args only EXIST in pooled mode, so everything that touches them has to
+// live in a template: an `if constexpr` inside kernel_main() would not discard the branch
+// (kernel_main is not a template) and TensorAccessorArgs<BIDX_OFF> would still be
+// instantiated past the end of the arg list. It has to stay a PARTIAL specialization for
+// the same reason — a full `template <> struct BidxWriter<true>` is a concrete class and
+// its members are instantiated where it is defined, not where it is used.
+template <bool P, uint32_t OFF>
+struct BidxWriter {
+    explicit BidxWriter(uint32_t) {}
+    FORCE_INLINE void write(uint32_t, uint32_t) const {}
+};
+
+template <uint32_t OFF>
+struct BidxWriter<true, OFF> {
+    decltype(TensorAccessor(TensorAccessorArgs<OFF>(), 0u)) acc;
+    uint32_t stage_l1;
+
+    // One staged row per camera instead of the whole CAP x BIDX_W buffer: a row is
+    // (camera, 0, 0, ...) and only NUM_CAMS distinct rows ever exist, so the L1 cost
+    // drops from ~30 KB to under 256 B and the per-slot work becomes a single write.
+    explicit BidxWriter(uint32_t bidx_addr)
+        : acc(TensorAccessorArgs<OFF>(), bidx_addr), stage_l1(get_write_ptr(BIDX_CB)) {
+        volatile tt_l1_ptr uint32_t* s = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(stage_l1);
+        for (uint32_t c = 0; c < NUM_CAMS; c++) {
+            for (uint32_t j = 0; j < BIDX_W; j++) {
+                s[c * BIDX_W + j] = (j == 0) ? c : 0u;
+            }
         }
     }
-}
+
+    // Every bidx slot must name a real camera, including the ones past the kept count:
+    // grid_sample still walks those sticks and turns the value into a NOC address, so a
+    // stale one would be an out-of-range read rather than a discarded sample. Camera 0
+    // is written into the tail for exactly that reason.
+    FORCE_INLINE void write(uint32_t slot, uint32_t cam) const {
+        noc_async_write(stage_l1 + cam * bidx_row_bytes, acc.get_noc_addr(slot), bidx_row_bytes);
+    }
+};
 
 void kernel_main() {
-    const uint32_t grid_addr  = get_arg_val<uint32_t>(0);
-    const uint32_t cgrid_addr = get_arg_val<uint32_t>(1);
-    const uint32_t index_addr = get_arg_val<uint32_t>(2);
-    const uint32_t flags_addr = get_arg_val<uint32_t>(3);
-    const uint32_t bidx_addr  = get_arg_val<uint32_t>(4);
+    // The buffer addresses are the same on every core, so they go in the COMMON args and
+    // are the only thing the host rewrites per dispatch. Putting them in per-core args
+    // meant re-writing 5 words x 64 cores every call, which measured 84 us of host time.
+    const uint32_t grid_addr  = get_common_arg_val<uint32_t>(0);
+    const uint32_t cgrid_addr = get_common_arg_val<uint32_t>(1);
+    const uint32_t index_addr = get_common_arg_val<uint32_t>(2);
+    const uint32_t flags_addr = get_common_arg_val<uint32_t>(3);
+    const uint32_t bidx_addr  = get_common_arg_val<uint32_t>(4);
+    const uint32_t core_id    = get_arg_val<uint32_t>(0);
 
-    constexpr uint32_t NUM_ROWS = get_compile_time_arg_val(0);
-    constexpr uint32_t NUM_PTS  = get_compile_time_arg_val(1);
-    constexpr uint32_t ROW_W    = get_compile_time_arg_val(2);
-    constexpr uint32_t CAP      = get_compile_time_arg_val(3);
-    constexpr uint32_t ANCHORS  = get_compile_time_arg_val(4);
-    constexpr uint32_t THR_X    = get_compile_time_arg_val(5);
-    constexpr uint32_t ROW_CB   = get_compile_time_arg_val(6);
-    constexpr uint32_t IDX_CB   = get_compile_time_arg_val(7);
-    constexpr uint32_t BATCH    = get_compile_time_arg_val(8);
-    constexpr uint32_t FLG_CB   = get_compile_time_arg_val(9);
-    constexpr uint32_t FLG_W    = get_compile_time_arg_val(10);
-    constexpr uint32_t THR_Y    = get_compile_time_arg_val(11);
-    // Pooled: one shared list of kept rows, each carrying its camera in bidx, instead of a
-    // fixed block per camera. The cameras do not peak together, so the shared list needs
-    // barely half the capacity for the same zero-loss guarantee.
-    constexpr uint32_t POOLED   = get_compile_time_arg_val(12);
-    constexpr uint32_t BIDX_CB  = get_compile_time_arg_val(13);
-    constexpr uint32_t BIDX_W   = get_compile_time_arg_val(14);
-
-    constexpr uint32_t SENTINEL = 0xFFFFFFFFu;
-    constexpr uint32_t ABS_MASK = 0x7FFFFFFFu;
-    constexpr uint16_t BF16_ONE = 0x3F80u;  // 1.0f truncated to bfloat16
-    constexpr uint32_t row_bytes = ROW_W * 4;
-    // NOC endpoints must be 32 B aligned, and a row is 26 floats = 104 B, so the L1
-    // batch buffer is strided at the aligned size while only row_bytes is transferred.
-    // Packing rows tight in L1 put every odd row at a misaligned address and the reads
-    // came back as garbage — which read as in bounds and kept everything.
-    constexpr uint32_t row_stride = ((row_bytes + 31) / 32) * 32;
-    constexpr uint32_t NUM_CAMS = NUM_ROWS / ANCHORS;
-    constexpr uint32_t idx_bytes = (POOLED ? CAP : NUM_CAMS * CAP) * 4;
-    constexpr uint32_t flag_bytes = FLG_W * 2;
-    constexpr uint32_t flag_stride = ((flag_bytes + 31) / 32) * 32;  // same, per camera
-
-    constexpr auto grid_args  = TensorAccessorArgs<15>();  // 0-14 are the scalars above
-    constexpr auto cgrid_args = TensorAccessorArgs<grid_args.next_compile_time_args_offset()>();
-    constexpr auto index_args = TensorAccessorArgs<cgrid_args.next_compile_time_args_offset()>();
-    constexpr auto flags_args = TensorAccessorArgs<index_args.next_compile_time_args_offset()>();
     // No explicit page size: that argument is the ALIGNED page size, and DRAM pages are
     // padded to 32 B. A grid row is 26 floats = 104 B, which pads to 128, so passing
     // row_bytes here put every row after the first at the wrong address — the kernel
     // then read garbage and kept every row. Let TensorAccessorArgs supply the real one.
-    const auto grid_acc  = TensorAccessor(grid_args, grid_addr);
+    const auto grid_acc = TensorAccessor(grid_args, grid_addr);
+
+    const uint32_t row_l1  = get_write_ptr(ROW_CB);
+    const uint32_t mask_l1 = get_write_ptr(MASK_CB);
+    volatile tt_l1_ptr uint8_t* mask = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(mask_l1);
+
+    // ---------------------------------------------------------------- phase 1
+    // Every core tests its own contiguous slice. The slices are laid out at a stride of
+    // MASK_BLK rather than RPC so each core's relay lands on a 32 B boundary, which the
+    // NOC requires; the slack bytes are zeroed so phase 2 can read a block whole.
+    const uint32_t my_start = core_id * RPC;
+    uint32_t my_count = 0;
+    if (my_start < NUM_ROWS) {
+        my_count = NUM_ROWS - my_start;
+        if (my_count > RPC) {
+            my_count = RPC;
+        }
+    }
+
+    for (uint32_t b = 0; b < my_count; b++) {
+        noc_async_read(grid_acc.get_noc_addr(my_start + b), row_l1 + b * row_stride, row_bytes);
+    }
+    noc_async_read_barrier();
+
+    volatile tt_l1_ptr uint8_t* my_mask = mask + core_id * MASK_BLK;
+    for (uint32_t b = 0; b < my_count; b++) {
+        volatile tt_l1_ptr int16_t* rp =
+            reinterpret_cast<volatile tt_l1_ptr int16_t*>(row_l1 + b * row_stride);
+        uint8_t valid = 0;
+        for (uint32_t p = 0; p < NUM_PTS; p++) {
+            const int32_t vx = rp[2 * p];
+            const int32_t vy = rp[2 * p + 1];
+            const int32_t ax = vx < 0 ? -vx : vx;
+            const int32_t ay = vy < 0 ? -vy : vy;
+            if (ax < (int32_t)THR_X && ay < (int32_t)THR_Y) {
+                valid = 1;
+                break;
+            }
+        }
+        my_mask[b] = valid;
+    }
+    for (uint32_t b = my_count; b < MASK_BLK; b++) {
+        my_mask[b] = 0;
+    }
+
+    Noc noc;
+    Semaphore<> sem(SEM_ID);
+
+    if (core_id != 0) {
+        noc_async_write(mask_l1 + core_id * MASK_BLK,
+                        get_noc_addr(C0_X, C0_Y, mask_l1 + core_id * MASK_BLK),
+                        MASK_BLK);
+        noc_async_write_barrier();  // the relay must land before the semaphore says it did
+        sem.up(noc, C0_X, C0_Y, 1);
+        return;
+    }
+
+    // ---------------------------------------------------------------- phase 2
+    sem.wait(NUM_CORES - 1);
+
     const auto cgrid_acc = TensorAccessor(cgrid_args, cgrid_addr);
     const auto index_acc = TensorAccessor(index_args, index_addr);
     const auto flags_acc = TensorAccessor(flags_args, flags_addr);
+    BidxWriter<POOLED != 0, BIDX_OFF> bidx(bidx_addr);
 
-    const uint32_t row_l1 = get_write_ptr(ROW_CB);
     const uint32_t idx_l1 = get_write_ptr(IDX_CB);
     const uint32_t flg_l1 = get_write_ptr(FLG_CB);
-    volatile tt_l1_ptr uint32_t* row = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(row_l1);
     volatile tt_l1_ptr uint32_t* idx = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(idx_l1);
     // One bf16 flag per (camera, anchor), kept in L1 for the whole pass and dumped at
     // the end: a per-camera flush would have to barrier mid-batch before reusing the
@@ -120,78 +235,104 @@ void kernel_main() {
     for (uint32_t i = 0; i < NUM_CAMS * (flag_stride / 2); i++) {
         flg[i] = 0;
     }
-    // Every bidx slot must name a real camera, including the ones past the kept count:
-    // grid_sample still walks those sticks and turns the value into a NOC address, so a
-    // stale one would be an out-of-range read rather than a discarded sample.
-    volatile tt_l1_ptr uint32_t* bidx = nullptr;
-    if constexpr (POOLED) {
-        bidx = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(BIDX_CB));
-        for (uint32_t i = 0; i < CAP * BIDX_W; i++) {
-            bidx[i] = 0;
-        }
-    }
+
+    uint32_t pend_row[BATCH];
+    uint32_t pend_cam[BATCH];
+    uint32_t np = 0;
+    uint32_t n = 0;        // kept rows in the current camera (pooled: overall)
+    uint32_t cur_cam = 0;  // camera of the rows being written
+    uint32_t scan_cam = 0;  // camera of the row being scanned, always >= cur_cam
 
     // Rows are fetched BATCH at a time. One barrier per batch instead of per row:
     // a per-row barrier waits out the full DRAM round trip before issuing the next
     // read, which measured 1.96 ms/call — the loop was latency-bound, not busy.
-    uint32_t n = 0;        // kept rows in the current camera
-    uint32_t cam = 0;
-    uint32_t cam_base = 0;
-    uint32_t next_cam_row = ANCHORS;
-
-    for (uint32_t base = 0; base < NUM_ROWS; base += BATCH) {
-        uint32_t count = BATCH;
-        if (base + count > NUM_ROWS) {
-            count = NUM_ROWS - base;
-        }
-        for (uint32_t b = 0; b < count; b++) {
-            noc_async_read(grid_acc.get_noc_addr(base + b), row_l1 + b * row_stride, row_bytes);
+    // Only the KEPT rows are fetched here; phase 1 already read everything once, but
+    // re-reading ~900 of 2700 rows is cheaper than staging 345 KB across cores.
+    auto flush = [&]() {
+        for (uint32_t i = 0; i < np; i++) {
+            noc_async_read(grid_acc.get_noc_addr(pend_row[i]), row_l1 + i * row_stride, row_bytes);
         }
         noc_async_read_barrier();
-
-        for (uint32_t b = 0; b < count; b++) {
-            const uint32_t r = base + b;
-            if (r >= next_cam_row) {  // rows are camera-major, so this walks the cameras
-                if constexpr (!POOLED) {
+        for (uint32_t i = 0; i < np; i++) {
+            const uint32_t r = pend_row[i];
+            const uint32_t c = pend_cam[i];
+            if constexpr (!POOLED) {
+                if (c != cur_cam) {
                     while (n < CAP) {  // SENTINEL-fill the tail of the camera we just left
-                        idx[cam * CAP + n] = SENTINEL;
+                        idx[cur_cam * CAP + n] = SENTINEL;
                         n++;
                     }
+                    cur_cam = c;
                     n = 0;
                 }
-                cam++;
-                cam_base = next_cam_row;
-                next_cam_row += ANCHORS;
             }
-            volatile tt_l1_ptr uint32_t* rp = row + b * (row_stride / 4);
-
-            bool valid = false;
-            for (uint32_t p = 0; p < NUM_PTS; p++) {
-                const uint32_t ax = rp[2 * p] & ABS_MASK;
-                const uint32_t ay = rp[2 * p + 1] & ABS_MASK;
-                if (ax < THR_X && ay < THR_Y) {
-                    valid = true;
-                    break;
-                }
+            if (n >= CAP) {
+                continue;
             }
-
-            if (valid && n < CAP) {
-                const uint32_t slot = POOLED ? n : (cam * CAP + n);
-                if constexpr (POOLED) {
-                    bidx[n * BIDX_W] = cam;
-                }
-                noc_async_write(row_l1 + b * row_stride,
-                                cgrid_acc.get_noc_addr(slot), row_bytes);
-                idx[slot] = r;
-                // Flag the rows that were actually KEPT, not the ones that merely
-                // passed the bounds test: a row past CAP is dropped too, and its
-                // slot in the feature buffer keeps last frame's values.
-                flg[cam * (flag_stride / 2) + (r - cam_base)] = BF16_ONE;
-                n++;
-            }
+            const uint32_t slot = POOLED ? n : (c * CAP + n);
+            noc_async_write(row_l1 + i * row_stride, cgrid_acc.get_noc_addr(slot), row_bytes);
+            idx[slot] = r;
+            bidx.write(slot, c);
+            // Flag the rows that were actually KEPT, not the ones that merely passed the
+            // bounds test: a row past CAP is dropped too, and its slot in the feature
+            // buffer keeps last frame's values.
+            flg[c * (flag_stride / 2) + (r - c * ANCHORS)] = BF16_ONE;
+            n++;
         }
         // the batch buffer is about to be refilled, so the writes out of it must land
         noc_async_write_barrier();
+        np = 0;
+    };
+
+    bool done = false;
+    for (uint32_t blk = 0; blk < NUM_CORES && !done; blk++) {
+        const uint32_t base = blk * RPC;
+        if (base >= NUM_ROWS) {
+            break;
+        }
+        uint32_t cnt = NUM_ROWS - base;
+        if (cnt > RPC) {
+            cnt = RPC;
+        }
+        volatile tt_l1_ptr uint8_t* blk_mask = mask + blk * MASK_BLK;
+        for (uint32_t j = 0; j < cnt; j++) {
+            if (!blk_mask[j]) {
+                continue;
+            }
+            const uint32_t r = base + j;
+            // Once the budget is full there is nothing left to emit, and every row past
+            // that point would still be FETCHED by flush() before being discarded. On a
+            // grid where most rows pass the bounds test that was 2700 DRAM reads to write
+            // 928 rows.
+            if (n + np >= CAP) {
+                if constexpr (POOLED) {
+                    done = true;
+                    break;
+                }
+                // Per camera the budget is per block, so only the saturated camera's
+                // remaining rows are skipped — the next camera starts a fresh count.
+                while (r >= (scan_cam + 1) * ANCHORS) {
+                    scan_cam++;
+                }
+                if (scan_cam == cur_cam) {
+                    continue;
+                }
+            }
+            pend_row[np] = r;
+            // Rows are camera-major and r only increases, so the camera is a running
+            // counter rather than a divide — the dataflow core has no divider.
+            while (r >= (scan_cam + 1) * ANCHORS) {
+                scan_cam++;
+            }
+            pend_cam[np] = scan_cam;
+            np++;
+            if (np == BATCH) {
+                flush();
+            }
+        }
+    }
+    if (np > 0) {
+        flush();
     }
 
     if constexpr (POOLED) {
@@ -200,14 +341,22 @@ void kernel_main() {
         }
     } else {
         for (uint32_t j = n; j < CAP; j++) {  // tail of the last camera
-            idx[cam * CAP + j] = SENTINEL;
+            idx[cur_cam * CAP + j] = SENTINEL;
+        }
+        for (uint32_t c = cur_cam + 1; c < NUM_CAMS; c++) {  // cameras that kept nothing
+            for (uint32_t j = 0; j < CAP; j++) {
+                idx[c * CAP + j] = SENTINEL;
+            }
         }
     }
+    // The tail slots must still name a real camera; the staged row 0 does that.
+    for (uint32_t j = n; j < CAP; j++) {
+        bidx.write(j, 0);
+    }
+
     noc_async_write(idx_l1, index_acc.get_noc_addr(0), idx_bytes);
     for (uint32_t c = 0; c < NUM_CAMS; c++) {  // one page per camera
         noc_async_write(flg_l1 + c * flag_stride, flags_acc.get_noc_addr(c), flag_bytes);
     }
-    write_bidx<POOLED != 0, flags_args.next_compile_time_args_offset(), BIDX_CB, CAP, BIDX_W>(
-        bidx_addr);
     noc_async_write_barrier();
 }

--- a/tt-metal/ops/grid_sample/device/grid_sample_device_operation.cpp
+++ b/tt-metal/ops/grid_sample/device/grid_sample_device_operation.cpp
@@ -109,8 +109,9 @@ void GridSampleOperation::validate_on_program_cache_miss(
         TT_FATAL(grid_tensor.dtype() == DataType::BFLOAT16, "Precomputed grid tensor must be BFLOAT16");
     } else {
         TT_FATAL(
-            grid_tensor.dtype() == DataType::BFLOAT16 || grid_tensor.dtype() == DataType::FLOAT32,
-            "Grid tensor must be BFLOAT16 or FLOAT32");
+            grid_tensor.dtype() == DataType::BFLOAT16 || grid_tensor.dtype() == DataType::FLOAT32 ||
+                grid_tensor.dtype() == DataType::UINT16,
+            "Grid tensor must be BFLOAT16, FLOAT32, or UINT16 (Q14 fixed point)");
     }
 
     // Layout validation

--- a/tt-metal/ops/grid_sample/device/kernels/grid_sample_reader_common.hpp
+++ b/tt-metal/ops/grid_sample/device/kernels/grid_sample_reader_common.hpp
@@ -20,6 +20,15 @@ constexpr uint32_t STANDARD_GRID_ELEMENTS_PER_POINT = 2;
 // Data type constants (from ttnn/api/ttnn/tensor/types.hpp DataType enum)
 constexpr uint32_t DTYPE_BFLOAT16 = 0;
 constexpr uint32_t DTYPE_FLOAT32 = 1;
+// UINT16 is a CONTAINER for a Q14 fixed-point coordinate, not an unsigned value. The
+// coordinate is clamped to [-2, 2], so a float's exponent bits buy nothing while the
+// bilinear weight it feeds is the coordinate's fractional part and wants uniform
+// absolute precision. Measured relative error in the sampled value: bf16 3.8e-2,
+// Q14 8.6e-4, against 1.0e-3 from the feature map's own bf16 storage.
+// The shift is shared with kps_project_fused (which writes it) and grid_compact.
+constexpr uint32_t DTYPE_UINT16 = 6;
+constexpr int32_t GRID_FIXED_SHIFT = 14;
+constexpr float GRID_FIXED_INV = 1.0f / (float)(1 << GRID_FIXED_SHIFT);
 
 // Utility functions
 ALWI bool is_coordinate_valid(int32_t coord, uint32_t max_size) {
@@ -79,6 +88,13 @@ struct GridCoordinateReader {
                 const uint32_t float_offset = grid_idx * STANDARD_GRID_ELEMENTS_PER_POINT;
                 w_coord_rel = float_data[float_offset + 0];  // x coordinate
                 h_coord_rel = float_data[float_offset + 1];  // y coordinate
+            } else if constexpr (grid_dtype == DTYPE_UINT16) {
+                // Q14 fixed point: reinterpret the 16 bits as signed and scale.
+                const uint32_t coordinate_pair_offset = grid_idx * STANDARD_GRID_ELEMENTS_PER_POINT;
+                const uint16_t h_raw = grid_ptr[coordinate_pair_offset + 1];  // y coordinate
+                const uint16_t w_raw = grid_ptr[coordinate_pair_offset + 0];  // x coordinate
+                h_coord_rel = static_cast<float>(static_cast<int16_t>(h_raw)) * GRID_FIXED_INV;
+                w_coord_rel = static_cast<float>(static_cast<int16_t>(w_raw)) * GRID_FIXED_INV;
             } else {
                 // For BFLOAT16 grid, read as uint16 and convert
                 const uint32_t coordinate_pair_offset = grid_idx * STANDARD_GRID_ELEMENTS_PER_POINT;

--- a/tt-metal/ops/grouped_weighted_sum/device/grouped_weighted_sum_device_operation.cpp
+++ b/tt-metal/ops/grouped_weighted_sum/device/grouped_weighted_sum_device_operation.cpp
@@ -22,13 +22,27 @@ void GroupedWeightedSumOperation::validate_on_program_cache_miss(
     TT_FATAL(t.features.layout() == Layout::TILE || t.features.layout() == Layout::ROW_MAJOR,
              "features must be TILE or ROW_MAJOR");
     TT_FATAL(t.weights.layout() == Layout::TILE, "weights must be TILE");
-    TT_FATAL(t.features.logical_shape().rank() == 3, "features must be 3D [n, clp, E]");
-    TT_FATAL(t.weights.logical_shape().rank() == 3, "weights must be 3D [n, clp, G]");
-    TT_FATAL(t.features.logical_shape()[0] == t.weights.logical_shape()[0], "n must match");
-    TT_FATAL(t.features.logical_shape()[1] == t.weights.logical_shape()[1], "clp must match");
+    TT_FATAL(t.features.logical_shape().rank() == 3, "features must be 3D [clp, N, E]");
     TT_FATAL(t.features.logical_shape()[-1] == attrs.num_groups * attrs.group_dims, "E must be G*D");
-    TT_FATAL(t.weights.logical_shape()[-1] == attrs.num_groups, "last dim must be num_groups");
     TT_FATAL(attrs.group_dims == 32, "group_dims must be 32 (== TILE_WIDTH) in current implementation");
+
+    const uint32_t clp = t.features.logical_shape()[0];
+    const uint32_t anchors = t.features.logical_shape()[1];
+    const auto& w = t.weights.logical_shape();
+    // Two accepted weight layouts, told apart by the last dimension. COMPACT [N, clp*G]
+    // fills every column of a tile; the 3D [clp, N, G] leaves 24 of 32 as padding, which
+    // is 4x the tensor and 4x the reader's DRAM traffic for the same numbers.
+    if (w[-1] == attrs.num_groups * clp) {
+        TT_FATAL(w[-2] == anchors, "compact weights must be [N, clp*G]; got N={}", w[-2]);
+        TT_FATAL((attrs.num_groups * clp) % 32 == 0,
+                 "compact weights need clp*G to be a multiple of the tile width; got {}",
+                 attrs.num_groups * clp);
+    } else {
+        TT_FATAL(w.rank() == 3, "weights must be 3D [clp, N, G] or compact [N, clp*G]");
+        TT_FATAL(w[-1] == attrs.num_groups, "last dim must be num_groups");
+        TT_FATAL(w[0] == clp, "clp must match");
+        TT_FATAL(w[1] == anchors, "N must match");
+    }
 }
 
 TensorSpec GroupedWeightedSumOperation::compute_output_specs(

--- a/tt-metal/ops/grouped_weighted_sum/device/grouped_weighted_sum_program_factory.cpp
+++ b/tt-metal/ops/grouped_weighted_sum/device/grouped_weighted_sum_program_factory.cpp
@@ -76,6 +76,11 @@ GroupedWeightedSumProgramFactory::cached_program_t GroupedWeightedSumProgramFact
     reader_ct_args.push_back(rm_mode ? 1U : 0U);  // RM_MODE
     reader_ct_args.push_back(N_total);              // RM_N
     reader_ct_args.push_back(rm_mode ? rm_stick_size : 0U); // RM_STICK_SZ
+    // Compact weights, [N, clp*G]: one tile spans 32/G consecutive clp with no padding
+    // column, against one tile per clp with 24 of 32 columns wasted.
+    const bool wt_compact = t.weights.logical_shape()[-1] == static_cast<int32_t>(G * n);
+    reader_ct_args.push_back(wt_compact ? 1U : 0U);                 // WT_COMPACT
+    reader_ct_args.push_back(wt_compact ? (G * n) / 32 : 0U);       // WT_TC: tiles per row
 
     auto reader_kernel_id = CreateKernel(program,
         "ttnn/cpp/ttnn/operations/pool/grouped_weighted_sum/device/kernels/dataflow/reader_grouped_weighted_sum.cpp",

--- a/tt-metal/ops/grouped_weighted_sum/device/kernels/dataflow/reader_grouped_weighted_sum.cpp
+++ b/tt-metal/ops/grouped_weighted_sum/device/kernels/dataflow/reader_grouped_weighted_sum.cpp
@@ -34,6 +34,14 @@ void kernel_main() {
     constexpr uint32_t RM_MODE     = get_compile_time_arg_val(RM_OFFSET);
     constexpr uint32_t RM_N        = get_compile_time_arg_val(RM_OFFSET + 1);  // total anchors
     constexpr uint32_t RM_STICK_SZ = get_compile_time_arg_val(RM_OFFSET + 2);  // C*2
+    // COMPACT weights: [anchors, clp*G] instead of [clp, anchors, G]. The second layout
+    // spends 24 of every tile's 32 columns on padding, because G is 8 and a tile is 32
+    // wide; the first fills every column, so a tile covers 32/G consecutive clp at once
+    // and the whole tensor is 4x smaller. Getting there also costs the model nothing: the
+    // linear already produces [anchors, clp*G], and it is the reshape INTO [anchors, clp, G]
+    // that was the single most expensive op in the attention-weight path.
+    constexpr uint32_t WT_COMPACT = get_compile_time_arg_val(RM_OFFSET + 3);
+    constexpr uint32_t WT_TC      = get_compile_time_arg_val(RM_OFFSET + 4);  // tiles per row
 
     // Feature accessor: use correct page_size based on mode
     const auto feat_acc = TensorAccessor(feat_args, feat_addr, feat_page_bytes);
@@ -56,6 +64,11 @@ void kernel_main() {
             z[i] = 0;
         }
     }
+
+    // wt_raw_cb holds a single page that is never pushed or popped, so its address is
+    // fixed and a tile already sitting there can be reused. In the compact layout the
+    // inner loop walks clp one at a time while the tile only changes every 32/G steps.
+    uint32_t cached_wt_tile = 0xFFFFFFFFu;
 
     for (uint32_t wu = 0; wu < num_wus; wu++) {
         uint32_t wu_id = start_wu + wu;
@@ -93,23 +106,42 @@ void kernel_main() {
             }
 
             // === Weight read ===
+            // Compact: this clp's G columns start at column clp*G of tile-row n_tr, so one
+            // tile serves 32/G consecutive clp and is only re-read when clp crosses it.
+            uint32_t wt_tile_id, col_base;
+            if constexpr (WT_COMPACT) {
+                const uint32_t c0 = clp * NUM_GROUPS;
+                wt_tile_id = n_tr * WT_TC + (c0 >> 5);
+                col_base = c0 & 31;
+            } else {
+                wt_tile_id = clp * wt_tpb + n_tr;
+                col_base = 0;
+            }
             uint32_t wt_raw_l1 = get_write_ptr(wt_raw_cb);
-            noc_async_read(wt_acc.get_noc_addr(clp * wt_tpb + n_tr),
-                           wt_raw_l1, wt_tile_bytes);
+            if (wt_tile_id != cached_wt_tile) {
+                noc_async_read(wt_acc.get_noc_addr(wt_tile_id), wt_raw_l1, wt_tile_bytes);
+                cached_wt_tile = wt_tile_id;
+            }
             noc_async_read_barrier();
             cb_push_back(feat_cb, FEAT_TC);
 
             // === Extract weight columns ===
+            // A 32x32 tile is stored as four 16x16 faces, so a column lands in face
+            // (row>=16)*2 + (col>=16) at offset (row%16)*16 + col%16. col_base is 0 in the
+            // non-compact layout, which reduces this to the original "column g" case.
             volatile tt_l1_ptr uint16_t* raw = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(wt_raw_l1);
             cb_reserve_back(wt_col_cb, NUM_GROUPS);
             uint32_t col_l1 = get_write_ptr(wt_col_cb);
             for (uint32_t g = 0; g < NUM_GROUPS; g++) {
+                const uint32_t sc = col_base + g;
+                const uint32_t cf = (sc >= 16) ? 1 : 0;
+                const uint32_t cc = sc & 15;
                 volatile tt_l1_ptr uint16_t* col = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(
                     col_l1 + g * wt_tile_bytes);
                 for (uint32_t r = 0; r < 32; r++) {
-                    uint32_t sf = (r >= 16) ? 2 : 0;
+                    uint32_t sf = ((r >= 16) ? 2 : 0) + cf;
                     uint32_t fr = r % 16;
-                    uint16_t val = raw[sf * 256 + fr * 16 + g];
+                    uint16_t val = raw[sf * 256 + fr * 16 + cc];
                     uint32_t df = (r >= 16) ? 2 : 0;
                     col[df * 256 + fr * 16 + 0] = val;
                 }

--- a/tt-metal/ops/kps_project_fused/device/kernels/dataflow/reader_kps_project.cpp
+++ b/tt-metal/ops/kps_project_fused/device/kernels/dataflow/reader_kps_project.cpp
@@ -21,6 +21,25 @@ constexpr uint32_t ANC_X = 0, ANC_Y = 1, ANC_Z = 2;
 constexpr uint32_t ANC_SIN_YAW = 6, ANC_COS_YAW = 7;
 
 // bf16 → f32 conversion: bf16 is upper 16 bits of f32
+// Q14 fixed point over [-2, 2]: the grid coordinate is clamped to that range, so the
+// exponent bits a float spends are dead weight, while the bilinear weight it feeds is the
+// coordinate's FRACTIONAL part and therefore wants uniform ABSOLUTE precision. Both
+// grid_compact and grid_sample decode with the same shift; changing it means changing all
+// three. GRID_FIXED_SHIFT 29 with an int32 container is the same code at twice the width.
+constexpr int32_t GRID_FIXED_SHIFT = 14;
+constexpr float GRID_FIXED_SCALE = (float)(1 << GRID_FIXED_SHIFT);
+
+inline int16_t f32_to_grid_fixed(float g) {
+    // Saturate rather than wrap: the clamp above already caps |g| at 2, whose exact
+    // encoding is one past INT16_MAX, and anything at the cap is far outside the bounds
+    // test regardless.
+    float v = g * GRID_FIXED_SCALE;
+    int32_t q = (int32_t)(v >= 0.0f ? v + 0.5f : v - 0.5f);
+    if (q > 32767) q = 32767;
+    if (q < -32768) q = -32768;
+    return (int16_t)q;
+}
+
 inline float bf16_to_f32(uint16_t bf16) {
     uint32_t bits = static_cast<uint32_t>(bf16) << 16;
     float result;
@@ -80,6 +99,11 @@ void kernel_main() {
     constexpr uint32_t PRECOMPUTE_OFFSET = wh_args.next_compile_time_args_offset();
     constexpr uint32_t PRECOMPUTE = get_compile_time_arg_val(PRECOMPUTE_OFFSET);
     constexpr uint32_t NL = get_compile_time_arg_val(PRECOMPUTE_OFFSET + 1);
+    // The anchor centre reaches the projection as either bf16 or fp32. bf16 costs 0.081 px
+    // of grid error on the finest FPN level (measured, layer 0) because its absolute error
+    // scales with |x|, |y| which reach +-60 m — and the projection's division by depth
+    // cancels the distance, leaving the error flat rather than falling off.
+    constexpr uint32_t ANC_FP32 = get_compile_time_arg_val(PRECOMPUTE_OFFSET + 2);
 
     const auto kp_accessor = TensorAccessor(kp_args, kp_addr, kp_page_size);
     const auto anchor_accessor = TensorAccessor(anchor_args, anchor_addr, anchor_page_size);
@@ -117,12 +141,22 @@ void kernel_main() {
             noc_async_read(noc_addr, anchor_l1, anchor_page_size);
             noc_async_read_barrier();
         }
-        volatile tt_l1_ptr uint16_t* anc_bf16 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(anchor_l1);
-        float cos_yaw = bf16_to_f32(anc_bf16[ANC_COS_YAW]);
-        float sin_yaw = bf16_to_f32(anc_bf16[ANC_SIN_YAW]);
-        float cx = bf16_to_f32(anc_bf16[ANC_X]);
-        float cy = bf16_to_f32(anc_bf16[ANC_Y]);
-        float cz = bf16_to_f32(anc_bf16[ANC_Z]);
+        float cos_yaw, sin_yaw, cx, cy, cz;
+        if constexpr (ANC_FP32) {
+            volatile tt_l1_ptr float* a = reinterpret_cast<volatile tt_l1_ptr float*>(anchor_l1);
+            cos_yaw = a[ANC_COS_YAW];
+            sin_yaw = a[ANC_SIN_YAW];
+            cx = a[ANC_X];
+            cy = a[ANC_Y];
+            cz = a[ANC_Z];
+        } else {
+            volatile tt_l1_ptr uint16_t* a = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(anchor_l1);
+            cos_yaw = bf16_to_f32(a[ANC_COS_YAW]);
+            sin_yaw = bf16_to_f32(a[ANC_SIN_YAW]);
+            cx = bf16_to_f32(a[ANC_X]);
+            cy = bf16_to_f32(a[ANC_Y]);
+            cz = bf16_to_f32(a[ANC_Z]);
+        }
 
         // Read key_points[a, :num_pts, :3]
         uint32_t kp_l1 = get_write_ptr(kp_cb_index);
@@ -250,7 +284,12 @@ void kernel_main() {
                     cb_reserve_back(out_cb_index, NC);
                 }
                 uint32_t out_l1 = get_write_ptr(out_cb_index) + c * out_page_size;
-                volatile tt_l1_ptr float* out = reinterpret_cast<volatile tt_l1_ptr float*>(out_l1);
+                // The projection itself stays in fp32 — only the stored coordinate is
+                // quantised. Rounding at the end rather than partway keeps it to the
+                // single step the consumer actually sees, which matters here because the
+                // intermediate 1/z spans up to 1e10 and needs the float range.
+                volatile tt_l1_ptr int16_t* out =
+                    reinterpret_cast<volatile tt_l1_ptr int16_t*>(out_l1);
 
                 for (uint32_t p = 0; p < NUM_PTS; p++) {
                     uint32_t bf16_offset = p * (kp_page_size / sizeof(uint16_t));
@@ -284,8 +323,8 @@ void kernel_main() {
                     if (grid_y < -2.0f) grid_y = -2.0f;
                     if (grid_y >  2.0f) grid_y =  2.0f;
 
-                    out[p * 2 + 0] = grid_x;
-                    out[p * 2 + 1] = grid_y;
+                    out[p * 2 + 0] = f32_to_grid_fixed(grid_x);
+                    out[p * 2 + 1] = f32_to_grid_fixed(grid_y);
                 }
                 // Batch CB: push all NC pages at once (last camera only)
                 if (c == NC - 1) {

--- a/tt-metal/ops/kps_project_fused/device/kps_project_fused_device_operation.cpp
+++ b/tt-metal/ops/kps_project_fused/device/kps_project_fused_device_operation.cpp
@@ -71,12 +71,24 @@ TensorSpec KpsProjectFusedOperation::compute_output_specs(
                 output_shape, output_shape));
     }
     // Standard: input [n, pts, 3] → n is dim[0]
+    // The grid is 16-bit FIXED POINT, Q14 over [-2, 2] — see GRID_FIXED_SHIFT below.
+    //
+    // bf16 is the wrong 16-bit format here. The coordinate is clamped to [-2, 2], so the
+    // 8 bits bf16 spends on an exponent buy nothing, while bilinear sampling cares about
+    // the ABSOLUTE error in the coordinate (the weight is its fractional part). Measured
+    // as relative error in the sampled value: bf16 3.8e-2, Q14 fixed point 8.6e-4 — and
+    // the feature map's own bf16 storage already contributes 1.0e-3, so the fixed-point
+    // grid sits below the noise that is there regardless. bf16 coordinates cost
+    // 0.0012 mAP / 0.0024 NDS on nuScenes val; this is what replaces them.
+    //
+    // UINT16 is a container, not the interpretation: ttnn has no INT16, and the kernels
+    // reinterpret the bits. Nothing reads this tensor as an unsigned integer.
     const uint32_t n = t.key_points.logical_shape()[0];
     const ttnn::Shape output_shape({attrs.num_cams, n, 1, attrs.num_pts * 2});
     return TensorSpec(
         output_shape,
         TensorLayout::fromPaddedShape(
-            DataType::FLOAT32,
+            DataType::UINT16,
             PageConfig(Layout::ROW_MAJOR),
             attrs.output_mem_config,
             output_shape, output_shape));

--- a/tt-metal/ops/kps_project_fused/device/kps_project_fused_program_factory.cpp
+++ b/tt-metal/ops/kps_project_fused/device/kps_project_fused_program_factory.cpp
@@ -42,7 +42,10 @@ KpsProjectFusedProgramFactory::cached_program_t KpsProjectFusedProgramFactory::c
     const uint32_t proj_page_size = tt::round_up(4 * sizeof(float), align);     // proj_mat always f32
     const uint32_t wh_page_size = tt::round_up(2 * sizeof(float), align);       // image_wh always f32
     const uint32_t NL = attrs.precompute_grid ? attrs.spatial_shapes.size() : 0;
-    const uint32_t out_elem_size = (attrs.precompute_grid && !standalone_precompute) ? sizeof(uint16_t) : sizeof(float);
+    // 16 bits either way: bf16 for the precomputed weights, Q14 fixed point for the
+    // standard normalised grid. The formats differ because the quantities do — a weight
+    // in [0, 1] wants relative precision, a clamped coordinate wants absolute.
+    const uint32_t out_elem_size = sizeof(uint16_t);
     const uint32_t out_elems_per_page = attrs.precompute_grid ? num_pts * 6 : num_pts * 2;
     const uint32_t out_page_size = tt::round_up(out_elems_per_page * out_elem_size, align);
 
@@ -83,7 +86,9 @@ KpsProjectFusedProgramFactory::cached_program_t KpsProjectFusedProgramFactory::c
 
     // CB4: output scratch
     const uint32_t out_cb_pages = fused_precompute ? nc * NL : ((attrs.precompute_grid && !fused_precompute) ? nc * NL * 2 : nc);
-    const auto out_df = (attrs.precompute_grid && !standalone_precompute) ? tt::DataFormat::Float16_b : f32_df;
+    const auto out_df = (attrs.precompute_grid && !standalone_precompute)
+                            ? tt::DataFormat::Float16_b   // precomputed bilinear weights
+                            : tt::DataFormat::UInt16;     // Q14 fixed-point coordinates
     const auto [out_cb_index, out_cb_handle] =
         create_cb(cb_idx++, program, all_cores, out_page_size, out_cb_pages, out_df);
 
@@ -155,6 +160,7 @@ KpsProjectFusedProgramFactory::cached_program_t KpsProjectFusedProgramFactory::c
         // H,W passed via runtime args to avoid program cache collision
         reader_ct_args.push_back(1U);  // PRECOMPUTE=1
         reader_ct_args.push_back(NL);  // NL=4
+        reader_ct_args.push_back(t.anchor.dtype() == DataType::FLOAT32 ? 1U : 0U);
         for (uint32_t i = 0; i < 4; i++) {
             reader_ct_args.push_back(0);  // placeholder H (runtime)
             reader_ct_args.push_back(0);  // placeholder W (runtime)
@@ -211,6 +217,9 @@ KpsProjectFusedProgramFactory::cached_program_t KpsProjectFusedProgramFactory::c
         // Standard mode: no precompute args needed
         reader_ct_args.push_back(0U);  // PRECOMPUTE=0
         reader_ct_args.push_back(0U);  // NL=0
+        // The anchor may arrive fp32: its centre is what the projection error is most
+        // sensitive to, and bf16 there costs 0.081 px on the finest level.
+        reader_ct_args.push_back(t.anchor.dtype() == DataType::FLOAT32 ? 1U : 0U);
 
         reader_kernel_id = CreateKernel(
             program,


### PR DESCRIPTION
## Summary

Closes the accuracy gap to the CUDA reference on Sparse4D v3 / Wormhole N300 (2-chip mesh SPMD): **mAP 0.3974 → 0.4476, NDS 0.5190 → 0.5534**, with latency down **95.2 → 90.7 ms**.
**The mAP gap to PyTorch is now **-0.005** (was -0.055).**`

## Changes

  **Softmax denominator was per-device** (`model/deformable_feature_aggregation.py`)
  - SPMD gives each device 3 of 6 cameras, so its sampling-point axis is 156 of 312, and `_softmax_clp` built the denominator from its own 156
  - Each device's weights summed to 1 alone (row sums 1.0063 each, 2.01 together), so the `all_reduce` after the fusion added two complete distributions
  - Fixed by reducing the denominator across devices **and** the max shift with it — `exp(l - m0)` and `exp(l - m1)` are not summable, so both devices must subtract the same constant. `ttnn.all_reduce` is Sum-only, so it uses the mean of the per-device maxima; any common constant is exact
  - Applied to both the compact and the pure-TT-NN paths

## Performance

 |  | PyTorch (RTX 5060 Ti) | TT-NN Pure (N300) | TT-NN + Custom Kernels (N300) |
  | :--- | :---: | :---: | :---: |
  | **Latency** | ~95 ms | 235 ms | **90.7 ms** |
  | **FPS** | 10.5 | 4.2 | **11.02** |

## Accuracy


  Full nuScenes val, 6019 samples, `sparse4dv3_r50.pth`.

  |  | PyTorch (CUDA) | TT-NN (N300) | Gap |
  | :--- | :---: | :---: | :---: |
  | **mAP** | 0.4529 | **0.4476** | -0.0053 |
  | **NDS** | 0.5602 | **0.5534** | -0.0068 |
  | **mATE** | 0.5455 | 0.5532 | +0.0077 |
  | **mASE** | 0.2622 | 0.2608 | -0.0014 |
  | **mAOE** | 0.4373 | 0.4686 | +0.0313 |
  | **mAVE** | 0.2195 | 0.2135 | -0.0060 |
  | **mAAE** | 0.1987 | 0.2073 | +0.0086 |

