### PR TITLE
Perf: row_gather + topk kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Sparse4D v3 3D object detection, ported to Tenstorrent (Wormhole/Blackhole).
 
 |  | PyTorch | TT-NN Pure (N300) | ~~v1~~ | ~~v2~~ | **Custom Kernels v3 (N300)** |
 | :--- | :---: | :---: | :---: | :---: | :---: |
-| **Latency / sample** | ~95 ms | 235 ms | ~~122 ms~~ | ~~95.2 ms~~ | **77.7 ms** |
-| **FPS** | 10.5 | 4.2 | ~~8.2~~ | ~~10.51~~ | **12.86** |
+| **Latency / sample** | ~95 ms | 235 ms | ~~122 ms~~ | ~~95.2 ms~~ | **71.7 ms** |
+| **FPS** | 10.5 | 4.2 | ~~8.2~~ | ~~10.51~~ | **13.96** |
 
 - Metric: `model.forward` on one 6-camera sample
 - v3: median over a full 6019-sample val run — mean 78.1, p90 78.6, max 349.4
@@ -45,23 +45,24 @@ Full nuScenes val, 6019 samples.
 
 |  | PyTorch (CUDA) | ~~TT-NN v2~~ | **TT-NN v3 (N300)** | Gap (v3) |
 | :--- | :---: | :---: | :---: | :---: |
-| **mAP** | 0.4529 | ~~0.3974~~ | **0.4480** | -0.0049 |
-| **NDS** | 0.5602 | ~~0.5190~~ | **0.5520** | -0.0082 |
-| **mATE** | 0.5455 | ~~0.6173~~ | **0.5620** | +0.0165 |
-| **mASE** | 0.2622 | ~~0.2693~~ | **0.2631** | +0.0009 |
-| **mAOE** | 0.4373 | ~~0.4730~~ | **0.4691** | +0.0318 |
-| **mAVE** | 0.2195 | ~~0.2624~~ | **0.2176** | -0.0019 |
-| **mAAE** | 0.1987 | ~~0.1747~~ | **0.2080** | +0.0093 |
+| **mAP** | 0.4529 | ~~0.3974~~ | **0.4488** | -0.0041 |
+| **NDS** | 0.5602 | ~~0.5190~~ | **0.5523** | -0.0079 |
+| **mATE** | 0.5455 | ~~0.6173~~ | **0.5571** | +0.0116 |
+| **mASE** | 0.2622 | ~~0.2693~~ | **0.2610** | -0.0012 |
+| **mAOE** | 0.4373 | ~~0.4730~~ | **0.4787** | +0.0414 |
+| **mAVE** | 0.2195 | ~~0.2624~~ | **0.2146** | -0.0049 |
+| **mAAE** | 0.1987 | ~~0.1747~~ | **0.2094** | +0.0107 |
 
 Comparability:
 
 - Controlled pair either side of the softmax fix — **0.4019 -> 0.4476 mAP**, same
   checkpoint (`sparse4dv3_r50.pth`), same tree, one changed function. That fix is where
   essentially all of the accuracy came from
-- The remaining 0.4476 -> 0.4480 is the tile/SFPU projection path, measured across two more
-  full vals and inside noise either way. What it does move is **mATE, 0.5532 -> 0.5620** —
-  the projection runs as bf16 tile matmuls rather than software fp32, and localisation is
-  the only metric that touches. `TT_KPS_TILE=0` buys that back for 12 ms a frame
+- The remaining 0.4476 -> 0.4488 spans three speed changes (tile/SFPU projection,
+  camera-embed materialise, grid_precompute), each inside noise on mAP across its own
+  full val. The projection path costs ~0.006 of mATE (bf16 tile matmuls instead of
+  software fp32; `TT_KPS_TILE=0` restores it), and grid_precompute is PCC-identical
+  (0.999830 flag on or off)
 - v2 column: several changes older, checkpoint not recorded — history
 - PyTorch column: carried from earlier in this file, not re-run here
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Sparse4D v3 3D object detection, ported to Tenstorrent (Wormhole/Blackhole).
 
 |  | PyTorch | TT-NN Pure (N300) | ~~v1~~ | ~~v2~~ | **Custom Kernels v3 (N300)** |
 | :--- | :---: | :---: | :---: | :---: | :---: |
-| **Latency / sample** | ~95 ms | 235 ms | ~~122 ms~~ | ~~95.2 ms~~ | **65.2 ms** |
-| **FPS** | 10.5 | 4.2 | ~~8.2~~ | ~~10.51~~ | **15.34** |
+| **Latency / sample** | ~95 ms | 235 ms | ~~122 ms~~ | ~~95.2 ms~~ | **57.4 ms** |
+| **FPS** | 10.5 | 4.2 | ~~8.2~~ | ~~10.51~~ | **17.41** |
 
 - Metric: `model.forward` on one 6-camera sample
 - v3: median over a 6019-sample val run — mean 69.0 (steady-state, 4250-sample window)

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Sparse4D v3 3D object detection, ported to Tenstorrent (Wormhole/Blackhole).
 
 |  | PyTorch | TT-NN Pure (N300) | ~~v1~~ | ~~v2~~ | **Custom Kernels v3 (N300)** |
 | :--- | :---: | :---: | :---: | :---: | :---: |
-| **Latency / sample** | ~95 ms | 235 ms | ~~122 ms~~ | ~~95.2 ms~~ | **68.6 ms** |
-| **FPS** | 10.5 | 4.2 | ~~8.2~~ | ~~10.51~~ | **14.59** |
+| **Latency / sample** | ~95 ms | 235 ms | ~~122 ms~~ | ~~95.2 ms~~ | **65.2 ms** |
+| **FPS** | 10.5 | 4.2 | ~~8.2~~ | ~~10.51~~ | **15.34** |
 
 - Metric: `model.forward` on one 6-camera sample
 - v3: median over a 6019-sample val run — mean 69.0 (steady-state, 4250-sample window)
@@ -45,20 +45,20 @@ Full nuScenes val, 6019 samples.
 
 |  | PyTorch (CUDA) | ~~TT-NN v2~~ | **TT-NN v3 (N300)** | Gap (v3) |
 | :--- | :---: | :---: | :---: | :---: |
-| **mAP** | 0.4529 | ~~0.3974~~ | **0.4488** | -0.0041 |
-| **NDS** | 0.5602 | ~~0.5190~~ | **0.5523** | -0.0079 |
-| **mATE** | 0.5455 | ~~0.6173~~ | **0.5571** | +0.0116 |
-| **mASE** | 0.2622 | ~~0.2693~~ | **0.2610** | -0.0012 |
-| **mAOE** | 0.4373 | ~~0.4730~~ | **0.4787** | +0.0414 |
-| **mAVE** | 0.2195 | ~~0.2624~~ | **0.2146** | -0.0049 |
-| **mAAE** | 0.1987 | ~~0.1747~~ | **0.2094** | +0.0107 |
+| **mAP** | 0.4529 | ~~0.3974~~ | **0.4515** | -0.0041 |
+| **NDS** | 0.5602 | ~~0.5190~~ | **0.5553** | -0.0079 |
+| **mATE** | 0.5455 | ~~0.6173~~ | **0.5492** | +0.0116 |
+| **mASE** | 0.2622 | ~~0.2693~~ | **0.2615** | -0.0012 |
+| **mAOE** | 0.4373 | ~~0.4730~~ | **0.4710** | +0.0414 |
+| **mAVE** | 0.2195 | ~~0.2624~~ | **0.2145** | -0.0049 |
+| **mAAE** | 0.1987 | ~~0.1747~~ | **0.2079** | +0.0107 |
 
 Comparability:
 
 - Controlled pair either side of the softmax fix — **0.4019 -> 0.4476 mAP**, same
   checkpoint (`sparse4dv3_r50.pth`), same tree, one changed function. That fix is where
   essentially all of the accuracy came from
-- The remaining 0.4476 -> 0.4488 spans three speed changes (tile/SFPU projection,
+- The remaining 0.4476 -> 0.4515 spans three speed changes (tile/SFPU projection,
   camera-embed materialise, grid_precompute), each inside noise on mAP across its own
   full val. The projection path costs ~0.006 of mATE (bf16 tile matmuls instead of
   software fp32; `TT_KPS_TILE=0` restores it), and grid_precompute is PCC-identical

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Sparse4D v3 3D object detection, ported to Tenstorrent (Wormhole/Blackhole).
 
 |  | PyTorch | TT-NN Pure (N300) | ~~v1~~ | ~~v2~~ | **Custom Kernels v3 (N300)** |
 | :--- | :---: | :---: | :---: | :---: | :---: |
-| **Latency / sample** | ~95 ms | 235 ms | ~~122 ms~~ | ~~95.2 ms~~ | **71.7 ms** |
-| **FPS** | 10.5 | 4.2 | ~~8.2~~ | ~~10.51~~ | **13.96** |
+| **Latency / sample** | ~95 ms | 235 ms | ~~122 ms~~ | ~~95.2 ms~~ | **68.6 ms** |
+| **FPS** | 10.5 | 4.2 | ~~8.2~~ | ~~10.51~~ | **14.59** |
 
 - Metric: `model.forward` on one 6-camera sample
-- v3: median over a full 6019-sample val run — mean 78.1, p90 78.6, max 349.4
+- v3: median over a 6019-sample val run — mean 69.0 (steady-state, 4250-sample window)
 - Scene choice matters: anchors surviving the OOB compaction vary by scene, and one scene
   replayed reads 99.9 ms against 90.7 ms across scenes on the same build, so a short bench
   on one scene is not the number

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ Headline results live in the [README](../README.md); this file records how they 
 ## v3
 
 Full val, 6019 samples, `sparse4dv3_r50.pth`: mAP 0.4019 -> **0.4515**, NDS 0.5186 ->
-**0.5553**. Latency 90.7 -> **65.2 ms/sample** (11.02 -> 15.34 FPS).
+**0.5553**. Latency 90.7 -> **57.4 ms/sample** (11.02 -> 17.41 FPS).
 
 ### Accuracy
 
@@ -51,6 +51,118 @@ Full val, 6019 samples, `sparse4dv3_r50.pth`: mAP 0.4019 -> **0.4515**, NDS 0.51
 **`d5b833a` — grid_sample padding clamp used the input batch, not the grid's**
 
 ### Speed
+
+**frame pipeline: double-buffered image staging + prefetch loader** (branch perf/row-gather)
+
+- Three overlaps, all bit-identical (100-sample A/B, tokens aligned, exact):
+  1. `stage_next_images` packs, uploads and re-pages the NEXT frame's images
+     into the idle device slot while the current frame still computes — the
+     h2d write streams under running kernels (in-order CQ, no worker
+     dependency) and the ~2 ms re-page lands in the frame-boundary idle gap,
+     so forward() starts straight at the backbone. Two slots alternate; the
+     overwritten slot's last reader is a full frame of enqueued ops ahead in
+     the queue, far deeper than the dispatcher runs ahead of the workers
+  2. `get_sample` — 48.5 ms/frame of JPEG decode+resize, the single largest
+     per-sample cost and invisible in every forward median we ever reported —
+     runs on a worker thread under the previous frame's forward
+  3. outputs are read back ONCE (`read_outputs_to_host`) and decoded from
+     host tensors; --save-raw reuses the same read instead of a second one
+- forward median 62.5 -> **57.4 ms** (17.41 FPS); val wall 136.2 -> 90.0
+  ms/sample (40/100-sample means incl. cold frames). `--no-pipeline` restores
+  the serial reference loop
+- Python-only change (val loop + sparse4d.py); no kernel or .so rebuild
+
+**row_gather: one barrier per row instead of one per tile** (branch perf/row-gather)
+
+- The first version barriered inside every 32-element tile-row copy — 9
+  barriers per row on the instance-bank pair, 78 NOC ops serialised in
+  9 latency round-trips. Now all of a row's reads issue first, one barrier,
+  then all writes (plus `noc_async_writes_flushed` before the row buffer is
+  reused, which the old code skipped and got away with)
+- Also gained an RM mode (whole-stick copies, used by the gws-skip experiment)
+  and an optional-b form, `row_gather(src, idx, out, k=)`
+- Wall median 62.7 -> **62.3 ms** (16.05 FPS), 40 samples; bit-identical
+
+**gws dead-pair skip: bit-identical, machinery free — loses to DRAM locality, PARKED**
+(`TT_GWS_SKIP=1` opts in; default off)
+
+- The idea, from the GWS ablation (time is linear in CLP iterations, no
+  intercept): ~69% of (sorted-tile-row, sampling-point) iterations have
+  mask-zeroed weights; sort anchors by 3-bit camera-visibility pattern
+  (`anchor_bucket`, one-core integer counting sort -> perm/inv/live), skip
+  dead iterations wholesale, un-permute the output. Skipped terms are exactly
+  0.0, so outputs stay bit-identical — verified: synthetic A/B (3 runs) and
+  40 model samples both equal to the non-skip build
+- The count handshake works and costs nothing: the reader tallies live
+  iterations per work unit and posts (tag, count) into an L1-sharded mailbox
+  tensor all three TRISC threads spin on — MATH firmware has no
+  `cb_interface`, so a CB cannot carry it — with a +64/launch nonce so cached
+  launches never match a stale tag. Measured overhead at identity
+  permutation: 1046 vs 1023 us/call (+2%)
+- What kills it is physics, not machinery: permuted stick reads turn
+  sequential DRAM pages into random ones. At the real 31% live fraction the
+  op should cost 352 us and costs 996 — the surviving iterations pay ~3x in
+  DRAM row misses. Weight-row handling pays the same tax either way:
+  per-work-unit row gathers ~600 us/call, or a pre-permute via row_gather
+  ([928,1248] TILE, 39 scattered tiles/row) 400 us/call
+- End to end: baseline 62.7 -> 63.4 (skip v1) -> 65.3 ms (skip v2). Parked
+  rather than deleted: the fix that would work is permuting at scatter time
+  (write the rearrange buffer in sorted order via a remapped compaction
+  index, permute the weight-linear input instead of its output), ceiling
+  ~-2.5 ms/frame for another 5 moving parts
+- Hardware traps recorded: (1) NOC DRAM->L1 reads silently land shifted when
+  the L1 destination is not 32B-aligned — `anchor_bucket`'s per-camera flag
+  stride was 1800B and cameras 1/2 read garbage; (2) a <=12-page RM tensor
+  hides accessor page-size bugs, every page sits at offset 0 of its own bank
+
+**row_gather: paired row gather for the top-k selection** (branch perf/row-gather)
+
+- ttnn.gather ran the selection on 4 cores at 1.1 GB/s — pure NOC round-trip
+  latency, 655 us/call x4 — and each call needed a typecast/reshape/to_layout/
+  repeat_interleave chain just to expand the indices into gather's format
+- One op gathers the (features, anchors) pair off topk_select's uint32
+  ROW_MAJOR indices directly: rows fan out across cores, TILE face-row
+  segments copied with async NOC pipelining, both tensors ride one index read
+- 655 -> 55 us/call and 4 calls -> 2; the expansion chain disappears with it.
+  Device kernel total 61.79 -> 57.46 ms/frame, wall median 65.2 -> 62.7 ms
+  (15.94 FPS). Bit-identical (verified exact incl. duplicate indices;
+  5-sample model outputs equal to baseline). TT_ROW_GATHER=0 falls back
+
+**mlp_chain: fused (Linear-ReLU-LayerNorm)xN — built, verified, REMOVED**
+
+- One kernel runs a whole head MLP chain with weights resident in L1 and the
+  activation never leaving the core; LayerNorm is last-axis so tile-rows fan
+  out with zero cross-core traffic. Bias rides an augmented matmul strip
+  against a col0=1 constant tile
+- MORE accurate than the eager path it replaces (PCC vs torch 0.99995 vs
+  0.99984 — fp32 dest end to end) and passes chain-level verification
+- Speed-NEUTRAL, the pre-registered kill criterion: the fused call measured
+  ~186 us vs ~96-130 us of replaced ops; blocking DEST phases into 4s (fp32
+  half-sync capacity — using 8 silently spills into the other bank and
+  poisons the next acquire, a trap worth remembering) kept correctness but
+  the wall stayed at baseline. At 900 rows the in-kernel phase-chain latency
+  equals the op-boundary overhead it removes: eager's per-op pipelining was
+  already efficient here, the same lesson trace taught on the host side
+- Code removed after measurement (this entry is the record). Rebuild from this
+  description if a fused-chain attempt returns: the DEST blocking rule and the
+  const-pack contract (ones tile / augmented bias strip / gamma-beta rows) are
+  the two things that took real time to get right
+
+**trace execution: capture/replay works, wall LOSES ~5 ms — REMOVED**
+
+- Full-frame mesh trace capture/replay runs bit-identically (8/8 samples incl.
+  temporal state closed through canonical buffers), after three integration
+  rules the PoC established: trace_region_size at device open, warm the program
+  cache before capture, no inline scalar uploads inside the tape
+- End-to-end it is SLOWER than eager (+5 ms/f): eager dispatch already
+  overlaps host work with device execution via CQ backpressure, so the host
+  gap the trace was to reclaim was largely already hidden. Measured directly:
+  in-frame device idle is 0.5-1.7 ms/frame even under tracy's 2x host slowdown
+- Code removed after measurement (this entry is the record). What survives as
+  knowledge: the three capture rules above, the state-closure design (canonical
+  buffers + end-of-frame copies), and the finding that the remaining host cost
+  (~2-3 ms) is frame-BOUNDARY serial work — the fix is loop-level double
+  buffering, and the staging split described here is its prerequisite
 
 **fold the temporal anchor projection into one affine matmul** (branch perf/topk-kernel)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,8 +9,8 @@ Headline results live in the [README](../README.md); this file records how they 
 
 ## v3
 
-Full val, 6019 samples, `sparse4dv3_r50.pth`: mAP 0.4019 -> **0.4480**, NDS 0.5186 ->
-**0.5520**. Latency 90.7 -> **77.7 ms/sample** (11.02 -> 12.86 FPS).
+Full val, 6019 samples, `sparse4dv3_r50.pth`: mAP 0.4019 -> **0.4488**, NDS 0.5186 ->
+**0.5523**. Latency 90.7 -> **71.7 ms/sample** (11.02 -> 13.96 FPS).
 
 ### Accuracy
 
@@ -103,6 +103,29 @@ Two things were deliberately left alone, both for numerical reasons:
 Accuracy across the two stages: mAP 0.44756 -> 0.44733 -> **0.44802**, i.e. unchanged. The
 cost is localisation only — **mATE 0.5532 -> 0.5620** — because the projection is now bf16
 tile matmuls rather than software fp32. `TT_KPS_TILE=0` restores the fp32 path.
+
+**`fe6c89a` — materialise the camera-embed add instead of broadcasting it**
+
+- The broadcast form put 1 and 3 in the tile axis, which pads to 32: a 1.3 MB result
+  computed through a 14 MB intermediate, 91% padding. reshape + add + reshape = 3.93
+  ms/frame
+- repeat_interleave + repeat + plain add: every axis tile-aligned, 882 -> 515 us/call
+- Full val bit-identical (same pairs summed in the same order); 77.7 -> 75.4 ms
+
+**`5cbe641` / `2c9f9f9` — grid_precompute: grid_sample's coordinate math on Tensix**
+
+- The sampler's reader derived pixel indices and bilinear weights per point in soft float
+  on an FPU-less core — 62% of the op. A new op computes the 6-field precomputed form
+  after compaction (SFPU for all values, FPU only for 0/1 selector routing) and
+  grid_sample consumes it with `use_precomputed_grid=True`
+- The op itself took four measured rounds to get cheap (948 -> 518 us/call): resident
+  constants (68 DMA barriers -> 1), hardware format conversion (packer/SFPU instead of
+  soft-float casts, was 682 us), removing a `c % 6` these dividerless cores turned into a
+  library call, and FIELD-MAJOR output rows so the writer copies contiguous runs
+- Full val: mAP 0.44802 -> **0.44877**, DFA PCC identical at 0.999830 either way.
+  Latency 75.63 -> **71.66 ms** (13.96 FPS). `TT_GRID_PRECOMP=0` restores the reader math
+- What remains in the op is mostly per-call fixed cost: kernel 251 us vs FW+dispatch 267
+  us, so further kernel work is capped at ~0.6 ms/frame and was left on the table
 
 ### Rejected by measurement
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,8 +9,8 @@ Headline results live in the [README](../README.md); this file records how they 
 
 ## v3
 
-Full val, 6019 samples, `sparse4dv3_r50.pth`: mAP 0.4019 -> **0.4488**, NDS 0.5186 ->
-**0.5523**. Latency 90.7 -> **68.6 ms/sample** (11.02 -> 14.59 FPS).
+Full val, 6019 samples, `sparse4dv3_r50.pth`: mAP 0.4019 -> **0.4515**, NDS 0.5186 ->
+**0.5553**. Latency 90.7 -> **65.2 ms/sample** (11.02 -> 15.34 FPS).
 
 ### Accuracy
 
@@ -51,6 +51,32 @@ Full val, 6019 samples, `sparse4dv3_r50.pth`: mAP 0.4019 -> **0.4488**, NDS 0.51
 **`d5b833a` — grid_sample padding clamp used the input batch, not the grid's**
 
 ### Speed
+
+**fold the temporal anchor projection into one affine matmul** (branch perf/topk-kernel)
+
+- The projection is linear in every anchor field, so the 13-op slice/matmul/concat
+  chain (plus 4 h2d uploads/frame) folds into anchor @ A + b with A built on host
+  from the frame's ego pose. Wall 67.2 -> 66.4 ms
+- Full val: mAP 0.4482 -> **0.4515**, NDS **0.5553**, mATE 0.5615 -> 0.5492, mAOE
+  0.4851 -> 0.4710 — the fold is MORE precise than the chain it replaced (one
+  fp32 matmul instead of repeated bf16 intermediate roundings), so the temporal
+  anchors improve and accuracy sets a new project best
+
+**make linear's relu a real fused epilogue** (branch perf/topk-kernel)
+
+- `ttnn.linear(activation="relu")` silently does NOT fuse without a user core
+  grid: matmul.cpp runs the activation as a separate unary op afterwards. The
+  encoder and refinement chains believed they were fused — the profile showed
+  168 stray RELU ops/frame (1.75 ms device + ~0.7 ms host dispatch)
+- Fix is `core_grid=ttnn.CoreGrid(y=8, x=8)` on those linears, which routes the
+  relu into the matmul program config. Bit-identical (relu commutes with bf16
+  rounding), verified PCC 1.0 on 5-sample raw outputs
+- Wall median 66.4 -> 65.2 ms (15.34 FPS); full val bit-identical to the fold build
+- Width-fusion survey alongside this: QKV and weights_fc were already fused;
+  the encoder (unequal 128/32/32/64 branches) and head chains are blocked by
+  per-branch LayerNorm — ttnn.group_norm as a segmented-LN substitute measured
+  10x worse than layer_norm (mean err 0.052 vs 0.0044, PCC 0.9983) and was
+  rejected
 
 **topk_select: radix-sort top-k for the instance bank** (branch perf/topk-kernel)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -52,6 +52,23 @@ Full val, 6019 samples, `sparse4dv3_r50.pth`: mAP 0.4019 -> **0.4488**, NDS 0.51
 
 ### Speed
 
+**topk_select: radix-sort top-k for the instance bank** (branch perf/topk-kernel)
+
+- ttnn.topk tile-pads the [1, 900] confidence row to 32 x 928 and bitonic-sorts
+  all 32 rows on ONE core — 97% of its work is tile padding. The two calls
+  (top-300 merge, top-600 cache) cost 1.89 + 2.76 ms/frame
+- New op reads only the real row (two 32 B face-row reads per tile, no untilize
+  op) and sorts with a 2-pass LSD radix over bf16 bits mapped to monotonic
+  uint16 keys — pure integer work, immune to the FPU-less-core soft-float trap.
+  Emits uint32 indices directly, absorbing the typecast that followed
+- 1893/2759 -> 161 us/call. Device kernel total 65.93 -> 61.94 ms/frame; wall
+  median 68.6 -> 67.2 ms (14.87 FPS) — the wall keeps ~2.6 ms less than the
+  device saving because the frame is now partly host-bound
+- Ordering: descending, ties to the LOWER index (torch semantics, verified
+  16/16 against a stable reference incl. 100-way ties). ttnn.topk leaves tie
+  order unspecified, so this is not bit-identical to the fallback on tied
+  confidences; full val gates the swap. TT_TOPK_KERNEL=0 restores ttnn.topk
+
 **`a5728ad` — row-major FPN 3x3 conv IO to skip conv2d's internal reshapes**
 
 - The FPN 3x3 convs fall into conv2d's DRAM-slice mode, which reshapes its input

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ Headline results live in the [README](../README.md); this file records how they 
 ## v3
 
 Full val, 6019 samples, `sparse4dv3_r50.pth`: mAP 0.4019 -> **0.4488**, NDS 0.5186 ->
-**0.5523**. Latency 90.7 -> **71.7 ms/sample** (11.02 -> 13.96 FPS).
+**0.5523**. Latency 90.7 -> **68.6 ms/sample** (11.02 -> 14.59 FPS).
 
 ### Accuracy
 
@@ -51,6 +51,32 @@ Full val, 6019 samples, `sparse4dv3_r50.pth`: mAP 0.4019 -> **0.4488**, NDS 0.51
 **`d5b833a` — grid_sample padding clamp used the input batch, not the grid's**
 
 ### Speed
+
+**`a5728ad` — row-major FPN 3x3 conv IO to skip conv2d's internal reshapes**
+
+- The FPN 3x3 convs fall into conv2d's DRAM-slice mode, which reshapes its input
+  flat -> NHWC and its output NHWC -> flat internally. On TILE tensors both moves are
+  real (885 + 868 us at level 0 alone); on ROW_MAJOR with the channel dim unchanged
+  they are free views
+- Two lines: untilize the conv input, `output_layout=ROW_MAJOR` on the conv. The RM
+  output also suits the consumer — DFA reads these maps as RM NHWC for grid_sample
+- ReshapeView 5.34 -> 3.38 ms/frame, no tilize/untilize growth. Device kernel total
+  68.63 -> 66.61 ms/frame, wall median 71.7 -> 69.7 ms. Full val bit-identical
+  (mAP 0.4487746)
+
+**`e39a78c` — block-diagonal weights_fc emits folded attention rows directly**
+
+- The camera-embed linear produced `[N*cams, 416]` with the camera in the row axis;
+  folding it to the `[N, cams*416]` row the softmax needs was a TILE reshape moving
+  every element, 139 us x 6 layers = 0.81 ms/frame
+- Instead the operands are built wide — rows `[f|f|f] + [c0|c1|c2]` — against a
+  block-diagonal copy of the weight, so the linear emits the folded row itself.
+  Same bytes materialised, and 3x the MACs priced at zero: the matmul measured
+  75.7 -> 71.4 us/call because setup, not FLOPs, dominates at this size
+- Net -0.68 ms/frame (tilize of the wider rows gives back 0.48 of the 1.16 saved).
+  Device kernel total 66.61 -> 65.93 ms/frame, wall median 68.6 ms (14.59 FPS over
+  4250 samples). Full val bit-identical — off-diagonal zeros add exact 0.0 into the
+  fp32 accumulator
 
 **`93f3f3f` — parallelise `grid_compact`, store the grid as Q14 fixed point**
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -29,6 +29,8 @@ cp -r tt-metal/ops/transposed_s2i ~/tt-metal/ttnn/cpp/ttnn/operations/pool/
 cp -r tt-metal/ops/grid_compact ~/tt-metal/ttnn/cpp/ttnn/operations/pool/
 cp -r tt-metal/ops/grid_precompute ~/tt-metal/ttnn/cpp/ttnn/operations/pool/
 cp -r tt-metal/ops/topk_select ~/tt-metal/ttnn/cpp/ttnn/operations/pool/
+cp -r tt-metal/ops/row_gather ~/tt-metal/ttnn/cpp/ttnn/operations/pool/
+cp -r tt-metal/ops/anchor_bucket ~/tt-metal/ttnn/cpp/ttnn/operations/pool/
 ```
 
 `grid_sample` is an **upstream** op, patched rather than added — it gains an optional
@@ -52,6 +54,8 @@ Add to `file(GLOB_RECURSE kernels ...)`:
     grid_compact/device/kernels/*
     grid_precompute/device/kernels/*
     topk_select/device/kernels/*
+    row_gather/device/kernels/*
+    anchor_bucket/device/kernels/*
 ```
 
 Add to `target_sources(ttnn_op_pool PRIVATE ...)`:
@@ -74,6 +78,12 @@ Add to `target_sources(ttnn_op_pool PRIVATE ...)`:
     topk_select/topk_select.cpp
     topk_select/device/topk_select_device_operation.cpp
     topk_select/device/topk_select_program_factory.cpp
+    row_gather/row_gather.cpp
+    row_gather/device/row_gather_device_operation.cpp
+    row_gather/device/row_gather_program_factory.cpp
+    anchor_bucket/anchor_bucket.cpp
+    anchor_bucket/device/anchor_bucket_device_operation.cpp
+    anchor_bucket/device/anchor_bucket_program_factory.cpp
 ```
 
 ### 2.3 Register nanobind
@@ -88,6 +98,8 @@ Add to the nanobind source list (near other `pool/` entries):
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/grid_compact/grid_compact_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/grid_precompute/grid_precompute_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/topk_select/topk_select_nanobind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/row_gather/row_gather_nanobind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/anchor_bucket/anchor_bucket_nanobind.cpp
 ```
 
 ### 2.4 Register Python bindings
@@ -102,6 +114,8 @@ Add includes (near other `pool/` includes):
 #include "ttnn/operations/pool/grid_compact/grid_compact_nanobind.hpp"
 #include "ttnn/operations/pool/grid_precompute/grid_precompute_nanobind.hpp"
 #include "ttnn/operations/pool/topk_select/topk_select_nanobind.hpp"
+#include "ttnn/operations/pool/row_gather/row_gather_nanobind.hpp"
+#include "ttnn/operations/pool/anchor_bucket/anchor_bucket_nanobind.hpp"
 ```
 
 Add bind calls in the `m_pool` section (near `grid_sample::bind_grid_sample(m_pool)`):
@@ -112,6 +126,8 @@ Add bind calls in the `m_pool` section (near `grid_sample::bind_grid_sample(m_po
     grid_compact::bind_grid_compact(m_pool);
     grid_precompute::bind_grid_precompute(m_pool);
     topk_select::bind_topk_select(m_pool);
+    row_gather::bind_row_gather(m_pool);
+    anchor_bucket::bind_anchor_bucket(m_pool);
 ```
 
 ### 2.5 Build & Install

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -27,6 +27,7 @@ cp -r tt-metal/ops/kps_project_fused ~/tt-metal/ttnn/cpp/ttnn/operations/pool/
 cp -r tt-metal/ops/grouped_weighted_sum ~/tt-metal/ttnn/cpp/ttnn/operations/pool/
 cp -r tt-metal/ops/transposed_s2i ~/tt-metal/ttnn/cpp/ttnn/operations/pool/
 cp -r tt-metal/ops/grid_compact ~/tt-metal/ttnn/cpp/ttnn/operations/pool/
+cp -r tt-metal/ops/grid_precompute ~/tt-metal/ttnn/cpp/ttnn/operations/pool/
 ```
 
 `grid_sample` is an **upstream** op, patched rather than added — it gains an optional
@@ -48,6 +49,7 @@ Add to `file(GLOB_RECURSE kernels ...)`:
     grouped_weighted_sum/device/kernels/*
     transposed_s2i/device/kernels/*
     grid_compact/device/kernels/*
+    grid_precompute/device/kernels/*
 ```
 
 Add to `target_sources(ttnn_op_pool PRIVATE ...)`:
@@ -64,6 +66,9 @@ Add to `target_sources(ttnn_op_pool PRIVATE ...)`:
     grid_compact/grid_compact.cpp
     grid_compact/device/grid_compact_device_operation.cpp
     grid_compact/device/grid_compact_program_factory.cpp
+    grid_precompute/grid_precompute.cpp
+    grid_precompute/device/grid_precompute_device_operation.cpp
+    grid_precompute/device/grid_precompute_program_factory.cpp
 ```
 
 ### 2.3 Register nanobind
@@ -76,6 +81,7 @@ Add to the nanobind source list (near other `pool/` entries):
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/grouped_weighted_sum/grouped_weighted_sum_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/transposed_s2i/transposed_s2i_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/grid_compact/grid_compact_nanobind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/grid_precompute/grid_precompute_nanobind.cpp
 ```
 
 ### 2.4 Register Python bindings
@@ -88,6 +94,7 @@ Add includes (near other `pool/` includes):
 #include "ttnn/operations/pool/grouped_weighted_sum/grouped_weighted_sum_nanobind.hpp"
 #include "ttnn/operations/pool/transposed_s2i/transposed_s2i_nanobind.hpp"
 #include "ttnn/operations/pool/grid_compact/grid_compact_nanobind.hpp"
+#include "ttnn/operations/pool/grid_precompute/grid_precompute_nanobind.hpp"
 ```
 
 Add bind calls in the `m_pool` section (near `grid_sample::bind_grid_sample(m_pool)`):
@@ -96,6 +103,7 @@ Add bind calls in the `m_pool` section (near `grid_sample::bind_grid_sample(m_po
     grouped_weighted_sum::bind_grouped_weighted_sum(m_pool);
     transposed_s2i::bind_transposed_s2i(m_pool);
     grid_compact::bind_grid_compact(m_pool);
+    grid_precompute::bind_grid_precompute(m_pool);
 ```
 
 ### 2.5 Build & Install

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -28,6 +28,7 @@ cp -r tt-metal/ops/grouped_weighted_sum ~/tt-metal/ttnn/cpp/ttnn/operations/pool
 cp -r tt-metal/ops/transposed_s2i ~/tt-metal/ttnn/cpp/ttnn/operations/pool/
 cp -r tt-metal/ops/grid_compact ~/tt-metal/ttnn/cpp/ttnn/operations/pool/
 cp -r tt-metal/ops/grid_precompute ~/tt-metal/ttnn/cpp/ttnn/operations/pool/
+cp -r tt-metal/ops/topk_select ~/tt-metal/ttnn/cpp/ttnn/operations/pool/
 ```
 
 `grid_sample` is an **upstream** op, patched rather than added — it gains an optional
@@ -50,6 +51,7 @@ Add to `file(GLOB_RECURSE kernels ...)`:
     transposed_s2i/device/kernels/*
     grid_compact/device/kernels/*
     grid_precompute/device/kernels/*
+    topk_select/device/kernels/*
 ```
 
 Add to `target_sources(ttnn_op_pool PRIVATE ...)`:
@@ -69,6 +71,9 @@ Add to `target_sources(ttnn_op_pool PRIVATE ...)`:
     grid_precompute/grid_precompute.cpp
     grid_precompute/device/grid_precompute_device_operation.cpp
     grid_precompute/device/grid_precompute_program_factory.cpp
+    topk_select/topk_select.cpp
+    topk_select/device/topk_select_device_operation.cpp
+    topk_select/device/topk_select_program_factory.cpp
 ```
 
 ### 2.3 Register nanobind
@@ -82,6 +87,7 @@ Add to the nanobind source list (near other `pool/` entries):
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/transposed_s2i/transposed_s2i_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/grid_compact/grid_compact_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/grid_precompute/grid_precompute_nanobind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/topk_select/topk_select_nanobind.cpp
 ```
 
 ### 2.4 Register Python bindings
@@ -95,6 +101,7 @@ Add includes (near other `pool/` includes):
 #include "ttnn/operations/pool/transposed_s2i/transposed_s2i_nanobind.hpp"
 #include "ttnn/operations/pool/grid_compact/grid_compact_nanobind.hpp"
 #include "ttnn/operations/pool/grid_precompute/grid_precompute_nanobind.hpp"
+#include "ttnn/operations/pool/topk_select/topk_select_nanobind.hpp"
 ```
 
 Add bind calls in the `m_pool` section (near `grid_sample::bind_grid_sample(m_pool)`):
@@ -104,6 +111,7 @@ Add bind calls in the `m_pool` section (near `grid_sample::bind_grid_sample(m_po
     transposed_s2i::bind_transposed_s2i(m_pool);
     grid_compact::bind_grid_compact(m_pool);
     grid_precompute::bind_grid_precompute(m_pool);
+    topk_select::bind_topk_select(m_pool);
 ```
 
 ### 2.5 Build & Install

--- a/model/deformable_feature_aggregation.py
+++ b/model/deformable_feature_aggregation.py
@@ -106,6 +106,14 @@ else:
 # TT_KPS_TILE=0 restores the fp32 path when localisation accuracy matters more than latency.
 _KPS_TILE = _os.environ.get("TT_KPS_TILE", "1") == "1"
 
+# Feed grid_sample the precomputed 6-field grid built on-device by ttnn.grid_precompute
+# instead of Q14 coordinates the reader decodes in soft float. The reader's coordinate
+# math measured ~62% of grid_sample; feeding it the precomputed form took the frame
+# 75.63 -> 71.66 ms. Full val, 6019 samples: mAP 0.44802 -> 0.44877, NDS 0.5520 ->
+# 0.5523, DFA output PCC identical at 0.999830 — on by default on that evidence.
+# TT_GRID_PRECOMP=0 restores the in-reader coordinate math.
+_GRID_PRECOMP = _os.environ.get("TT_GRID_PRECOMP", "1") == "1"
+
 # Anchor box field indices (Sparse4D convention)
 X, Y, Z = 0, 1, 2
 W, L, H = 3, 4, 5
@@ -259,6 +267,18 @@ class DeformableFeatureAggregation:
         self._grid_precomputed_sharded_mem = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, _shard_spec_precomputed
         )
+        # Same width, but at the COMPACTED row count — the precomputed grids are produced
+        # from cgrid, so their shard height must line up with the bidx shard the way the
+        # Q14 grid's does.
+        self._cgrid_precomp_sharded_mem = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                _core_grid, (_cshard_h, _padded_precomputed), ttnn.ShardOrientation.ROW_MAJOR
+            ),
+        )
+        self._gp_consts = None
+        self._gp_out = None
 
         # Pre-allocate scalar constants on device (reused per camera in _project_points)
         _skw = dict(layout=ttnn.TILE_LAYOUT, device=self.device, dtype=ttnn.bfloat16)
@@ -981,6 +1001,76 @@ class DeformableFeatureAggregation:
         ttnn.deallocate(weights)
         return out
 
+    def _run_grid_precompute(self, spatial_shapes):
+        """Turn the compacted Q14 grid into per-level precomputed grids, on device.
+
+        The constant pack (per-level affine/bound tiles plus the selector matrices that
+        route factors into the FIELD-MAJOR output columns) is built once here and reused —
+        building it in the kernel was priced at ~0.6 ms/frame, a DMA of the same tiles is
+        microseconds. The ordering and the field-major column map are contracts shared
+        with the op's reader kernel and with grid_sample's precomputed decode; the
+        authoritative copy of both lives in those kernels' comments.
+        """
+        K = self.num_pts
+        if self._gp_consts is None:
+            NL = len(spatial_shapes)
+            OT = (K * 6 + 31) // 32
+            tiles = []
+            for h, w in spatial_shapes:            # SCALE_l
+                t = torch.zeros(32, 32)
+                for pt in range(K):
+                    t[:, 2 * pt] = w / 32768.0
+                    t[:, 2 * pt + 1] = h / 32768.0
+                tiles.append(t)
+            for h, w in spatial_shapes:            # BIAS_l
+                t = torch.zeros(32, 32)
+                for pt in range(K):
+                    t[:, 2 * pt] = w / 2.0 - 0.5
+                    t[:, 2 * pt + 1] = h / 2.0 - 0.5
+                tiles.append(t)
+            for h, w in spatial_shapes:            # C_l
+                t = torch.zeros(32, 32)
+                for pt in range(K):
+                    t[:, 2 * pt] = w - 1
+                    t[:, 2 * pt + 1] = h - 1
+                tiles.append(t)
+            sel = [torch.zeros(32, 32) for _ in range(5 * OT)]
+            for pt in range(K):
+                for f, kind, src in (
+                    (2, 0, 2 * pt), (4, 0, 2 * pt),          # SB0: b0 -> nw, sw
+                    (3, 1, 2 * pt), (5, 1, 2 * pt),          # SB1: b1 -> ne, se
+                    (2, 2, 2 * pt + 1), (3, 2, 2 * pt + 1),  # SH0: a0 -> nw, ne
+                    (4, 3, 2 * pt + 1), (5, 3, 2 * pt + 1),  # SH1: a1 -> sw, se
+                    (0, 4, 2 * pt + 1), (1, 4, 2 * pt),      # SI: h0 <- y, w0 <- x
+                ):
+                    g = f * K + pt                           # field-major column
+                    sel[5 * (g // 32) + kind][src, g % 32] = 1.0
+            tiles += sel
+            _kw = dict(device=self.device)
+            if self._mesh_device is not None:
+                _kw["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+            self._gp_consts = ttnn.from_torch(
+                torch.stack(tiles).reshape(1, 1, -1, 32),
+                dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, **_kw,
+            )
+            self._gp_out = [
+                ttnn.from_torch(
+                    torch.zeros(1, self._oob_cap, 1, K * 6),
+                    dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG, **_kw,
+                )
+                for _ in range(NL)
+            ]
+
+        ttnn.grid_precompute(
+            self._cgrid, self._gp_consts,
+            self._gp_out[0], self._gp_out[1], self._gp_out[2], self._gp_out[3],
+            num_pts=K,
+        )
+        return [
+            ttnn.to_memory_config(o, self._cgrid_precomp_sharded_mem) for o in self._gp_out
+        ]
+
     def _compact_grid(self, points_2d, n, nc, spatial_shapes):
         """Compact the sampling grid to the rows that actually hit an image.
 
@@ -1155,8 +1245,12 @@ class DeformableFeatureAggregation:
                 points_2d_sh, bidx_sh = self._compact_grid(
                     points_2d, n, nc, spatial_shapes
                 )
+                gp_grids = (
+                    self._run_grid_precompute(spatial_shapes) if _GRID_PRECOMP else None
+                )
             else:
                 points_2d_sh = ttnn.to_memory_config(points_2d, self._grid_sharded_mem)
+                gp_grids = None
             ttnn.deallocate(points_2d)
 
             if _WT_COMPACT and self.use_camera_embed:
@@ -1172,10 +1266,20 @@ class DeformableFeatureAggregation:
                     weights_t = self._mask_weights(weights_t, n, nc)
 
             for level_idx, fm_tt in enumerate(feature_maps):
-                sampled = ttnn.grid_sample(
-                    fm_tt, points_2d_sh, padding_mode="zeros", align_corners=False,
-                    batch_index=bidx_sh,
-                )
+                if gp_grids is not None:
+                    # Per-level precomputed grid: pixel indices and masked bilinear
+                    # weights already computed on the Tensix engines, so the reader
+                    # skips its ~928-cycle soft-float coordinate math per point.
+                    sampled = ttnn.grid_sample(
+                        fm_tt, gp_grids[level_idx], padding_mode="zeros",
+                        align_corners=False, use_precomputed_grid=True,
+                        batch_index=bidx_sh,
+                    )
+                else:
+                    sampled = ttnn.grid_sample(
+                        fm_tt, points_2d_sh, padding_mode="zeros", align_corners=False,
+                        batch_index=bidx_sh,
+                    )
                 ttnn.transposed_s2i(
                     sampled, self._rearrange_buf,
                     num_cams=nc, num_pts=self.num_pts, num_anchors=n,
@@ -1184,6 +1288,9 @@ class DeformableFeatureAggregation:
                     capacity=self._oob_cap if _OOB_COMPACT else 0,
                 )
             ttnn.deallocate(points_2d_sh)
+            if gp_grids is not None:
+                for g in gp_grids:
+                    ttnn.deallocate(g)
             if bidx_sh is not None:
                 ttnn.deallocate(bidx_sh)
 

--- a/model/deformable_feature_aggregation.py
+++ b/model/deformable_feature_aggregation.py
@@ -324,6 +324,21 @@ class DeformableFeatureAggregation:
             parameters["weights_fc_bias"]
         )  # [1,1,1,416]
 
+        if use_camera_embed:
+            # Block-diagonal copy of weights_fc: linear([f|f|f] + [c0|c1|c2]) then
+            # emits the folded [N, cams*416] row directly, replacing the TILE reshape
+            # [N*cams, 416] -> [N, cams*416] after the linear. The off-diagonal zeros
+            # add exact 0.0 into the fp32 accumulator, so the outputs are unchanged.
+            w = parameters["weights_fc_weight"].t()  # [256, 416]
+            d_in, d_out = w.shape
+            wbd = torch.zeros(num_cams * d_in, num_cams * d_out, dtype=w.dtype)
+            for c in range(num_cams):
+                wbd[c * d_in : (c + 1) * d_in, c * d_out : (c + 1) * d_out] = w
+            self.weights_fc_weight_bd = self._to_device(wbd)  # [768, 1248]
+            self.weights_fc_bias_bd = self._to_device_bias(
+                parameters["weights_fc_bias"].repeat(num_cams)
+            )  # [1,1,1,1248]
+
         # Output projection
         self.output_proj_weight = self._to_device(
             parameters["output_proj_weight"].t()
@@ -804,57 +819,51 @@ class DeformableFeatureAggregation:
                 or self._cached_camera_embed is None
             ):
                 self._cached_camera_embed = self._camera_encoder(projection_mat, bs)
-            camera_embed = self._cached_camera_embed
-            # Materialise both operands at [1, 1, N*nc, C] instead of letting a broadcast
-            # do it from [N, 1, C] and [1, nc, C].
-            #
-            # The broadcast form is the obvious one and it is the expensive one: 1 and nc
-            # land in the tile axis, which pads to 32, so a 1.3 MB answer is computed
-            # through a 14 MB intermediate — 91% of the tiles carry nothing. Profiled, the
-            # reshape in, the add and the reshape out came to 3.93 ms/frame between them.
-            #
-            # repeat_interleave on the anchors and repeat on the cameras cost two extra ops
-            # but leave every axis tile-aligned, and the add itself then has no broadcast.
-            # Measured on the real shapes: 882 -> 515 us per call.
-            #
-            # The row order is load-bearing. repeat_interleave gives anchor-major and repeat
-            # cycles the cameras fastest, which is exactly the (anchor, camera) ordering the
-            # reshape after the linear relies on to read clp = cam*L*K + level*K + point.
+                # Row form [1,1,1,nc*C] for the block-diagonal linear below; tiny
+                # TILE reshape, paid once per frame alongside the encoder.
+                self._cached_camera_row = ttnn.reshape(
+                    self._cached_camera_embed,
+                    (1, 1, 1, self.num_cams * self.embed_dims),
+                )
+            # Build the operands wide instead of tall: [N, nc*C] rows [f|f|f] and
+            # [c0|c1|c2]. Same bytes as the old [N*nc, C] materialisation (the
+            # broadcast form was rejected earlier — 1 and nc land in the tile axis
+            # and pad to 32, computing a 1.3 MB answer through a 14 MB
+            # intermediate), but with the camera in the COLUMNS the linear against
+            # the block-diagonal weights_fc emits the folded [N, cams*L*K*G] row
+            # directly and the TILE reshape that followed the linear disappears.
             feat_flat = ttnn.reshape(feature, (1, 1, bs * num_anchor, self.embed_dims))
-            cam_flat = ttnn.reshape(camera_embed, (1, 1, self.num_cams, self.embed_dims))
-            f_rep = ttnn.repeat_interleave(feat_flat, self.num_cams, dim=2)
-            c_rep = ttnn.repeat(cam_flat, ttnn.Shape([1, 1, bs * num_anchor, 1]))
+            f_rep = ttnn.repeat(feat_flat, ttnn.Shape([1, 1, 1, self.num_cams]))
+            c_rep = ttnn.repeat(
+                self._cached_camera_row, ttnn.Shape([1, 1, bs * num_anchor, 1])
+            )
             feature = ttnn.add(f_rep, c_rep)
             ttnn.deallocate(f_rep)
             ttnn.deallocate(c_rep)
             # Don't deallocate camera_embed — it's cached for reuse
+
+            # Column index is cam*(L*K*G) + (level*K + point)*G + g: the camera
+            # block comes from the weight's block column, the rest from the
+            # linear's own column order — the clp*G + g ordering the feature
+            # buffer and the mask already use.
+            weights = ttnn.linear(
+                feature,
+                self.weights_fc_weight_bd,
+                bias=self.weights_fc_bias_bd,
+                compute_kernel_config=self._hifi_compute_config,
+            )
+            ttnn.deallocate(feature)
         else:
             feature = ttnn.reshape(feature, (1, 1, bs * num_anchor, self.embed_dims))
-
-        weights = ttnn.linear(
-            feature,
-            self.weights_fc_weight,
-            bias=self.weights_fc_bias,
-            compute_kernel_config=self._hifi_compute_config,
-        )
-
-        ttnn.deallocate(feature)
+            weights = ttnn.linear(
+                feature,
+                self.weights_fc_weight,
+                bias=self.weights_fc_bias,
+                compute_kernel_config=self._hifi_compute_config,
+            )
+            ttnn.deallocate(feature)
 
         total_clp = self.num_cams * self.num_levels * self.num_pts
-        if self.use_camera_embed:
-            # [1, 1, bs*N, CLP*G]. The camera came from the row axis and the linear's
-            # columns are (level, point, group), so the merged column index is exactly
-            # clp*G + g with clp = cam*L*K + level*K + point — the ordering the feature
-            # buffer and the mask both already use.
-            weights = ttnn.reshape(
-                weights,
-                (
-                    1,
-                    1,
-                    bs * num_anchor,
-                    self.num_cams * self.num_levels * self.num_pts * self.num_groups,
-                ),
-            )
 
         # Only the camera-embed path produces the compact layout for free: without it the
         # linear has no camera axis to fold into the columns, so CLP*G would not be the

--- a/model/deformable_feature_aggregation.py
+++ b/model/deformable_feature_aggregation.py
@@ -26,6 +26,19 @@ import ttnn
 # TT_CUSTOM_KERNELS=0 → force pure ttnn, TT_CUSTOM_KERNELS=1 → force custom kernels
 import os as _os
 _KERNELS_AVAILABLE = all(hasattr(ttnn, op) for op in ["kps_project_fused", "transposed_s2i", "grouped_weighted_sum"])
+
+# Dead-pair skip for grouped_weighted_sum: anchors bucketed by camera
+# visibility (anchor_bucket) so the gws reader can skip the ~75-80% of
+# (tile-row, clp) iterations whose weights the mask zeroed anyway. Ablation
+# measured gws time linear in clp iterations (1003/451/238 us at 156/78/40),
+# so the skip converts ~1:1. Output is bit-identical: every skipped term is
+# exactly 0.0. PARKED (TT_GWS_SKIP=1 opts in): bit-identical but slower —
+# the permuted stick reads lose DRAM locality and the surviving 31% of
+# iterations run ~3x slower, erasing the win (see CHANGELOG 2026-08-19).
+_GWS_SKIP = (
+    all(hasattr(ttnn, op) for op in ["anchor_bucket", "row_gather"])
+    and _os.environ.get("TT_GWS_SKIP", "0") == "1"
+)
 _env = _os.environ.get("TT_CUSTOM_KERNELS")
 if _env is not None:
     _HAS_CUSTOM_KERNELS = _env == "1"
@@ -1123,6 +1136,42 @@ class DeformableFeatureAggregation:
                 torch.zeros(1, 1, self._oob_cap, 8, dtype=torch.int32),
                 dtype=ttnn.uint32, **_kw,
             )
+            if _GWS_SKIP:
+                npad = ((n + 31) // 32) * 32
+                self._ab_perm = ttnn.from_torch(
+                    torch.zeros(1, 1, 1, npad, dtype=torch.int32), dtype=ttnn.uint32, **_kw)
+                self._ab_inv = ttnn.from_torch(
+                    torch.zeros(1, 1, 1, npad, dtype=torch.int32), dtype=ttnn.uint32, **_kw)
+                self._ab_live = ttnn.from_torch(
+                    torch.zeros(1, 1, 1, 32, dtype=torch.int32), dtype=ttnn.uint32, **_kw)
+                # weights permuted into sorted-anchor order, once per gws call —
+                # the reader then reads them tile-cached like the non-skip path
+                _wkw = dict(dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT,
+                            device=self.device)
+                if self._mesh_device is not None:
+                    _wkw["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+                self._wt_perm = ttnn.from_torch(
+                    torch.zeros(n, nc * self.num_levels * self.num_pts
+                                * self.num_groups), **_wkw)
+                self._gws_unperm = None  # lazy: matches the fused feature shape
+                # Count mailbox: L1-sharded so every core's 32-word shard sits
+                # at ONE base address the kernels get as a plain runtime arg —
+                # the MATH thread has no cb_interface, so a CB cannot carry it.
+                _grid = self.device.compute_with_storage_grid_size()
+                _mbox_shard = ttnn.MemoryConfig(
+                    ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1,
+                    ttnn.ShardSpec(
+                        ttnn.CoreRangeSet({ttnn.CoreRange(
+                            ttnn.CoreCoord(0, 0),
+                            ttnn.CoreCoord(_grid.x - 1, _grid.y - 1))}),
+                        [1, 32], ttnn.ShardOrientation.ROW_MAJOR))
+                _mkw = dict(layout=ttnn.ROW_MAJOR_LAYOUT, device=self.device,
+                            memory_config=_mbox_shard)
+                if self._mesh_device is not None:
+                    _mkw["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+                self._gws_mbox = ttnn.from_torch(
+                    torch.zeros(1, 1, _grid.x * _grid.y, 32, dtype=torch.int32),
+                    dtype=ttnn.uint32, **_mkw)
 
         # With align_corners=False a point contributes iff g is in [-1 - 1/S, 1 + 1/S),
         # S being W on x and H on y. Take the loosest LEVEL so one compaction serves all
@@ -1135,6 +1184,9 @@ class DeformableFeatureAggregation:
             num_pts=self.num_pts, capacity=self._oob_cap, anchors=n,
             threshold_x=thr_x, threshold_y=thr_y, bidx=self._cbidx,
         )
+        if _GWS_SKIP:
+            ttnn.anchor_bucket(self._cflags, self._ab_perm, self._ab_inv,
+                               self._ab_live, num_anchors=n)
         return (
             ttnn.to_memory_config(self._cgrid, self._cgrid_sharded_mem),
             ttnn.to_memory_config(self._cbidx, self._cbidx_sharded_mem),
@@ -1308,10 +1360,20 @@ class DeformableFeatureAggregation:
             # 137 MB DRAM round trip per call — is not needed. RM_MODE is only correct
             # with the kernel fix that configures both compute pipelines before the loop;
             # without it the op is wrong on its first call after any other op has run.
-            gws_out = ttnn.grouped_weighted_sum(
-                self._rearrange_buf, weights_t,
-                num_groups=self.num_groups, group_dims=self.group_dims,
-            )
+            if _GWS_SKIP:
+                ttnn.row_gather(weights_t, self._ab_perm, self._wt_perm, k=n)
+                gws_out = ttnn.grouped_weighted_sum(
+                    self._rearrange_buf, self._wt_perm,
+                    num_groups=self.num_groups, group_dims=self.group_dims,
+                    perm=self._ab_perm, live=self._ab_live,
+                    clp_per_cam=self.num_levels * self.num_pts,
+                    mbox=self._gws_mbox,
+                )
+            else:
+                gws_out = ttnn.grouped_weighted_sum(
+                    self._rearrange_buf, weights_t,
+                    num_groups=self.num_groups, group_dims=self.group_dims,
+                )
             ttnn.deallocate(weights_t)
             n_padded = ((n + 31) // 32) * 32
             chunk0 = ttnn.slice(gws_out, [0, 0], [n, self.embed_dims])
@@ -1320,6 +1382,18 @@ class DeformableFeatureAggregation:
             features = ttnn.add(chunk0, chunk1)
             ttnn.deallocate(chunk0)
             ttnn.deallocate(chunk1)
+            if _GWS_SKIP:
+                # rows came out in sorted-anchor order; un-permute via inv
+                if self._gws_unperm is None:
+                    _ukw = dict(layout=features.layout, device=self.device,
+                                dtype=features.dtype)
+                    if self._mesh_device is not None:
+                        _ukw["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+                    self._gws_unperm = ttnn.from_torch(
+                        torch.zeros(n, self.embed_dims), **_ukw)
+                ttnn.row_gather(features, self._ab_inv, self._gws_unperm, k=n)
+                ttnn.deallocate(features)
+                features = self._gws_unperm
         else:
             # === Fallback path: original pure ttnn ops (from pre-kernel commit bc5e388) ===
             ttnn.deallocate(anchor_rm)

--- a/model/fpn.py
+++ b/model/fpn.py
@@ -196,6 +196,9 @@ class FPN:
 
             x = laterals[i]
             x = ttnn.to_memory_config(x, ttnn.DRAM_MEMORY_CONFIG)
+            # conv2d's slice path reshapes flat->NHWC internally; on TILE that
+            # materialises (~885us at level 0), on ROW_MAJOR it is a free view.
+            x = ttnn.to_layout(x, ttnn.ROW_MAJOR_LAYOUT)
 
             total_rows = self.batch_size * h * w
             use_sharding = total_rows >= 128
@@ -205,6 +208,9 @@ class FPN:
                     ttnn.TensorMemoryLayout.HEIGHT_SHARDED if use_sharding else None
                 ),
                 reshard_if_not_optimal=True,
+                # DFA consumes these as ROW_MAJOR NHWC; RM out also turns the slice-mode
+                # epilogue reshape (4D->flat, ~868us at level 0) into a view.
+                output_layout=ttnn.ROW_MAJOR_LAYOUT,
             )
 
             [x, [out_h, out_w], [self.fpn_weights[i], self.fpn_biases[i]]] = (

--- a/model/instance_bank.py
+++ b/model/instance_bank.py
@@ -13,9 +13,10 @@
 #   update() → merge cached + new instances via topk + mask
 #   cache()  → save top-K instances for next frame
 #
-# All operations on device using ttnn ops.
-# anchor_projection handled on host (per-frame coordinate transform,
-# requires numpy metas) then transferred back to device.
+# All operations on device using ttnn ops. The temporal anchor projection is
+# folded into a single matmul+add against an 11x11 affine built on host from
+# the frame's ego-pose metas — host touches the metas (their birthplace), the
+# device does all the anchor math.
 # =============================================================================
 
 import numpy as np
@@ -26,6 +27,16 @@ import os as _os
 
 # TT_ANCHOR_FP32=0 puts the anchor back in bf16 for an A/B.
 _ANCHOR_DTYPE = ttnn.bfloat16 if _os.environ.get("TT_ANCHOR_FP32") == "0" else ttnn.float32
+
+# Custom top-k kernel. ttnn.topk tile-pads the [1, 900] confidence row to
+# 32 x 928 and bitonic-sorts all 32 rows on one core (1.9 + 2.8 ms/frame between
+# the two calls); topk_select radix-sorts the one real row. TT_TOPK_KERNEL=0
+# falls back to ttnn.topk. Tie order differs from ttnn.topk (ours is torch's
+# lower-index-first), so an A/B against the fallback is not bit-identical on
+# tied confidences.
+_TOPK_KERNEL = (
+    hasattr(ttnn, "topk_select") and _os.environ.get("TT_TOPK_KERNEL", "1") == "1"
+)
 
 # Anchor box field indices
 X, Y, Z = 0, 1, 2
@@ -77,7 +88,25 @@ class InstanceBank:
         self._dev_anchor = self._to_dev(anchor_tiled, _ANCHOR_DTYPE)
         self._dev_feature = self._to_dev(feature_tiled)
 
+        # Persistent output buffers for topk_select, one (values, indices) pair
+        # per k. The op writes every slot on every call, so reuse is safe.
+        self._topk_bufs = {}
+
         self.reset()
+
+    def _topk_out(self, k: int):
+        buf = self._topk_bufs.get(k)
+        if buf is None:
+            kw = dict(device=self.device, layout=ttnn.ROW_MAJOR_LAYOUT)
+            if self._mesh_device is not None:
+                kw["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+            vals = ttnn.from_torch(
+                torch.zeros(1, 1, 1, k), dtype=ttnn.bfloat16, **kw)
+            idxs = ttnn.from_torch(
+                torch.zeros(1, 1, 1, k, dtype=torch.int32), dtype=ttnn.uint32, **kw)
+            buf = (vals, idxs)
+            self._topk_bufs[k] = buf
+        return buf
 
     def _to_dev(self, tensor: torch.Tensor, dtype=None) -> ttnn.Tensor:
         """Helper: from_torch with mesh_mapper if mesh mode."""
@@ -144,37 +173,41 @@ class InstanceBank:
             if self._mesh_device is not None:
                 _kw["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
 
-            anc = self.cached_anchor
-            nt = anc.shape[1]
-            neg_ti_bf = (-time_interval_pt).reshape(bs, 1, 1).bfloat16()
-            ti_tt = ttnn.from_torch(neg_ti_bf, **_kw)
-            vel = ttnn.slice(anc, [0, 0, VX], [bs, nt, VZ + 1])
-            center = ttnn.slice(anc, [0, 0, X], [bs, nt, Z + 1])
-            translation = ttnn.multiply(vel, ti_tt)
-            center = ttnn.subtract(center, translation)
-            ttnn.deallocate(translation); ttnn.deallocate(ti_tt)
+            # Every projected field is LINEAR in the anchor fields:
+            #   center' = (center - ti_used*vel) @ R^T + t
+            #   size'   = size
+            #   yaw'    = [cos, sin] @ R22^T   (written back [cos', sin'] into the
+            #             (SIN, COS) slots — the upstream Sparse4D swap, preserved
+            #             for checkpoint compatibility)
+            #   vel'    = vel @ R^T
+            # so the whole projection folds into ONE anchor @ A + b. The previous
+            # form spelled it out as 13 device ops with 4 h2d uploads per frame;
+            # host dispatch is the frame's scarce resource and a trace capture
+            # needs the op stream minimal and static, so A and b (two tiny
+            # constants) are built on host instead. ti_used = -dt, matching the
+            # original InstanceBank's anchor_projection(-time_interval) call.
+            Tm = T_temp2cur_pt.float()           # bf16-rounded, as uploaded before
+            RT = Tm[:, :3, :3].transpose(-1, -2)
+            ti_used = (-time_interval_pt).bfloat16().float().reshape(bs, 1, 1)
+            A = torch.zeros(bs, 11, 11)
+            b = torch.zeros(bs, 1, 11)
+            A[:, X : Z + 1, X : Z + 1] = RT
+            A[:, VX:, X : Z + 1] = -ti_used * RT
+            b[:, 0, X : Z + 1] = Tm[:, :3, 3]
+            for d in (W, L, H):
+                A[:, d, d] = 1.0
+            R22T = Tm[:, :2, :2].transpose(-1, -2)
+            A[:, COS_YAW, SIN_YAW] = R22T[:, 0, 0]  # col SIN receives cos'
+            A[:, SIN_YAW, SIN_YAW] = R22T[:, 1, 0]
+            A[:, COS_YAW, COS_YAW] = R22T[:, 0, 1]  # col COS receives sin'
+            A[:, SIN_YAW, COS_YAW] = R22T[:, 1, 1]
+            A[:, VX:, VX:] = RT
 
-            R33_T_pt = T_temp2cur_pt[:,:3,:3].transpose(-1,-2).contiguous()
-            R33_T = ttnn.from_torch(R33_T_pt, **_kw)
-            t3 = ttnn.from_torch(T_temp2cur_pt[:,:3,3].reshape(bs,1,3).contiguous(), **_kw)
-            center = ttnn.matmul(center, R33_T)
-            center = ttnn.add(center, t3); ttnn.deallocate(t3)
-
-            cos_yaw = ttnn.slice(anc, [0,0,COS_YAW], [bs,nt,COS_YAW+1])
-            sin_yaw = ttnn.slice(anc, [0,0,SIN_YAW], [bs,nt,SIN_YAW+1])
-            yaw_cs = ttnn.concat([cos_yaw, sin_yaw], dim=-1)
-            ttnn.deallocate(cos_yaw); ttnn.deallocate(sin_yaw)
-            R22_T = ttnn.from_torch(T_temp2cur_pt[:,:2,:2].transpose(-1,-2).contiguous(), **_kw)
-            yaw_out = ttnn.matmul(yaw_cs, R22_T); ttnn.deallocate(yaw_cs)
-
-            # Reuse R33_T for velocity rotation (same matrix, was uploaded twice before)
-            vel_out = ttnn.matmul(vel, R33_T)
-            ttnn.deallocate(vel); ttnn.deallocate(R33_T); ttnn.deallocate(R22_T)
-
-            size = ttnn.slice(anc, [0,0,W], [bs,nt,H+1])
-            cached_anchor = ttnn.concat([center, size, yaw_out, vel_out], dim=-1)
-            ttnn.deallocate(center); ttnn.deallocate(size)
-            ttnn.deallocate(yaw_out); ttnn.deallocate(vel_out)
+            A_tt = ttnn.from_torch(A, **_kw)
+            b_tt = ttnn.from_torch(b, **_kw)
+            cached_anchor = ttnn.matmul(self.cached_anchor, A_tt)
+            cached_anchor = ttnn.add(cached_anchor, b_tt)
+            ttnn.deallocate(A_tt); ttnn.deallocate(b_tt)
             self.cached_anchor = self._as_bank_dtype(cached_anchor)
 
             time_interval_pt = torch.where(
@@ -238,12 +271,20 @@ class InstanceBank:
         conf_max = ttnn.max(confidence, dim=-1, keepdim=True)
         conf_max_2d = ttnn.reshape(conf_max, (bs, self.num_anchor))
         ttnn.deallocate(conf_max)
-        _, top_idx_flat = ttnn.topk(conf_max_2d, N, dim=-1)
-        ttnn.deallocate(conf_max_2d)
-        top_idx_flat = ttnn.typecast(top_idx_flat, ttnn.uint32)
-        top_idx = ttnn.reshape(top_idx_flat, (bs, N, 1))
-        top_idx = ttnn.to_layout(top_idx, ttnn.TILE_LAYOUT)
-        ttnn.deallocate(top_idx_flat)
+        if _TOPK_KERNEL:
+            val_buf, idx_buf = self._topk_out(N)
+            ttnn.topk_select(conf_max_2d, val_buf, idx_buf, N)
+            ttnn.deallocate(conf_max_2d)
+            # Persistent buffer: reshape to a fresh view, never deallocated here.
+            top_idx = ttnn.reshape(idx_buf, (bs, N, 1))
+            top_idx = ttnn.to_layout(top_idx, ttnn.TILE_LAYOUT)
+        else:
+            _, top_idx_flat = ttnn.topk(conf_max_2d, N, dim=-1)
+            ttnn.deallocate(conf_max_2d)
+            top_idx_flat = ttnn.typecast(top_idx_flat, ttnn.uint32)
+            top_idx = ttnn.reshape(top_idx_flat, (bs, N, 1))
+            top_idx = ttnn.to_layout(top_idx, ttnn.TILE_LAYOUT)
+            ttnn.deallocate(top_idx_flat)
 
         idx_feat = ttnn.repeat_interleave(top_idx, self.embed_dims, dim=-1)
         selected_feature = ttnn.gather(instance_feature, 1, idx_feat)
@@ -327,12 +368,21 @@ class InstanceBank:
 
         # Device topk + gather
         K = self.num_temp_instances
-        top_conf, top_idx_flat = ttnn.topk(conf_scores, K, dim=-1)
-        ttnn.deallocate(conf_scores)
-        top_idx_flat = ttnn.typecast(top_idx_flat, ttnn.uint32)
-        top_idx = ttnn.reshape(top_idx_flat, (bs, K, 1))
-        top_idx = ttnn.to_layout(top_idx, ttnn.TILE_LAYOUT)
-        ttnn.deallocate(top_idx_flat)
+        if _TOPK_KERNEL:
+            val_buf, idx_buf = self._topk_out(K)
+            ttnn.topk_select(conf_scores, val_buf, idx_buf, K)
+            ttnn.deallocate(conf_scores)
+            # Downstream (decay multiply next frame) works on TILE.
+            top_conf = ttnn.to_layout(val_buf, ttnn.TILE_LAYOUT)
+            top_idx = ttnn.reshape(idx_buf, (bs, K, 1))
+            top_idx = ttnn.to_layout(top_idx, ttnn.TILE_LAYOUT)
+        else:
+            top_conf, top_idx_flat = ttnn.topk(conf_scores, K, dim=-1)
+            ttnn.deallocate(conf_scores)
+            top_idx_flat = ttnn.typecast(top_idx_flat, ttnn.uint32)
+            top_idx = ttnn.reshape(top_idx_flat, (bs, K, 1))
+            top_idx = ttnn.to_layout(top_idx, ttnn.TILE_LAYOUT)
+            ttnn.deallocate(top_idx_flat)
 
         idx_feat = ttnn.repeat_interleave(top_idx, self.embed_dims, dim=-1)
         self.cached_feature = ttnn.gather(instance_feature, 1, idx_feat)

--- a/model/instance_bank.py
+++ b/model/instance_bank.py
@@ -38,6 +38,17 @@ _TOPK_KERNEL = (
     hasattr(ttnn, "topk_select") and _os.environ.get("TT_TOPK_KERNEL", "1") == "1"
 )
 
+# Paired row-gather kernel: one op replaces the two ttnn.gather calls (655
+# us/call on 4 cores, latency-bound) AND the index expansion chain each needed
+# (typecast/reshape/to_layout/repeat_interleave). Consumes topk_select's uint32
+# ROW_MAJOR indices directly, so it requires _TOPK_KERNEL. Bit-identical row
+# copies (verified exact incl. duplicate indices). TT_ROW_GATHER=0 falls back.
+_ROW_GATHER = (
+    _TOPK_KERNEL
+    and hasattr(ttnn, "row_gather")
+    and _os.environ.get("TT_ROW_GATHER", "1") == "1"
+)
+
 # Anchor box field indices
 X, Y, Z = 0, 1, 2
 W, L, H = 3, 4, 5
@@ -91,6 +102,8 @@ class InstanceBank:
         # Persistent output buffers for topk_select, one (values, indices) pair
         # per k. The op writes every slot on every call, so reuse is safe.
         self._topk_bufs = {}
+        # Persistent (features, anchors) output pair per k for row_gather.
+        self._rg_bufs = {}
 
         self.reset()
 
@@ -106,6 +119,20 @@ class InstanceBank:
                 torch.zeros(1, 1, 1, k, dtype=torch.int32), dtype=ttnn.uint32, **kw)
             buf = (vals, idxs)
             self._topk_bufs[k] = buf
+        return buf
+
+    def _rg_out(self, k: int):
+        buf = self._rg_bufs.get(k)
+        if buf is None:
+            kw = dict(layout=ttnn.TILE_LAYOUT, device=self.device)
+            if self._mesh_device is not None:
+                kw["mesh_mapper"] = ttnn.ReplicateTensorToMesh(self._mesh_device)
+            feat = ttnn.from_torch(
+                torch.zeros(1, k, self.embed_dims), dtype=ttnn.bfloat16, **kw)
+            anch = ttnn.from_torch(
+                torch.zeros(1, k, 11), dtype=_ANCHOR_DTYPE, **kw)
+            buf = (feat, anch)
+            self._rg_bufs[k] = buf
         return buf
 
     def _to_dev(self, tensor: torch.Tensor, dtype=None) -> ttnn.Tensor:
@@ -275,9 +302,12 @@ class InstanceBank:
             val_buf, idx_buf = self._topk_out(N)
             ttnn.topk_select(conf_max_2d, val_buf, idx_buf, N)
             ttnn.deallocate(conf_max_2d)
-            # Persistent buffer: reshape to a fresh view, never deallocated here.
-            top_idx = ttnn.reshape(idx_buf, (bs, N, 1))
-            top_idx = ttnn.to_layout(top_idx, ttnn.TILE_LAYOUT)
+            if _ROW_GATHER:
+                top_idx = None   # row_gather eats idx_buf directly
+            else:
+                # Persistent buffer: reshape to a fresh view, never deallocated here.
+                top_idx = ttnn.reshape(idx_buf, (bs, N, 1))
+                top_idx = ttnn.to_layout(top_idx, ttnn.TILE_LAYOUT)
         else:
             _, top_idx_flat = ttnn.topk(conf_max_2d, N, dim=-1)
             ttnn.deallocate(conf_max_2d)
@@ -286,19 +316,25 @@ class InstanceBank:
             top_idx = ttnn.to_layout(top_idx, ttnn.TILE_LAYOUT)
             ttnn.deallocate(top_idx_flat)
 
-        idx_feat = ttnn.repeat_interleave(top_idx, self.embed_dims, dim=-1)
-        selected_feature = ttnn.gather(instance_feature, 1, idx_feat)
-        ttnn.deallocate(idx_feat)
+        if _ROW_GATHER:
+            selected_feature, selected_anchor = self._rg_out(N)
+            ttnn.row_gather(instance_feature, idx_buf, selected_feature,
+                            src_b=anchor, out_b=selected_anchor, k=N)
+        else:
+            idx_feat = ttnn.repeat_interleave(top_idx, self.embed_dims, dim=-1)
+            selected_feature = ttnn.gather(instance_feature, 1, idx_feat)
+            ttnn.deallocate(idx_feat)
 
-        anch_dim = anchor.shape[-1]
-        idx_anch = ttnn.repeat_interleave(top_idx, anch_dim, dim=-1)
-        selected_anchor = ttnn.gather(anchor, 1, idx_anch)
-        ttnn.deallocate(idx_anch); ttnn.deallocate(top_idx)
+            anch_dim = anchor.shape[-1]
+            idx_anch = ttnn.repeat_interleave(top_idx, anch_dim, dim=-1)
+            selected_anchor = ttnn.gather(anchor, 1, idx_anch)
+            ttnn.deallocate(idx_anch); ttnn.deallocate(top_idx)
 
         # Device concat
         merged_feature = ttnn.concat([self.cached_feature, selected_feature], dim=1)
         merged_anchor = ttnn.concat([self.cached_anchor, selected_anchor], dim=1)
-        ttnn.deallocate(selected_feature); ttnn.deallocate(selected_anchor)
+        if not _ROW_GATHER:
+            ttnn.deallocate(selected_feature); ttnn.deallocate(selected_anchor)
 
         if self.mask.all():
             instance_feature = merged_feature
@@ -374,8 +410,11 @@ class InstanceBank:
             ttnn.deallocate(conf_scores)
             # Downstream (decay multiply next frame) works on TILE.
             top_conf = ttnn.to_layout(val_buf, ttnn.TILE_LAYOUT)
-            top_idx = ttnn.reshape(idx_buf, (bs, K, 1))
-            top_idx = ttnn.to_layout(top_idx, ttnn.TILE_LAYOUT)
+            if _ROW_GATHER:
+                top_idx = None
+            else:
+                top_idx = ttnn.reshape(idx_buf, (bs, K, 1))
+                top_idx = ttnn.to_layout(top_idx, ttnn.TILE_LAYOUT)
         else:
             top_conf, top_idx_flat = ttnn.topk(conf_scores, K, dim=-1)
             ttnn.deallocate(conf_scores)
@@ -384,14 +423,21 @@ class InstanceBank:
             top_idx = ttnn.to_layout(top_idx, ttnn.TILE_LAYOUT)
             ttnn.deallocate(top_idx_flat)
 
-        idx_feat = ttnn.repeat_interleave(top_idx, self.embed_dims, dim=-1)
-        self.cached_feature = ttnn.gather(instance_feature, 1, idx_feat)
-        ttnn.deallocate(idx_feat)
+        if _ROW_GATHER:
+            feat_buf, anch_buf = self._rg_out(K)
+            ttnn.row_gather(instance_feature, idx_buf, feat_buf,
+                            src_b=self._as_bank_dtype(anchor), out_b=anch_buf, k=K)
+            self.cached_feature = feat_buf
+            self.cached_anchor = anch_buf
+        else:
+            idx_feat = ttnn.repeat_interleave(top_idx, self.embed_dims, dim=-1)
+            self.cached_feature = ttnn.gather(instance_feature, 1, idx_feat)
+            ttnn.deallocate(idx_feat)
 
-        anch_dim = anchor.shape[-1]
-        idx_anch = ttnn.repeat_interleave(top_idx, anch_dim, dim=-1)
-        self.cached_anchor = ttnn.gather(self._as_bank_dtype(anchor), 1, idx_anch)
-        ttnn.deallocate(idx_anch); ttnn.deallocate(top_idx)
+            anch_dim = anchor.shape[-1]
+            idx_anch = ttnn.repeat_interleave(top_idx, anch_dim, dim=-1)
+            self.cached_anchor = ttnn.gather(self._as_bank_dtype(anchor), 1, idx_anch)
+            ttnn.deallocate(idx_anch); ttnn.deallocate(top_idx)
 
         self.confidence = ttnn.reshape(top_conf, (1, 1, bs, K))
 

--- a/model/refinement_module.py
+++ b/model/refinement_module.py
@@ -119,8 +119,12 @@ class SparseBox3DRefinementModule:
         for idx, entry in enumerate(layers):
             linear_in = x
             # Fused linear+relu: single op instead of two
+            # core_grid makes the relu a REAL fused epilogue: without a user core
+            # grid, matmul runs `activation` as a separate unary op afterwards
+            # (matmul.cpp: user_fused_activation && !user_core_coord).
             x = ttnn.linear(x, entry["weight"], bias=entry["bias"],
                             activation="relu",
+                            core_grid=ttnn.CoreGrid(y=8, x=8),
                             compute_kernel_config=self._hifi_compute_config)
             if "ln_weight" in entry:
                 ln_in = x

--- a/model/sparse4d.py
+++ b/model/sparse4d.py
@@ -537,23 +537,29 @@ class Sparse4DInference:
         Returns:
             list of FPN feature maps as mesh tensors (sharded by camera)
         """
-        imgs_flat = images.reshape(self.num_cams, 3, 256, 704)
-
-        # Fast upload via persistent device buffer
-        if hasattr(self, '_next_host_input') and self._next_host_input is not None:
-            host_input = self._next_host_input
-            self._next_host_input = None
+        # Double-buffered path: stage_next_images() already packed, uploaded and
+        # re-paged this frame's images while the PREVIOUS frame was computing, so
+        # the whole input pipeline is off this frame's critical path.
+        staged = getattr(self, '_staged_tt_input', None)
+        if staged is not None:
+            tt_input = staged
+            self._staged_tt_input = None
         else:
-            host_input = self._prepare_host_input(images)
+            # Fast upload via persistent device buffer
+            if hasattr(self, '_next_host_input') and self._next_host_input is not None:
+                host_input = self._next_host_input
+                self._next_host_input = None
+            else:
+                host_input = self._prepare_host_input(images)
 
-        if not hasattr(self, '_img_dev_slot') or self._img_dev_slot is None:
-            self._img_dev_slot = ttnn.allocate_tensor_on_device(
-                ttnn.Shape([1, 1, self.UPLOAD_SHAPE[2], self.UPLOAD_SHAPE[3]]),
-                ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, self._mesh_device)
-        ttnn.copy_host_to_device_tensor(host_input, self._img_dev_slot)
-        # Back to the NHWC shape conv2d consumes. Same bytes in the same order, so
-        # this is a re-paging on device (~2 ms) in exchange for 39 ms of h2d.
-        tt_input = ttnn.reshape(self._img_dev_slot, (1, 1, 3 * 256 * 704, 4))
+            if not hasattr(self, '_img_dev_slot') or self._img_dev_slot is None:
+                self._img_dev_slot = ttnn.allocate_tensor_on_device(
+                    ttnn.Shape([1, 1, self.UPLOAD_SHAPE[2], self.UPLOAD_SHAPE[3]]),
+                    ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, self._mesh_device)
+            ttnn.copy_host_to_device_tensor(host_input, self._img_dev_slot)
+            # Back to the NHWC shape conv2d consumes. Same bytes in the same order, so
+            # this is a re-paging on device (~2 ms) in exchange for 39 ms of h2d.
+            tt_input = ttnn.reshape(self._img_dev_slot, (1, 1, 3 * 256 * 704, 4))
 
         # Backbone SPMD: each device processes its 3 cameras
         backbone_features = self.backbone(tt_input)
@@ -580,6 +586,41 @@ class Sparse4DInference:
             fpn_features[level_idx] = f
 
         return fpn_features
+
+    def stage_next_images(self, images: torch.Tensor):
+        """Stage the NEXT frame's images while the device still runs this one.
+
+        Packs on host, enqueues the h2d write and the on-device re-page into
+        the slot the in-flight frame is NOT reading. The write streams while
+        the current frame computes and the re-page fills the frame-boundary
+        idle gap, so the next forward() starts straight at the backbone.
+
+        Slot safety: the alternate slot's last reader is the backbone of the
+        frame BEFORE the one in flight — a full frame of enqueued ops sits
+        between it and this write in the command queue, far deeper than the
+        dispatcher ever runs ahead of the workers.
+        """
+        if not self.mesh_parallel_mode:
+            return
+        host_input = self._prepare_host_input(images)
+        if not hasattr(self, '_img_dev_slots'):
+            self._img_dev_slots = [None, None]
+            self._img_tt_inputs = [None, None]
+            self._img_slot_next = 0
+        slot = self._img_slot_next
+        if self._img_dev_slots[slot] is None:
+            self._img_dev_slots[slot] = ttnn.allocate_tensor_on_device(
+                ttnn.Shape([1, 1, self.UPLOAD_SHAPE[2], self.UPLOAD_SHAPE[3]]),
+                ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT, self._mesh_device)
+        ttnn.copy_host_to_device_tensor(host_input, self._img_dev_slots[slot])
+        # the re-page output staged into this slot two frames ago was consumed
+        # by that frame's backbone; free it before allocating this frame's
+        if self._img_tt_inputs[slot] is not None:
+            ttnn.deallocate(self._img_tt_inputs[slot])
+        self._img_tt_inputs[slot] = ttnn.reshape(
+            self._img_dev_slots[slot], (1, 1, 3 * 256 * 704, 4))
+        self._staged_tt_input = self._img_tt_inputs[slot]
+        self._img_slot_next = 1 - slot
 
     def reset(self):
         """Reset temporal state (call at start of new sequence)."""

--- a/model/sparse_box3d_encoder.py
+++ b/model/sparse_box3d_encoder.py
@@ -162,8 +162,10 @@ class SparseBox3DEncoder:
         """Run Linear+ReLU (→LN) chain with fused activation."""
         for idx, entry in enumerate(layers):
             linear_in = x
+            # core_grid makes the relu a REAL fused epilogue (see refinement_module).
             x = ttnn.linear(x, entry["weight"], bias=entry["bias"],
                             activation="relu",
+                            core_grid=ttnn.CoreGrid(y=8, x=8),
                             compute_kernel_config=self._hifi_compute_config)
             if idx > 0:
                 ttnn.deallocate(linear_in)

--- a/test/sparse4d_nuscenes_val.py
+++ b/test/sparse4d_nuscenes_val.py
@@ -13,6 +13,7 @@ Usage:
 import argparse
 import copy
 import gc
+from concurrent.futures import ThreadPoolExecutor
 import json
 import os
 import pickle
@@ -723,6 +724,37 @@ def _yaw_to_quaternion(yaw):
     return Quaternion(axis=[0, 0, 1], radians=float(yaw))
 
 
+def read_outputs_to_host(outputs, mesh_device=None):
+    """One device->host read of the final-layer outputs.
+
+    Shared by --save-raw and the decoder so the same tensors are never read
+    twice, and callable BEFORE the next frame is enqueued — on the single
+    in-order CQ a read enqueued after the next frame's ops would wait for
+    that whole frame.
+    """
+    prediction = outputs["prediction"][-1]
+    classification = outputs["classification"][-1]
+    quality_list = outputs.get("quality", [])
+    quality = quality_list[-1] if quality_list and quality_list[-1] is not None else None
+    if prediction is None or classification is None:
+        return None
+
+    def _tt_to_torch(t):
+        if t is None:
+            return None
+        if isinstance(t, torch.Tensor):
+            return t.float()
+        if mesh_device is not None:
+            return ttnn.to_torch(t, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0)).float()[:1]
+        return ttnn.to_torch(t).float()
+
+    return {
+        "prediction": _tt_to_torch(prediction),
+        "classification": _tt_to_torch(classification),
+        "quality": _tt_to_torch(quality),
+    }
+
+
 def postprocess_to_nuscenes(
     outputs,
     info,
@@ -748,33 +780,17 @@ def postprocess_to_nuscenes(
     Returns:
         list of dicts in nuScenes submission format
     """
-    prediction = outputs["prediction"][-1]
-    classification = outputs["classification"][-1]
-    quality_list = outputs.get("quality", [])
-    quality = quality_list[-1] if quality_list and quality_list[-1] is not None else None
+    host = read_outputs_to_host(outputs, mesh_device)
+    return decode_host_outputs(host, info, eval_config, max_dets=max_dets)
 
-    if prediction is None or classification is None:
+
+def decode_host_outputs(host, info, eval_config, max_dets=300):
+    """Decode already-read host outputs to nuScenes format (pure host math)."""
+    if host is None:
         return []
-
-    # To host
-    def _tt_to_torch(t, mesh_dev=None):
-        if isinstance(t, torch.Tensor):
-            return t.float()
-        if mesh_dev is not None:
-            return ttnn.to_torch(t, mesh_composer=ttnn.ConcatMeshToTensor(mesh_dev, dim=0)).float()[:1]
-        return ttnn.to_torch(t).float()
-
-    pred = _tt_to_torch(prediction, mesh_device)
-    cls = _tt_to_torch(classification, mesh_device)
-
-    if quality is not None:
-        qt = _tt_to_torch(quality, mesh_device)
-        qt = qt[0]  # [num_anchor, num_quality]
-    else:
-        qt = None
-
-    pred = pred[0]  # [num_anchor, 11]
-    cls = cls[0]  # [num_anchor, num_cls]
+    pred = host["prediction"][0]  # [num_anchor, 11]
+    cls = host["classification"][0]  # [num_anchor, num_cls]
+    qt = host["quality"][0] if host["quality"] is not None else None
 
     num_cls = cls.shape[-1]
     cls_scores = cls.sigmoid()  # [num_anchor, num_cls]
@@ -1125,6 +1141,11 @@ def main():
         help="(deprecated, now always single device) Kept for backward compatibility",
     )
     parser.add_argument(
+        "--no-pipeline",
+        action="store_true",
+        help="Disable the prefetch/staging pipeline (serial reference loop)",
+    )
+    parser.add_argument(
         "--save-raw",
         type=str,
         default=None,
@@ -1247,87 +1268,114 @@ def main():
         processed = 0
         frame_ms = []          # per-frame model.forward, for the median/p90 report
 
-        # Process scene by scene for temporal coherence
+        # Pipelined loop over a flat (scene, sample) list. Three overlaps, all
+        # bit-identical to the serial loop:
+        #   1. get_sample (~48 ms of JPEG decode, the single largest per-sample
+        #      cost) runs on a worker thread under the previous frame's forward
+        #   2. the next frame's images are packed/uploaded/re-paged while the
+        #      device still runs this frame (model.stage_next_images)
+        #   3. outputs are read back ONCE and decoded from host tensors
+        # --no-pipeline restores the serial order for A/B.
+        pipeline = not args.no_pipeline
+        flat = []
         for scene_idx, scene_samples in enumerate(loader.scenes):
-            model.reset()  # Reset temporal cache at scene boundary
-
-            for sample_idx_in_scene, global_idx in enumerate(scene_samples):
-                if processed >= total_samples:
+            for global_idx in scene_samples:
+                if len(flat) >= total_samples:
                     break
-
-                images, metas, info = loader.get_sample(global_idx)
-                token = info["token"]
-
-                t0 = time.time()
-                outputs = model.forward(images, metas, bs=1)
-                elapsed = time.time() - t0
-                total_time += elapsed
-                frame_ms.append(elapsed * 1e3)
-                processed += 1
-
-                # Save raw outputs if requested
-                if args.save_raw:
-                    raw_pred = outputs["prediction"][-1]
-                    raw_cls = outputs["classification"][-1]
-                    raw_qt_list = outputs.get("quality", [])
-                    raw_qt = raw_qt_list[-1] if raw_qt_list and raw_qt_list[-1] is not None else None
-
-                    def _to_cpu(t):
-                        if t is None:
-                            return None
-                        if isinstance(t, torch.Tensor):
-                            return t.cpu().float()
-                        if mesh_device is not None:
-                            return ttnn.to_torch(t, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0)).cpu().float()[:1]
-                        return ttnn.to_torch(t).cpu().float()
-
-                    entry = {
-                        "token": token,
-                        "prediction": _to_cpu(raw_pred)[0],  # [900, 11]
-                        "classification": _to_cpu(raw_cls)[0],  # [900, 10]
-                    }
-                    qt_val = _to_cpu(raw_qt)
-                    if qt_val is not None:
-                        entry["quality"] = qt_val[0]  # [900, 2]
-                    raw_outputs.append(entry)
-
-                # Post-process (PyTorch-identical: NuScenesBox + range filter)
-                dets = postprocess_to_nuscenes(
-                    outputs,
-                    info,
-                    eval_config,
-                    mesh_device=mesh_device,
-                )
-
-                # Add sample_token to each detection
-                for d in dets:
-                    d["sample_token"] = token
-                all_results[token] = dets
-
-                # Periodic GC to prevent host memory leak from to_torch/from_torch
-                if processed % 100 == 0:
-                    gc.collect()
-
-                if processed % 50 == 0 or processed == total_samples:
-                    # Milliseconds to one decimal, not seconds to two. On the old grid a
-                    # sample landed in a 10 ms bucket, which is coarser than most of the
-                    # optimisations this script is used to judge — a 4 ms win reads as no
-                    # change at all. The steady-state median matters more than the mean,
-                    # which stays skewed for hundreds of frames by kernel compilation, so
-                    # both are printed.
-                    warm = sorted(frame_ms[10:]) or sorted(frame_ms)
-                    med = warm[len(warm) // 2]
-                    print(
-                        f"  [{processed}/{total_samples}] "
-                        f"{elapsed * 1e3:6.1f} ms  "
-                        f"median {med:6.1f}  "
-                        f"mean {1e3 * total_time / processed:6.1f}  "
-                        f"{1000.0 / med:5.2f} FPS  "
-                        f"{len(dets)} dets"
-                    )
-
-            if processed >= total_samples:
+                flat.append((scene_idx, global_idx))
+            if len(flat) >= total_samples:
                 break
+
+        pool = ThreadPoolExecutor(max_workers=1) if pipeline else None
+        fut = None          # one outstanding get_sample
+        next_loaded = None  # its result, once staged
+        idx_next = 1
+        if pipeline:
+            fut = pool.submit(loader.get_sample, flat[0][1])
+        cur_scene = None
+        wall0 = time.time()
+
+        for k, (scene_idx, global_idx) in enumerate(flat):
+            if pipeline:
+                if next_loaded is not None:
+                    images, metas, info = next_loaded
+                    next_loaded = None
+                else:
+                    images, metas, info = fut.result()
+                    fut = (pool.submit(loader.get_sample, flat[idx_next][1])
+                           if idx_next < len(flat) else None)
+                    idx_next += 1
+            else:
+                images, metas, info = loader.get_sample(global_idx)
+            token = info["token"]
+
+            if scene_idx != cur_scene:
+                model.reset()  # Reset temporal cache at scene boundary
+                cur_scene = scene_idx
+
+            t0 = time.time()
+            outputs = model.forward(images, metas, bs=1)
+            elapsed = time.time() - t0
+            total_time += elapsed
+            frame_ms.append(elapsed * 1e3)
+            processed += 1
+
+            # Stage the next frame before the blocking readback: its h2d write
+            # streams while the device finishes this frame, its re-page fills
+            # the boundary idle gap
+            if pipeline and fut is not None:
+                next_loaded = fut.result()
+                fut = (pool.submit(loader.get_sample, flat[idx_next][1])
+                       if idx_next < len(flat) else None)
+                idx_next += 1
+                model.stage_next_images(next_loaded[0])
+
+            # One read for both --save-raw and the decoder (waits for the device)
+            host_out = read_outputs_to_host(outputs, mesh_device=mesh_device)
+
+            if args.save_raw and host_out is not None:
+                entry = {
+                    "token": token,
+                    "prediction": host_out["prediction"][0],  # [900, 11]
+                    "classification": host_out["classification"][0],  # [900, 10]
+                }
+                if host_out["quality"] is not None:
+                    entry["quality"] = host_out["quality"][0]  # [900, 2]
+                raw_outputs.append(entry)
+
+            # Post-process (PyTorch-identical: NuScenesBox + range filter)
+            dets = decode_host_outputs(host_out, info, eval_config)
+
+            # Add sample_token to each detection
+            for d in dets:
+                d["sample_token"] = token
+            all_results[token] = dets
+
+            # Periodic GC to prevent host memory leak from to_torch/from_torch
+            if processed % 100 == 0:
+                gc.collect()
+
+            if processed % 50 == 0 or processed == total_samples:
+                # Milliseconds to one decimal, not seconds to two. On the old grid a
+                # sample landed in a 10 ms bucket, which is coarser than most of the
+                # optimisations this script is used to judge — a 4 ms win reads as no
+                # change at all. The steady-state median matters more than the mean,
+                # which stays skewed for hundreds of frames by kernel compilation, so
+                # both are printed.
+                warm = sorted(frame_ms[10:]) or sorted(frame_ms)
+                med = warm[len(warm) // 2]
+                wall_ms = 1e3 * (time.time() - wall0) / processed
+                print(
+                    f"  [{processed}/{total_samples}] "
+                    f"{elapsed * 1e3:6.1f} ms  "
+                    f"median {med:6.1f}  "
+                    f"mean {1e3 * total_time / processed:6.1f}  "
+                    f"{1000.0 / med:5.2f} FPS  "
+                    f"wall {wall_ms:6.1f} ms/sample  "
+                    f"{len(dets)} dets"
+                )
+        if pool is not None:
+            pool.shutdown(wait=False)
 
         # Report the distribution, not one number. The mean carries the cold frames, the
         # median is what the model actually runs at, and p90/max are where a scene with an

--- a/tt-metal/ops/anchor_bucket/anchor_bucket.cpp
+++ b/tt-metal/ops/anchor_bucket/anchor_bucket.cpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include "anchor_bucket.hpp"
+#include "device/anchor_bucket_device_operation.hpp"
+
+namespace ttnn::operations::anchor_bucket {
+
+void anchor_bucket(
+    const tt::tt_metal::Tensor& flags, tt::tt_metal::Tensor& perm,
+    tt::tt_metal::Tensor& inv, tt::tt_metal::Tensor& live,
+    uint32_t num_anchors) {
+    ttnn::prim::anchor_bucket(flags, perm, inv, live, num_anchors);
+}
+
+}  // namespace ttnn::operations::anchor_bucket

--- a/tt-metal/ops/anchor_bucket/anchor_bucket.hpp
+++ b/tt-metal/ops/anchor_bucket/anchor_bucket.hpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "ttnn/types.hpp"
+
+namespace ttnn {
+namespace operations::anchor_bucket {
+
+void anchor_bucket(
+    const ttnn::Tensor& flags, ttnn::Tensor& perm, ttnn::Tensor& inv,
+    ttnn::Tensor& live, uint32_t num_anchors);
+
+}  // namespace operations::anchor_bucket
+using ttnn::operations::anchor_bucket::anchor_bucket;
+}  // namespace ttnn

--- a/tt-metal/ops/anchor_bucket/anchor_bucket_nanobind.cpp
+++ b/tt-metal/ops/anchor_bucket/anchor_bucket_nanobind.cpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include "anchor_bucket_nanobind.hpp"
+#include <nanobind/nanobind.h>
+#include "ttnn-nanobind/bind_function.hpp"
+#include "anchor_bucket.hpp"
+
+namespace ttnn::operations::anchor_bucket {
+
+void bind_anchor_bucket(nb::module_& mod) {
+    ttnn::bind_function<"anchor_bucket">(
+        mod,
+        "Buckets anchors by camera-visibility pattern from grid_compact's "
+        "flags: writes perm (sorted pos -> anchor), inv (anchor -> sorted "
+        "pos) and a per-tile-row live-camera bitmap, the inputs of "
+        "grouped_weighted_sum's dead-pair skip. Stable integer counting sort "
+        "on one core.",
+        &ttnn::anchor_bucket,
+        nb::arg("flags"), nb::arg("perm"), nb::arg("inv"), nb::arg("live"),
+        nb::arg("num_anchors"));
+}
+
+}  // namespace ttnn::operations::anchor_bucket

--- a/tt-metal/ops/anchor_bucket/anchor_bucket_nanobind.hpp
+++ b/tt-metal/ops/anchor_bucket/anchor_bucket_nanobind.hpp
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <nanobind/nanobind.h>
+namespace nb = nanobind;
+
+namespace ttnn::operations::anchor_bucket {
+void bind_anchor_bucket(nb::module_& mod);
+}

--- a/tt-metal/ops/anchor_bucket/device/anchor_bucket_device_operation.cpp
+++ b/tt-metal/ops/anchor_bucket/device/anchor_bucket_device_operation.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include "anchor_bucket_device_operation.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::prim {
+using namespace tt;
+using namespace tt::tt_metal;
+
+AnchorBucketOperation::program_factory_t AnchorBucketOperation::select_program_factory(
+    const operation_attributes_t&, const tensor_args_t&) {
+    return AnchorBucketProgramFactory{};
+}
+
+void AnchorBucketOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& a, const tensor_args_t& t) {
+    TT_FATAL(t.flags.dtype() == DataType::BFLOAT16, "flags must be BFLOAT16");
+    TT_FATAL(t.flags.layout() == Layout::ROW_MAJOR, "flags must be ROW_MAJOR");
+    TT_FATAL(t.flags.logical_shape()[-1] >= a.num_anchors, "flags row too short");
+    TT_FATAL(t.flags.logical_shape()[0] <= 8, "at most 8 cameras (3-bit pattern)");
+    for (const Tensor* x : {&t.perm, &t.inv, &t.live}) {
+        TT_FATAL(x->dtype() == DataType::UINT32, "outputs must be UINT32");
+        TT_FATAL(x->layout() == Layout::ROW_MAJOR, "outputs must be ROW_MAJOR");
+    }
+    TT_FATAL(t.perm.logical_shape()[-1] >= a.num_anchors, "perm too short");
+    TT_FATAL(t.live.logical_shape()[-1] >= 32, "live must hold 32 rows");
+}
+
+TensorSpec AnchorBucketOperation::compute_output_specs(
+    const operation_attributes_t&, const tensor_args_t& t) {
+    return t.perm.tensor_spec();
+}
+
+Tensor AnchorBucketOperation::create_output_tensors(
+    const operation_attributes_t&, const tensor_args_t& t) {
+    return t.perm;
+}
+
+void anchor_bucket(
+    const Tensor& flags, Tensor& perm, Tensor& inv, Tensor& live,
+    uint32_t num_anchors) {
+    using Op = AnchorBucketOperation;
+    ttnn::device_operation::launch<Op>(
+        Op::operation_attributes_t{
+            .num_anchors = num_anchors,
+            .output_mem_config = perm.memory_config()},
+        Op::tensor_args_t{.flags = flags, .perm = perm, .inv = inv, .live = live});
+}
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/anchor_bucket/device/anchor_bucket_device_operation.hpp
+++ b/tt-metal/ops/anchor_bucket/device/anchor_bucket_device_operation.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/device_operation.hpp"
+#include "anchor_bucket_device_operation_types.hpp"
+#include "anchor_bucket_program_factory.hpp"
+
+namespace ttnn::prim {
+
+struct AnchorBucketOperation {
+    using operation_attributes_t = AnchorBucketParams;
+    using tensor_args_t = AnchorBucketInputs;
+    using spec_return_value_t = tt::tt_metal::TensorSpec;
+    using tensor_return_value_t = tt::tt_metal::Tensor;
+    using program_factory_t = std::variant<AnchorBucketProgramFactory>;
+
+    static program_factory_t select_program_factory(
+        const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(
+        const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(
+        const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t&, const tensor_args_t&);
+};
+
+void anchor_bucket(
+    const tt::tt_metal::Tensor& flags,
+    tt::tt_metal::Tensor& perm,
+    tt::tt_metal::Tensor& inv,
+    tt::tt_metal::Tensor& live,
+    uint32_t num_anchors);
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/anchor_bucket/device/anchor_bucket_device_operation_types.hpp
+++ b/tt-metal/ops/anchor_bucket/device/anchor_bucket_device_operation_types.hpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <tt-metalium/constants.hpp>
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::prim {
+
+// Buckets anchors by camera-visibility pattern (from grid_compact's flags)
+// so grouped_weighted_sum can skip dead (tile-row, clp) iterations. See the
+// kernel header for the perm/inv/live contracts.
+struct AnchorBucketParams {
+    uint32_t num_anchors;
+    tt::tt_metal::MemoryConfig output_mem_config;
+};
+
+struct AnchorBucketInputs {
+    const tt::tt_metal::Tensor& flags;  // [nc,1,1,FW] bf16 RM, 1.0 = live
+    const tt::tt_metal::Tensor& perm;   // [1,1,1,NPAD] u32 RM, preallocated
+    const tt::tt_metal::Tensor& inv;    // [1,1,1,NPAD] u32 RM, preallocated
+    const tt::tt_metal::Tensor& live;   // [1,1,1,32]  u32 RM, preallocated
+};
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/anchor_bucket/device/anchor_bucket_program_factory.cpp
+++ b/tt-metal/ops/anchor_bucket/device/anchor_bucket_program_factory.cpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "tt-metalium/tensor_accessor_args.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include "anchor_bucket_program_factory.hpp"
+
+namespace ttnn::prim {
+using namespace tt;
+using namespace tt::tt_metal;
+
+AnchorBucketProgramFactory::cached_program_t AnchorBucketProgramFactory::create(
+    const AnchorBucketParams& attrs,
+    const AnchorBucketInputs& t,
+    Tensor& /*output_tensor*/) {
+
+    Program program{};
+    const CoreCoord core{0, 0};
+    const CoreRangeSet core_range{CoreRange{core, core}};
+
+    const uint32_t nc = t.flags.logical_shape()[0];
+    const uint32_t fw = t.flags.logical_shape()[-1];
+    const uint32_t npad = t.perm.logical_shape()[-1];
+
+    constexpr uint32_t CB_FLG = tt::CBIndex::c_0;
+    constexpr uint32_t CB_OUT = tt::CBIndex::c_1;
+    const uint32_t flg_bytes = nc * (((fw * 2 + 31) / 32) * 32);
+    const uint32_t out_bytes = ((npad * 8 + 32 * 4 + npad + 31) / 32) * 32;
+
+    auto mk = [&](uint32_t cb, uint32_t bytes, DataFormat fmt) {
+        auto cfg = CircularBufferConfig(bytes, {{cb, fmt}}).set_page_size(cb, bytes);
+        CreateCircularBuffer(program, core_range, cfg);
+    };
+    mk(CB_FLG, flg_bytes, DataFormat::UInt16);
+    mk(CB_OUT, out_bytes, DataFormat::UInt32);
+
+    // RM sticks are DRAM-aligned: the buffer's page stride is the ALIGNED
+    // size (900*2=1800 -> 1824), so the accessor must use it, not fw*2.
+    const uint32_t fpage = t.flags.buffer()->aligned_page_size();
+    std::vector<uint32_t> ct = {attrs.num_anchors, nc, fw, npad, CB_FLG, CB_OUT, fpage};
+    TensorAccessorArgs(*t.flags.buffer()).append_to(ct);
+    TensorAccessorArgs(*t.perm.buffer()).append_to(ct);
+    TensorAccessorArgs(*t.inv.buffer()).append_to(ct);
+    TensorAccessorArgs(*t.live.buffer()).append_to(ct);
+
+    KernelHandle kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/pool/anchor_bucket/device/kernels/dataflow/anchor_bucket.cpp",
+        core_range, WriterDataMovementConfig(ct));
+
+    SetRuntimeArgs(program, kernel_id, core, {
+        t.flags.buffer()->address(), t.perm.buffer()->address(),
+        t.inv.buffer()->address(), t.live.buffer()->address()});
+
+    return cached_program_t{
+        std::move(program), shared_variables_t{.kernel_id = kernel_id}};
+}
+
+void AnchorBucketProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const AnchorBucketParams&,
+    const AnchorBucketInputs& t,
+    Tensor& /*output_tensor*/) {
+    auto& r = GetRuntimeArgs(cached_program.program,
+                             cached_program.shared_variables.kernel_id,
+                             CoreCoord{0, 0});
+    r[0] = t.flags.buffer()->address();
+    r[1] = t.perm.buffer()->address();
+    r[2] = t.inv.buffer()->address();
+    r[3] = t.live.buffer()->address();
+}
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/anchor_bucket/device/anchor_bucket_program_factory.hpp
+++ b/tt-metal/ops/anchor_bucket/device/anchor_bucket_program_factory.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <vector>
+#include <tt-metalium/host_api.hpp>
+#include "ttnn/device_operation.hpp"
+#include "anchor_bucket_device_operation_types.hpp"
+
+namespace ttnn::prim {
+
+struct AnchorBucketProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle kernel_id;
+    };
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const AnchorBucketParams& attrs,
+        const AnchorBucketInputs& t,
+        tt::tt_metal::Tensor& output_tensor);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const AnchorBucketParams& attrs,
+        const AnchorBucketInputs& t,
+        tt::tt_metal::Tensor& output_tensor);
+};
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/anchor_bucket/device/kernels/dataflow/anchor_bucket.cpp
+++ b/tt-metal/ops/anchor_bucket/device/kernels/dataflow/anchor_bucket.cpp
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+// Buckets anchors by camera-visibility pattern for grouped_weighted_sum's
+// dead-pair skip. Reads grid_compact's flags (1.0/0.0 per (camera, anchor)),
+// stable-counting-sorts the anchors by their 3-bit pattern, and emits:
+//   perm  [PAD] u32 : sorted position -> original anchor
+//   inv   [PAD] u32 : original anchor -> sorted position (output un-permute)
+//   live  [32]  u32 : per sorted tile-row, OR of member patterns (bit c = cam
+//                     c has at least one live anchor in the row)
+// Sorting makes each 32-anchor tile row pattern-homogeneous, which is what
+// lets gws skip whole (row, clp) iterations. Integer-only, one core — the
+// same soft-float-free discipline as topk_select.
+
+#include <stdint.h>
+#include "api/compile_time_args.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+
+void kernel_main() {
+    constexpr uint32_t N      = get_compile_time_arg_val(0);   // anchors (900)
+    constexpr uint32_t NC     = get_compile_time_arg_val(1);   // cameras (3)
+    constexpr uint32_t FW     = get_compile_time_arg_val(2);   // flags row width
+    constexpr uint32_t NPAD   = get_compile_time_arg_val(3);   // perm/inv length
+    constexpr uint32_t CB_FLG = get_compile_time_arg_val(4);
+    constexpr uint32_t CB_OUT = get_compile_time_arg_val(5);
+    constexpr uint32_t FPAGE  = get_compile_time_arg_val(6);  // aligned stick bytes
+
+    constexpr auto f_args = TensorAccessorArgs<7>();
+    constexpr auto p_args = TensorAccessorArgs<f_args.next_compile_time_args_offset()>();
+    constexpr auto i_args = TensorAccessorArgs<p_args.next_compile_time_args_offset()>();
+    constexpr auto l_args = TensorAccessorArgs<i_args.next_compile_time_args_offset()>();
+
+    const uint32_t f_addr = get_arg_val<uint32_t>(0);
+    const uint32_t p_addr = get_arg_val<uint32_t>(1);
+    const uint32_t i_addr = get_arg_val<uint32_t>(2);
+    const uint32_t l_addr = get_arg_val<uint32_t>(3);
+
+    const auto fa = TensorAccessor(f_args, f_addr, FPAGE);
+    const auto pa = TensorAccessor(p_args, p_addr, NPAD * 4);
+    const auto ia = TensorAccessor(i_args, i_addr, NPAD * 4);
+    const auto la = TensorAccessor(l_args, l_addr, 32 * 4);
+
+    // NOC DRAM->L1 reads need a 32B-aligned L1 destination; FW*2=1800 is not,
+    // so pad the per-camera stride (misalignment silently lands data shifted).
+    constexpr uint32_t FSTRIDE = (FW * 2 + 31) & ~31u;  // bytes, 32B-aligned
+    cb_reserve_back(CB_FLG, 1);
+    const uint32_t fbuf = get_write_ptr(CB_FLG);
+    for (uint32_t c = 0; c < NC; c++) {
+        noc_async_read(fa.get_noc_addr(c), fbuf + c * FSTRIDE, FW * 2);
+    }
+    noc_async_read_barrier();
+    volatile tt_l1_ptr uint16_t* flg = (volatile tt_l1_ptr uint16_t*)fbuf;
+
+    cb_reserve_back(CB_OUT, 1);
+    const uint32_t obuf = get_write_ptr(CB_OUT);
+    uint32_t* perm = (uint32_t*)obuf;
+    uint32_t* inv  = perm + NPAD;
+    uint32_t* live = inv + NPAD;
+    uint8_t*  pat  = (uint8_t*)(live + 32);
+
+    // Pattern pass: two bf16 flags per uint32 load (the volatile uint16 loop
+    // was the op's hot spot at 2700 L1 reads).
+    for (uint32_t a = 0; a < N; a++) {
+        pat[a] = 0;
+    }
+    for (uint32_t c = 0; c < NC; c++) {
+        const uint8_t bit = (uint8_t)(1u << c);
+        volatile tt_l1_ptr uint32_t* f32 =
+            (volatile tt_l1_ptr uint32_t*)(fbuf + c * FSTRIDE);
+        for (uint32_t a = 0; a < N; a += 2) {
+            const uint32_t v = f32[a >> 1];
+            if (v & 0xFFFFu) {
+                pat[a] |= bit;
+            }
+            if ((v >> 16) && (a + 1 < N)) {
+                pat[a + 1] |= bit;
+            }
+        }
+    }
+    uint32_t cnt[8] = {0};
+    for (uint32_t a = 0; a < N; a++) {
+        cnt[pat[a]]++;
+    }
+    uint32_t run = 0;
+    for (uint32_t b = 0; b < 8; b++) {
+        const uint32_t c = cnt[b];
+        cnt[b] = run;
+        run += c;
+    }
+    for (uint32_t a = 0; a < N; a++) {          // stable scatter
+        const uint32_t pos = cnt[pat[a]]++;
+        perm[pos] = a;
+        inv[a] = pos;
+    }
+    for (uint32_t a = N; a < NPAD; a++) {
+        perm[a] = 0;
+        inv[a] = 0;
+    }
+    for (uint32_t rt = 0; rt < 32; rt++) {
+        uint32_t bits = 0;
+        for (uint32_t r = 0; r < 32; r++) {
+            const uint32_t sp = rt * 32 + r;
+            if (sp < N) {
+                bits |= pat[perm[sp]];
+            }
+        }
+        live[rt] = bits;
+    }
+
+    noc_async_write((uint32_t)(uintptr_t)perm, pa.get_noc_addr(0), NPAD * 4);
+    noc_async_write((uint32_t)(uintptr_t)inv,  ia.get_noc_addr(0), NPAD * 4);
+    noc_async_write((uint32_t)(uintptr_t)live, la.get_noc_addr(0), 32 * 4);
+    noc_async_write_barrier();
+}

--- a/tt-metal/ops/grid_precompute/device/grid_precompute_device_operation.cpp
+++ b/tt-metal/ops/grid_precompute/device/grid_precompute_device_operation.cpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include "grid_precompute_device_operation.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::prim {
+using namespace tt;
+using namespace tt::tt_metal;
+
+GridPrecomputeOperation::program_factory_t GridPrecomputeOperation::select_program_factory(
+    const operation_attributes_t&, const tensor_args_t&) {
+    return GridPrecomputeProgramFactory{};
+}
+
+void GridPrecomputeOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& a, const tensor_args_t& t) {
+    TT_FATAL(t.cgrid.dtype() == DataType::UINT16, "cgrid must be UINT16 (Q14 fixed point)");
+    TT_FATAL(t.cgrid.layout() == Layout::ROW_MAJOR, "cgrid must be ROW_MAJOR");
+    TT_FATAL(t.cgrid.storage_type() == StorageType::DEVICE, "cgrid must be on device");
+    // The constant pack is read tile-by-tile via the accessor, which is only
+    // valid when a page IS a tile — i.e. FLOAT32 TILE layout.
+    TT_FATAL(t.consts.dtype() == DataType::FLOAT32, "consts must be FLOAT32");
+    TT_FATAL(t.consts.layout() == Layout::TILE, "consts must be TILE layout");
+    TT_FATAL(t.consts.storage_type() == StorageType::DEVICE, "consts must be on device");
+    const uint32_t expected_tiles = 3 * a.num_levels + 5 * ((a.num_pts * 6 + 31) / 32);
+    TT_FATAL(
+        t.consts.physical_volume() / (32 * 32) >= expected_tiles,
+        "consts holds {} tiles, ordering needs {}",
+        t.consts.physical_volume() / (32 * 32), expected_tiles);
+    for (const Tensor* out : {&t.out0, &t.out1, &t.out2, &t.out3}) {
+        TT_FATAL(out->dtype() == DataType::BFLOAT16, "outputs must be BFLOAT16");
+        TT_FATAL(out->layout() == Layout::ROW_MAJOR, "outputs must be ROW_MAJOR");
+        TT_FATAL(out->storage_type() == StorageType::DEVICE, "outputs must be on device");
+        TT_FATAL(
+            out->logical_shape()[-1] == a.num_pts * 6,
+            "output last dim must be num_pts*6 ({}), got {}",
+            a.num_pts * 6, out->logical_shape()[-1]);
+    }
+    TT_FATAL(a.row_width >= 2 * a.num_pts, "row_width must hold 2*num_pts coordinates");
+    TT_FATAL(a.num_levels == 4, "wired for 4 FPN levels (writer takes 4 output addresses)");
+}
+
+TensorSpec GridPrecomputeOperation::compute_output_specs(
+    const operation_attributes_t&, const tensor_args_t& t) {
+    return t.out0.tensor_spec();
+}
+
+Tensor GridPrecomputeOperation::create_output_tensors(
+    const operation_attributes_t&, const tensor_args_t& t) {
+    return t.out0;
+}
+
+void grid_precompute(
+    const Tensor& cgrid, const Tensor& consts,
+    Tensor& out0, Tensor& out1, Tensor& out2, Tensor& out3,
+    uint32_t num_pts) {
+    const auto& gs = cgrid.logical_shape();
+    uint32_t num_rows = 1;
+    for (int i = 0; i < gs.rank() - 1; i++) {
+        num_rows *= gs[i];
+    }
+    using Op = GridPrecomputeOperation;
+    ttnn::device_operation::launch<Op>(
+        Op::operation_attributes_t{
+            .num_pts = num_pts,
+            .num_levels = 4,
+            .num_rows = num_rows,
+            .row_width = static_cast<uint32_t>(gs[-1]),
+            .output_mem_config = out0.memory_config(),
+        },
+        Op::tensor_args_t{
+            .cgrid = cgrid, .consts = consts,
+            .out0 = out0, .out1 = out1, .out2 = out2, .out3 = out3});
+}
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/grid_precompute/device/grid_precompute_device_operation.hpp
+++ b/tt-metal/ops/grid_precompute/device/grid_precompute_device_operation.hpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/device_operation.hpp"
+#include "grid_precompute_device_operation_types.hpp"
+#include "grid_precompute_program_factory.hpp"
+
+namespace ttnn::prim {
+
+struct GridPrecomputeOperation {
+    using operation_attributes_t = GridPrecomputeParams;
+    using tensor_args_t = GridPrecomputeInputs;
+    using spec_return_value_t = tt::tt_metal::TensorSpec;
+    using tensor_return_value_t = tt::tt_metal::Tensor;
+    using program_factory_t = std::variant<GridPrecomputeProgramFactory>;
+
+    static program_factory_t select_program_factory(
+        const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(
+        const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(
+        const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t&, const tensor_args_t&);
+};
+
+void grid_precompute(
+    const tt::tt_metal::Tensor& cgrid,
+    const tt::tt_metal::Tensor& consts,
+    tt::tt_metal::Tensor& out0,
+    tt::tt_metal::Tensor& out1,
+    tt::tt_metal::Tensor& out2,
+    tt::tt_metal::Tensor& out3,
+    uint32_t num_pts);
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/grid_precompute/device/grid_precompute_device_operation_types.hpp
+++ b/tt-metal/ops/grid_precompute/device/grid_precompute_device_operation_types.hpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <tt-metalium/constants.hpp>
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::prim {
+
+// Converts the compacted Q14 sampling grid into grid_sample's precomputed
+// 6-field form (h0, w0, four bilinear weights), one output tensor per FPN
+// level, with all arithmetic on the Tensix engines.
+//
+// Exists because grid_sample's reader otherwise derives those six values per
+// point per level in soft float on an FPU-less core — measured at ~62% of the
+// op, and the precomputed path measured 2.78x. Runs AFTER compaction on
+// purpose: the kept rows are ~2.3x fewer than the full grid, and the variant
+// that ran this math before compaction was priced at +38.5 ms/frame.
+struct GridPrecomputeParams {
+    uint32_t num_pts;      // K, points per row
+    uint32_t num_levels;   // FPN levels = number of output tensors
+    uint32_t num_rows;     // capacity of the compacted grid
+    uint32_t row_width;    // values per cgrid row (>= 2*K)
+    tt::tt_metal::MemoryConfig output_mem_config;
+};
+
+struct GridPrecomputeInputs {
+    const tt::tt_metal::Tensor& cgrid;    // DRAM [1, cap, 1, row_width] UINT16 (Q14)
+    // 23 f32 TILE-layout tiles built once in python: per-level affine D and
+    // bound C, plus the level-independent selector matrices. See the reader
+    // for the ordering contract.
+    const tt::tt_metal::Tensor& consts;
+    // Preallocated DRAM [1, cap, 1, K*6] BFLOAT16 ROW_MAJOR, one per level.
+    // Row r corresponds 1:1 to cgrid row r, so bidx / index / flags from
+    // grid_compact apply unchanged.
+    const tt::tt_metal::Tensor& out0;
+    const tt::tt_metal::Tensor& out1;
+    const tt::tt_metal::Tensor& out2;
+    const tt::tt_metal::Tensor& out3;
+};
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/grid_precompute/device/grid_precompute_program_factory.cpp
+++ b/tt-metal/ops/grid_precompute/device/grid_precompute_program_factory.cpp
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <cstdint>
+#include "tt-metalium/tensor_accessor_args.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/math.hpp>
+#include <tt-metalium/work_split.hpp>
+#include "grid_precompute_program_factory.hpp"
+
+namespace ttnn::prim {
+using namespace tt;
+using namespace tt::tt_metal;
+
+// One coords tile per core: a core owns at most 32 compacted rows, which is what
+// keeps every stage of this op a single-tile pipeline. cap ~1176 rows lands on
+// ~37 cores; the arithmetic per core is ~120 tile ops and the writer's scalar
+// conversion ~6K elements, so the op prices in the tens of microseconds where
+// the reader math it replaces measured ~6.5 ms/frame.
+GridPrecomputeProgramFactory::cached_program_t GridPrecomputeProgramFactory::create(
+    const GridPrecomputeParams& attrs,
+    const GridPrecomputeInputs& t,
+    Tensor& /*output_tensor*/) {
+
+    Program program{};
+    const uint32_t align = hal::get_dram_alignment();
+
+    constexpr uint32_t ROWS_PER_CORE = 32;
+    const uint32_t num_cores = (attrs.num_rows + ROWS_PER_CORE - 1) / ROWS_PER_CORE;
+    const auto grid_size = t.cgrid.device()->compute_with_storage_grid_size();
+    TT_FATAL(num_cores <= grid_size.x * grid_size.y,
+             "grid_precompute: {} rows need {} cores, device has {}",
+             attrs.num_rows, num_cores, grid_size.x * grid_size.y);
+    const CoreRangeSet core_range = num_cores_to_corerangeset(num_cores, grid_size, true);
+
+    const uint32_t cgrid_page = tt::round_up(attrs.row_width * 2, align);
+    const uint32_t out_page = tt::round_up(attrs.num_pts * 6 * 2, align);
+    const uint32_t out_tiles = (attrs.num_pts * 6 + 31) / 32;
+    constexpr uint32_t f32_tile = 32 * 32 * 4;
+
+    const auto f32_df = tt::DataFormat::Float32;
+    const auto u16_df = tt::DataFormat::UInt16;
+
+    auto mk_cb = [&](uint32_t idx, uint32_t total, uint32_t page, tt::DataFormat df) {
+        auto cfg = CircularBufferConfig(total, {{idx, df}}).set_page_size(idx, page);
+        CreateCircularBuffer(program, core_range, cfg);
+    };
+    mk_cb(tt::CBIndex::c_0, f32_tile, f32_tile, f32_df);            // coords
+    // Constant pack, resident: pushed once, indexed by tile, never popped.
+    const uint32_t n_const = 3 * attrs.num_levels + 5 * out_tiles;
+    mk_cb(tt::CBIndex::c_1, n_const * f32_tile, f32_tile, f32_df);
+    mk_cb(tt::CBIndex::c_3, f32_tile, f32_tile, f32_df);            // F
+    mk_cb(tt::CBIndex::c_5, f32_tile, f32_tile, f32_df);            // R
+    mk_cb(tt::CBIndex::c_6, f32_tile, f32_tile, f32_df);            // FA0
+    mk_cb(tt::CBIndex::c_7, f32_tile, f32_tile, f32_df);            // FA1
+    // Output rings hold two levels' worth so the writer's copy of level l
+    // overlaps the compute of level l+1. cb_16 is BF16 — the packer does the
+    // f32->bf16 conversion in hardware — and cb_17 carries the SFPU-typecast
+    // int32 indices.
+    constexpr uint32_t bf16_tile = 32 * 32 * 2;
+    mk_cb(tt::CBIndex::c_16, 2 * out_tiles * bf16_tile, bf16_tile, tt::DataFormat::Float16_b);
+    mk_cb(tt::CBIndex::c_17, 2 * out_tiles * f32_tile, f32_tile, tt::DataFormat::Int32);
+    mk_cb(tt::CBIndex::c_24, ROWS_PER_CORE * cgrid_page, ROWS_PER_CORE * cgrid_page, u16_df);  // reader scratch
+    mk_cb(tt::CBIndex::c_25, ROWS_PER_CORE * out_page, ROWS_PER_CORE * out_page, u16_df);      // writer stage
+
+    // Reader
+    std::vector<uint32_t> reader_ct = {
+        tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_24,
+        attrs.num_pts, cgrid_page, attrs.num_levels, out_tiles,
+    };
+    TensorAccessorArgs(*t.cgrid.buffer()).append_to(reader_ct);
+    TensorAccessorArgs(*t.consts.buffer()).append_to(reader_ct);
+    auto reader_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/pool/grid_precompute/device/kernels/dataflow/reader_grid_precompute.cpp",
+        core_range, ReaderDataMovementConfig(reader_ct));
+
+    // Compute — fp32 dest, and the coords CB unpacks STRAIGHT to dest. The
+    // default copy_tile path goes through the srcA register, which holds fp32
+    // at ~10 mantissa bits; a raw Q14 coordinate needs 15, and the truncation
+    // measured out as floor() flipping a pixel index on ~1% of points (every
+    // mismatch sat within 0.005 below an integer). The constants do NOT need
+    // the exact path: SCALE is 11*2^-k, BIAS is W/2-0.5 and C is a small
+    // integer — all exactly representable in 10 bits — and the selector
+    // matrices must stay on the regular unpack path anyway to feed matmul.
+    std::vector<UnpackToDestMode> unpack_modes(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    unpack_modes[tt::CBIndex::c_0] = UnpackToDestMode::UnpackToDestFp32;
+    auto compute_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/pool/grid_precompute/device/kernels/compute/compute_grid_precompute.cpp",
+        core_range,
+        ComputeConfig{
+            .math_fidelity = MathFidelity::HiFi4,
+            .fp32_dest_acc_en = true,
+            .unpack_to_dest_mode = unpack_modes,
+            .math_approx_mode = false,
+            .compile_args = {},
+        });
+
+    // Writer
+    std::vector<uint32_t> writer_ct = {
+        tt::CBIndex::c_16, tt::CBIndex::c_25,
+        attrs.num_pts, attrs.num_levels, out_tiles, out_page,
+        tt::CBIndex::c_17,
+    };
+    // All four outputs are allocated with identical shape/dtype/memory config,
+    // so one accessor arg set serves them all; only the base address differs.
+    TensorAccessorArgs(*t.out0.buffer()).append_to(writer_ct);
+    auto writer_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/pool/grid_precompute/device/kernels/dataflow/writer_grid_precompute.cpp",
+        core_range, WriterDataMovementConfig(writer_ct));
+
+    auto cores = corerange_to_cores(core_range, num_cores, true);
+    for (uint32_t i = 0; i < num_cores; i++) {
+        const uint32_t row_start = i * ROWS_PER_CORE;
+        const uint32_t rows = std::min(ROWS_PER_CORE, attrs.num_rows - row_start);
+        SetRuntimeArgs(program, reader_id, cores[i],
+                       {t.cgrid.buffer()->address(), t.consts.buffer()->address(), row_start, rows});
+        SetRuntimeArgs(program, compute_id, cores[i], {attrs.num_levels, out_tiles});
+        SetRuntimeArgs(program, writer_id, cores[i],
+                       {t.out0.buffer()->address(), t.out1.buffer()->address(),
+                        t.out2.buffer()->address(), t.out3.buffer()->address(),
+                        row_start, rows});
+    }
+
+    return cached_program_t{
+        std::move(program),
+        shared_variables_t{.reader_id = reader_id, .writer_id = writer_id, .cores = std::move(cores)}};
+}
+
+void GridPrecomputeProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const GridPrecomputeParams&,
+    const GridPrecomputeInputs& t,
+    Tensor& /*output_tensor*/) {
+    auto& prog = cached_program.program;
+    const auto& sv = cached_program.shared_variables;
+    for (const auto& core : sv.cores) {
+        auto& r = GetRuntimeArgs(prog, sv.reader_id, core);
+        r[0] = t.cgrid.buffer()->address();
+        r[1] = t.consts.buffer()->address();
+        auto& w = GetRuntimeArgs(prog, sv.writer_id, core);
+        w[0] = t.out0.buffer()->address();
+        w[1] = t.out1.buffer()->address();
+        w[2] = t.out2.buffer()->address();
+        w[3] = t.out3.buffer()->address();
+    }
+}
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/grid_precompute/device/grid_precompute_program_factory.hpp
+++ b/tt-metal/ops/grid_precompute/device/grid_precompute_program_factory.hpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <vector>
+#include <tt-metalium/host_api.hpp>
+#include "ttnn/device_operation.hpp"
+#include "grid_precompute_device_operation_types.hpp"
+
+namespace ttnn::prim {
+
+struct GridPrecomputeProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle reader_id;
+        tt::tt_metal::KernelHandle writer_id;
+        std::vector<tt::tt_metal::CoreCoord> cores;
+    };
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const GridPrecomputeParams& attrs,
+        const GridPrecomputeInputs& t,
+        tt::tt_metal::Tensor& output_tensor);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const GridPrecomputeParams& attrs,
+        const GridPrecomputeInputs& t,
+        tt::tt_metal::Tensor& output_tensor);
+};
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/grid_precompute/device/kernels/compute/compute_grid_precompute.cpp
+++ b/tt-metal/ops/grid_precompute/device/kernels/compute/compute_grid_precompute.cpp
@@ -1,0 +1,226 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+// =============================================================================
+// grid_precompute — turn the compacted Q14 grid into grid_sample's precomputed
+// 6-field form (h0, w0, w_nw, w_ne, w_sw, w_se), per FPN level.
+//
+// Why this op exists: grid_sample's reader spends ~928 of ~1494 cycles per
+// point deriving exactly these six values in soft float on a core with no FPU.
+// Feeding it the precomputed form measured 2.78x. The math cannot run in that
+// reader (the SFPU is not callable from dataflow cores) and must not run
+// before compaction (2.3x more rows; the pre-compaction variant priced out at
+// +38.5 ms/frame) — so it runs here, on the rows compaction kept.
+//
+// ENGINE CHOICE IS THE POINT OF THIS FILE. Every VALUE computation runs on
+// the SFPU, which is true IEEE fp32; the FPU matmul path truncates fp32
+// operands to ~10 effective mantissa bits (measured on the kps tile path as
+// 0.13 px of grid error), and floor() sits exactly at the cliff where that
+// truncation flips a pixel index by one. The FPU is used only for the
+// selector matmuls at the end, where every operand is either 0/1 or a small
+// integer or a weight that ships as bf16 anyway — all exact or already
+// rounded coarser than the truncation.
+//
+//   per level, all SFPU:
+//     P   = coords * SCALE + BIAS      per-column affine (x cols W-derived,
+//                                      y cols H-derived; Q14 scale folded in)
+//     F   = floor(P);  R = P - F
+//     m0  = [0 <= F <= C-1]            C is the per-column bound tile
+//     m1  = [0 <= F+1 <= C-1]
+//     FA0 = (1-R) * m0                 boundary masks FACTORISE into the
+//     FA1 = R * m1                     bilinear terms, so the four masked
+//                                      weights are outer products of factors
+//   then FPU routing:
+//     out_j = (FA0xSB0_j + FA1xSB1_j) . (FA0xSH0_j + FA1xSH1_j) + F x SI_j
+//
+// The selectors are 0/1 matrices that route x/y factor columns into the
+// interleaved 6-field output — the same trick _softmax_clp uses. SI routes
+// the indices into fields 0..1 where the weight product is zero by
+// construction, so one accumulating matmul finishes the tile.
+// =============================================================================
+
+#include <cstdint>
+#include "api/compute/common.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/matmul.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/pack.h"
+#include "api/compute/reg_api.h"
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/eltwise_unary/rounding.h"
+#include "api/compute/eltwise_unary/comp.h"
+#include "api/compute/eltwise_unary/binop_with_scalar.h"
+#include "api/compute/eltwise_binary_sfpu.h"
+#include "api/compute/copy_dest_values.h"
+#include "api/compute/eltwise_unary/typecast.h"
+
+void kernel_main() {
+    const uint32_t num_levels = get_arg_val<uint32_t>(0);   // 4
+    const uint32_t out_tiles  = get_arg_val<uint32_t>(1);   // ceil(K*6 / 32) = 3
+
+    constexpr auto cb_coords = tt::CBIndex::c_0;   // f32, reader-built, reused all levels
+    constexpr auto cb_const  = tt::CBIndex::c_1;   // f32 stream: per level SCALE, BIAS, C, then per j: SB0 SB1 SH0 SH1 SI
+    constexpr auto cb_F      = tt::CBIndex::c_3;
+    constexpr auto cb_R      = tt::CBIndex::c_5;
+    constexpr auto cb_FA0    = tt::CBIndex::c_6;
+    constexpr auto cb_FA1    = tt::CBIndex::c_7;
+    constexpr auto cb_outw   = tt::CBIndex::c_16;  // bf16 CB: packer converts the weights in hardware
+    constexpr auto cb_outi   = tt::CBIndex::c_17;  // int32 CB: SFPU-typecast indices, writer just moves bytes
+
+    constexpr uint32_t d0 = 0, d1 = 1, d2 = 2, d3 = 3;
+    constexpr uint32_t ZERO_F32 = 0u;              // bit pattern of 0.0f
+    constexpr uint32_t ONE_F32 = 0x3F800000u;
+
+    // Init against a REGULAR CB, not the unpack-to-dest one, and prime the
+    // matmul config once. Without this the first matmul the kernel ever runs
+    // (level 0's selector routing) read srcA shifted by one column — h0 came
+    // back holding x, w0 held the previous point's value — while every later
+    // level was perfect, because their preceding state was a clean matmul.
+    binary_op_init_common(cb_F, cb_const, cb_outw);
+    mm_init(cb_FA0, cb_const, cb_outw);
+
+    cb_wait_front(cb_coords, 1);
+    // The whole constant pack is RESIDENT: 27 tiles pushed once by the reader
+    // and never popped, addressed by tile index. Streaming them per level cost
+    // 68 serialised DMA barriers a call.
+    const uint32_t n_const = 3 * num_levels + 5 * out_tiles;
+    cb_wait_front(cb_const, n_const);
+
+    for (uint32_t l = 0; l < num_levels; l++) {
+        // ---- P = coords*SCALE + BIAS ; F = floor(P) ; R = P - F -----------
+        // One acquire, entirely SFPU: mul, add, a dest copy, floor, sub.
+        tile_regs_acquire();
+        copy_tile_to_dst_init_short(cb_coords);
+        copy_tile(cb_coords, 0, d0);
+        copy_tile_to_dst_init_short(cb_const);
+        copy_tile(cb_const, l, d1);                // SCALE_l
+        mul_binary_tile_init();
+        mul_binary_tile(d0, d1, d0);
+        copy_tile_to_dst_init_short(cb_const);
+        copy_tile(cb_const, num_levels + l, d1);   // BIAS_l
+        add_binary_tile_init();
+        add_binary_tile(d0, d1, d0);               // P
+        copy_dest_values_init();
+        copy_dest_values(d0, d1);                  // d1 = P
+        rounding_op_tile_init();
+        floor_tile(d1);                            // d1 = F
+        sub_binary_tile_init();
+        sub_binary_tile(d0, d1, d2);               // d2 = R
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_reconfig_data_format(cb_F);           // packer format is global state;
+                                                   // the previous level ended on int32
+        cb_reserve_back(cb_F, 1);
+        pack_tile(d1, cb_F);
+        cb_reserve_back(cb_R, 1);
+        pack_tile(d2, cb_R);
+        tile_regs_release();
+        cb_push_back(cb_F, 1);
+        cb_push_back(cb_R, 1);
+
+        // ---- FA0 and FA1 in one acquire -----------------------------------
+        // Three rounds used to build these (F1 via its own CB, then each
+        // factor separately). Merged: F1 lives only in DEST, the copies are
+        // grouped so the unpack/datacopy config is programmed once per batch,
+        // and the acquire/pack round-trips drop from three to one. Every
+        // *_init here is a hardware reconfigure, not a function call — the
+        // interleaved version spent more time reprogramming the SFPU than
+        // computing.
+        //
+        // Slot walk (4 fp32 slots): d0=F->F-C->m_hi->m0->FA0 (held to pack),
+        // d1=C->(F1-C)->m1->FA1, d2=F(ge)->F1->ge(F1)->R, d3=R->(1-R)->R.
+        cb_wait_front(cb_F, 1);
+        cb_wait_front(cb_R, 1);
+        tile_regs_acquire();
+        copy_tile_to_dst_init_short(cb_F);
+        copy_tile(cb_F, 0, d0);
+        copy_tile(cb_const, 2 * num_levels + l, d1);   // C_l
+        copy_tile(cb_F, 0, d2);
+        copy_tile(cb_R, 0, d3);
+        sub_binary_tile_init();
+        sub_binary_tile(d0, d1, d0);               // F - (C-1)
+        unary_le_tile_init();
+        unary_le_tile(d0, ZERO_F32);               // F <= C-1
+        unary_ge_tile_init();
+        unary_ge_tile(d2, ZERO_F32);               // F >= 0
+        mul_binary_tile_init();
+        mul_binary_tile(d0, d2, d0);               // m0
+        binop_with_scalar_tile_init();
+        rsub_unary_tile(d3, ONE_F32);              // 1 - R
+        mul_binary_tile(d0, d3, d0);               // FA0, held in d0
+        copy_tile_to_dst_init_short(cb_F);
+        copy_tile(cb_F, 0, d2);
+        binop_with_scalar_tile_init();
+        add_unary_tile(d2, ONE_F32);               // F1 = F + 1, DEST-only
+        sub_binary_tile_init();
+        sub_binary_tile(d2, d1, d1);               // F1 - (C-1)  (C no longer needed)
+        unary_le_tile_init();
+        unary_le_tile(d1, ZERO_F32);
+        unary_ge_tile_init();
+        unary_ge_tile(d2, ZERO_F32);               // F1 >= 0
+        mul_binary_tile_init();
+        mul_binary_tile(d1, d2, d1);               // m1
+        copy_tile_to_dst_init_short(cb_R);
+        copy_tile(cb_R, 0, d2);
+        mul_binary_tile_init();
+        mul_binary_tile(d1, d2, d1);               // FA1 = R * m1
+        tile_regs_commit();
+        tile_regs_wait();
+        cb_reserve_back(cb_FA0, 1);
+        pack_tile(d0, cb_FA0);
+        cb_reserve_back(cb_FA1, 1);
+        pack_tile(d1, cb_FA1);
+        tile_regs_release();
+        cb_push_back(cb_FA0, 1);
+        cb_push_back(cb_FA1, 1);
+
+        cb_pop_front(cb_R, 1);
+
+        // ---- assemble output tiles ----------------------------------------
+        cb_wait_front(cb_FA0, 1);
+        cb_wait_front(cb_FA1, 1);
+        for (uint32_t j = 0; j < out_tiles; j++) {
+            // Selectors live in the resident const CB at 3*NL + 5j + {0..4}:
+            // SB0, SB1 accumulate the w-side factor into d0; SH0, SH1 the
+            // h-side into d1; SI routes the indices into d2. The SFPU then
+            // combines d0 = d0*d1 + d2, duplicates it, and typecasts the copy
+            // to int32 — so the writer receives weights already bf16 (packer
+            // conversion) and indices already integers, and does no float
+            // arithmetic at all. Its scalar conversion loop was the op's
+            // critical path at 682 of 948 us.
+            const uint32_t sel = 3 * num_levels + 5 * j;
+            tile_regs_acquire();
+            mm_init(cb_FA0, cb_const, cb_outw);
+            matmul_tiles(cb_FA0, cb_const, 0, sel + 0, d0);
+            matmul_tiles(cb_FA1, cb_const, 0, sel + 1, d0);
+            matmul_tiles(cb_FA0, cb_const, 0, sel + 2, d1);
+            matmul_tiles(cb_FA1, cb_const, 0, sel + 3, d1);
+            matmul_tiles(cb_F, cb_const, 0, sel + 4, d2);
+            mul_binary_tile_init();
+            mul_binary_tile(d0, d1, d0);
+            add_binary_tile_init();
+            add_binary_tile(d0, d2, d0);
+            copy_dest_values_init();
+            copy_dest_values(d0, d1);
+            typecast_tile_init<(uint32_t)DataFormat::Float32, (uint32_t)DataFormat::Int32>();
+            typecast_tile<(uint32_t)DataFormat::Float32, (uint32_t)DataFormat::Int32>(d1);
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_reconfig_data_format(cb_outw);    // f32 dest -> bf16 in the packer
+            cb_reserve_back(cb_outw, 1);
+            pack_tile(d0, cb_outw);
+            pack_reconfig_data_format(cb_outi);    // int32 passthrough
+            cb_reserve_back(cb_outi, 1);
+            pack_tile(d1, cb_outi);
+            tile_regs_release();
+            cb_push_back(cb_outw, 1);
+            cb_push_back(cb_outi, 1);
+        }
+        cb_pop_front(cb_FA0, 1);
+        cb_pop_front(cb_FA1, 1);
+        cb_pop_front(cb_F, 1);
+    }
+    cb_pop_front(cb_coords, 1);
+    cb_pop_front(cb_const, n_const);
+}

--- a/tt-metal/ops/grid_precompute/device/kernels/dataflow/reader_grid_precompute.cpp
+++ b/tt-metal/ops/grid_precompute/device/kernels/dataflow/reader_grid_precompute.cpp
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+// Reader for grid_precompute.
+//
+// Two jobs, both cheap by construction:
+//
+//  1. Build this core's coords tile: its slice of the compacted Q14 grid,
+//     sign-extended int16 -> f32, x/y interleaved in columns 0..2K-1 exactly as
+//     they sit in the row. The RAW integer goes in — the Q14 scale (1/2^14),
+//     the pixel scale and the -0.5 offset arrive as per-column SCALE and BIAS
+//     tiles the compute kernel applies on the SFPU — eltwise rather than a
+//     matmul on purpose, because the FPU matmul truncates fp32 operands and
+//     floor() sits exactly where that truncation flips a pixel index.
+//
+//  2. Stream the constant tiles (affine D per level, bound C per level, and
+//     the level-independent selector matrices) from DRAM in the exact order
+//     the compute kernel consumes them. They are built ONCE in python — 23
+//     f32 tiles, ~92 KB — because building them here in scalar code measured
+//     out at ~0.6 ms/frame when this design was priced, and a DMA of the same
+//     tiles is microseconds.
+
+#include <stdint.h>
+#include "api/compile_time_args.h"
+#include "api/dataflow/dataflow_api.h"
+
+inline void tile_set_f32(volatile tt_l1_ptr uint32_t* tile, uint32_t row, uint32_t col, float val) {
+    uint32_t face = ((row >= 16) ? 2 : 0) + ((col >= 16) ? 1 : 0);
+    uint32_t bits;
+    __builtin_memcpy(&bits, &val, sizeof(float));
+    tile[face * 256 + (row & 15) * 16 + (col & 15)] = bits;
+}
+
+void kernel_main() {
+    const uint32_t cgrid_addr = get_arg_val<uint32_t>(0);
+    const uint32_t const_addr = get_arg_val<uint32_t>(1);
+    const uint32_t row_start  = get_arg_val<uint32_t>(2);
+    const uint32_t num_rows   = get_arg_val<uint32_t>(3);   // <= 32
+
+    constexpr uint32_t cb_coords      = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_const       = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_scratch     = get_compile_time_arg_val(2);
+    constexpr uint32_t NUM_PTS        = get_compile_time_arg_val(3);   // 13
+    constexpr uint32_t cgrid_page     = get_compile_time_arg_val(4);   // aligned row bytes
+    constexpr uint32_t NUM_LEVELS     = get_compile_time_arg_val(5);
+    constexpr uint32_t OUT_TILES      = get_compile_time_arg_val(6);
+    constexpr uint32_t CONST_TILE_BYTES = 32 * 32 * 4;
+
+    constexpr auto cgrid_args = TensorAccessorArgs<7>();
+    constexpr auto const_args = TensorAccessorArgs<cgrid_args.next_compile_time_args_offset()>();
+    const auto cgrid_acc = TensorAccessor(cgrid_args, cgrid_addr, cgrid_page);
+    // A TILE-layout f32 tensor's page IS one 4 KB tile, so the accessor hands
+    // back whole constant tiles by index.
+    const auto const_acc = TensorAccessor(const_args, const_addr, CONST_TILE_BYTES);
+
+    // ---- coords tile ------------------------------------------------------
+    const uint32_t scratch = get_write_ptr(cb_scratch);
+    for (uint32_t r = 0; r < num_rows; r++) {
+        noc_async_read(cgrid_acc.get_noc_addr(row_start + r), scratch + r * cgrid_page, cgrid_page);
+    }
+
+    cb_reserve_back(cb_coords, 1);
+    const uint32_t coords_l1 = get_write_ptr(cb_coords);
+    volatile tt_l1_ptr uint32_t* ct = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(coords_l1);
+    // Zero once: rows past num_rows and columns past 2K must not carry stale
+    // values into the matmul.
+    for (uint32_t i = 0; i < 1024; i++) {
+        ct[i] = 0;
+    }
+    noc_async_read_barrier();
+
+    for (uint32_t r = 0; r < num_rows; r++) {
+        volatile tt_l1_ptr int16_t* rp =
+            reinterpret_cast<volatile tt_l1_ptr int16_t*>(scratch + r * cgrid_page);
+        for (uint32_t c = 0; c < 2 * NUM_PTS; c++) {
+            tile_set_f32(ct, r, c, (float)rp[c]);   // raw Q14 integer; scale lives in D
+        }
+    }
+    cb_push_back(cb_coords, 1);
+
+    // ---- constant pack, resident -----------------------------------------
+    // All tiles land in one reserve/push: the reads go to distinct offsets, so
+    // one barrier covers every tile. Streaming these per level put 68
+    // serialised barriers on this core per call.
+    const uint32_t n_const = 3 * NUM_LEVELS + 5 * OUT_TILES;
+    cb_reserve_back(cb_const, n_const);
+    const uint32_t const_l1 = get_write_ptr(cb_const);
+    for (uint32_t i = 0; i < n_const; i++) {
+        noc_async_read(const_acc.get_noc_addr(i), const_l1 + i * CONST_TILE_BYTES, CONST_TILE_BYTES);
+    }
+    noc_async_read_barrier();
+    cb_push_back(cb_const, n_const);
+}

--- a/tt-metal/ops/grid_precompute/device/kernels/dataflow/writer_grid_precompute.cpp
+++ b/tt-metal/ops/grid_precompute/device/kernels/dataflow/writer_grid_precompute.cpp
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+// Writer for grid_precompute.
+//
+// Converts the compute kernel's f32 output tiles into grid_sample's
+// precomputed-row format and lands them in the per-level output tensors.
+//
+// The format is the one contract in this op that is bit-for-bit fixed by a
+// consumer: grid_sample's reader takes fields 0..1 (h0, w0) as INT16 BITS
+// sitting in a bf16-sized slot, and fields 2..5 as real bf16 weights.
+//
+// This kernel does NO float arithmetic. Doing the conversions here in soft
+// float was the op's critical path — 682 of 948 us — so they moved upstream:
+// the packer converts the weights f32->bf16 in hardware on the way into
+// cb_outw, and the SFPU typecasts the indices to int32 into cb_outi. What is
+// left is interleaving uint16 moves from two tiles into the output stick.
+
+#include <stdint.h>
+#include "api/compile_time_args.h"
+#include "api/dataflow/dataflow_api.h"
+
+inline uint32_t tile_off(uint32_t row, uint32_t col) {
+    uint32_t face = ((row >= 16) ? 2 : 0) + ((col >= 16) ? 1 : 0);
+    return face * 256 + (row & 15) * 16 + (col & 15);
+}
+
+void kernel_main() {
+    // out addrs for up to 4 levels, then row range
+    const uint32_t out_addr0 = get_arg_val<uint32_t>(0);
+    const uint32_t out_addr1 = get_arg_val<uint32_t>(1);
+    const uint32_t out_addr2 = get_arg_val<uint32_t>(2);
+    const uint32_t out_addr3 = get_arg_val<uint32_t>(3);
+    const uint32_t row_start = get_arg_val<uint32_t>(4);
+    const uint32_t num_rows  = get_arg_val<uint32_t>(5);
+
+    constexpr uint32_t cb_outw      = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_stage     = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_outi      = get_compile_time_arg_val(6);
+    constexpr uint32_t NUM_PTS      = get_compile_time_arg_val(2);
+    constexpr uint32_t NUM_LEVELS   = get_compile_time_arg_val(3);
+    constexpr uint32_t OUT_TILES    = get_compile_time_arg_val(4);
+    constexpr uint32_t out_page     = get_compile_time_arg_val(5);   // aligned 6*K*2 bytes
+
+    constexpr uint32_t FIELDS = 6;
+    constexpr uint32_t row_vals = NUM_PTS * FIELDS;                  // 78
+
+    constexpr auto out_args = TensorAccessorArgs<7>();
+    const uint32_t out_addrs[4] = {out_addr0, out_addr1, out_addr2, out_addr3};
+
+    const uint32_t stage = get_write_ptr(cb_stage);
+
+    for (uint32_t l = 0; l < NUM_LEVELS; l++) {
+        const auto out_acc = TensorAccessor(out_args, out_addrs[l], out_page);
+        cb_wait_front(cb_outw, OUT_TILES);
+        cb_wait_front(cb_outi, OUT_TILES);
+        const uint32_t w_l1 = get_read_ptr(cb_outw);
+        const uint32_t i_l1 = get_read_ptr(cb_outi);
+
+        for (uint32_t r = 0; r < num_rows; r++) {
+            volatile tt_l1_ptr uint16_t* row16 =
+                reinterpret_cast<volatile tt_l1_ptr uint16_t*>(stage + r * out_page);
+            // FIELD-MAJOR stick: [h0 x K][w0 x K][weights x 4K]. Each field block
+            // is contiguous in its source tile within a 16-column face run, so
+            // the copy walks whole runs with an incrementing pointer instead of
+            // recomputing face arithmetic per element — the per-element version
+            // spent ~40 instructions moving each 2-byte value.
+            uint32_t c = 0;
+            while (c < 2 * NUM_PTS) {                     // index fields, int32 source
+                uint32_t run = ((c & ~15u) + 16 < 2 * NUM_PTS) ? ((c & ~15u) + 16 - c)
+                                                               : (2 * NUM_PTS - c);
+                volatile tt_l1_ptr uint32_t* src = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                    i_l1 + (c >> 5) * 4096) + tile_off(r, c & 31);
+                for (uint32_t i = 0; i < run; i++) {
+                    row16[c + i] = (uint16_t)(src[i] & 0xFFFFu);
+                }
+                c += run;
+            }
+            while (c < row_vals) {                        // weight fields, bf16 source
+                uint32_t lim = (c & ~15u) + 16;
+                uint32_t run = (lim < row_vals) ? (lim - c) : (row_vals - c);
+                volatile tt_l1_ptr uint16_t* src = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(
+                    w_l1 + (c >> 5) * 2048) + tile_off(r, c & 31);
+                // both sides 4-byte aligned when c is even, which every run start is
+                volatile tt_l1_ptr uint32_t* s32 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(src);
+                volatile tt_l1_ptr uint32_t* d32 =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(&row16[c]);
+                const uint32_t pairs = run >> 1;
+                for (uint32_t i = 0; i < pairs; i++) {
+                    d32[i] = s32[i];
+                }
+                if (run & 1) {
+                    row16[c + run - 1] = src[run - 1];
+                }
+                c += run;
+            }
+            noc_async_write(stage + r * out_page, out_acc.get_noc_addr(row_start + r), out_page);
+        }
+        // One barrier per level, not per row: the stage buffer is per-row slots,
+        // so nothing is overwritten while writes are in flight.
+        noc_async_write_barrier();
+        cb_pop_front(cb_outw, OUT_TILES);
+        cb_pop_front(cb_outi, OUT_TILES);
+    }
+}

--- a/tt-metal/ops/grid_precompute/grid_precompute.cpp
+++ b/tt-metal/ops/grid_precompute/grid_precompute.cpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include "grid_precompute.hpp"
+#include "device/grid_precompute_device_operation.hpp"
+
+namespace ttnn::operations::grid_precompute {
+
+void grid_precompute(
+    const ttnn::Tensor& cgrid, const ttnn::Tensor& consts,
+    ttnn::Tensor& out0, ttnn::Tensor& out1, ttnn::Tensor& out2, ttnn::Tensor& out3,
+    uint32_t num_pts) {
+    ttnn::prim::grid_precompute(cgrid, consts, out0, out1, out2, out3, num_pts);
+}
+
+}  // namespace ttnn::operations::grid_precompute

--- a/tt-metal/ops/grid_precompute/grid_precompute.hpp
+++ b/tt-metal/ops/grid_precompute/grid_precompute.hpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "ttnn/types.hpp"
+
+namespace ttnn {
+namespace operations::grid_precompute {
+
+void grid_precompute(
+    const ttnn::Tensor& cgrid,
+    const ttnn::Tensor& consts,
+    ttnn::Tensor& out0,
+    ttnn::Tensor& out1,
+    ttnn::Tensor& out2,
+    ttnn::Tensor& out3,
+    uint32_t num_pts);
+
+}  // namespace operations::grid_precompute
+using ttnn::operations::grid_precompute::grid_precompute;
+}  // namespace ttnn

--- a/tt-metal/ops/grid_precompute/grid_precompute_nanobind.cpp
+++ b/tt-metal/ops/grid_precompute/grid_precompute_nanobind.cpp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include "grid_precompute_nanobind.hpp"
+#include <nanobind/nanobind.h>
+#include "ttnn-nanobind/bind_function.hpp"
+#include "grid_precompute.hpp"
+
+namespace ttnn::operations::grid_precompute {
+
+void bind_grid_precompute(nb::module_& mod) {
+    ttnn::bind_function<"grid_precompute">(
+        mod,
+        "Converts a compacted Q14 sampling grid into grid_sample's precomputed 6-field "
+        "form (h0, w0, and the four boundary-masked bilinear weights), one BFLOAT16 "
+        "ROW_MAJOR output per FPN level, computed entirely on the Tensix engines. Row r "
+        "of every output corresponds 1:1 to cgrid row r, so the index/flags/bidx tensors "
+        "from grid_compact apply unchanged. `consts` is the tile pack built by the model "
+        "(per-level affine and bound tiles plus the selector matrices); its ordering is "
+        "the contract documented in the reader kernel. Exists because deriving these six "
+        "values in grid_sample's reader costs ~62% of that op in soft float on an "
+        "FPU-less core; feeding the precomputed form measured 2.78x.",
+        &ttnn::grid_precompute,
+        nb::arg("cgrid"), nb::arg("consts"),
+        nb::arg("out0"), nb::arg("out1"), nb::arg("out2"), nb::arg("out3"),
+        nb::arg("num_pts"));
+}
+
+}  // namespace ttnn::operations::grid_precompute

--- a/tt-metal/ops/grid_precompute/grid_precompute_nanobind.hpp
+++ b/tt-metal/ops/grid_precompute/grid_precompute_nanobind.hpp
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <nanobind/nanobind.h>
+namespace nb = nanobind;
+
+namespace ttnn::operations::grid_precompute {
+void bind_grid_precompute(nb::module_& mod);
+}

--- a/tt-metal/ops/grid_sample/device/kernels/dataflow/reader_grid_sample_interleaved_start_id.cpp
+++ b/tt-metal/ops/grid_sample/device/kernels/dataflow/reader_grid_sample_interleaved_start_id.cpp
@@ -91,7 +91,7 @@ void kernel_main() {
                 input_chunk_nbytes,
                 last_chunk_partial,
                 input_cb_index,
-                scalar_cb_index>(noc, input_cb, scalar_cb, grid_ptr, grid_idx, input_tensor_accessor, batch_offset);
+                scalar_cb_index>(noc, input_cb, scalar_cb, grid_ptr, grid_idx, grid_batches, input_tensor_accessor, batch_offset);
         }
 
         // Update batch tracking (avoid division in loop)

--- a/tt-metal/ops/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
+++ b/tt-metal/ops/grid_sample/device/kernels/dataflow/reader_grid_sample_sharded.cpp
@@ -181,7 +181,7 @@ void kernel_main() {
                 last_chunk_partial,
                 input_cb_index,
                 scalar_cb_index>(
-                noc, input_cb, scalar_cb, grid_stick_ptr, in_grid_row_idx, input_tensor_accessor, batch_offset);
+                noc, input_cb, scalar_cb, grid_stick_ptr, in_grid_row_idx, grid_batching_factor, input_tensor_accessor, batch_offset);
         } else {
             // Padding stick from height-sharding — push zero-weight data to CBs
             // so the compute kernel receives the expected number of items.

--- a/tt-metal/ops/grid_sample/device/kernels/grid_sample_reader_common.hpp
+++ b/tt-metal/ops/grid_sample/device/kernels/grid_sample_reader_common.hpp
@@ -49,6 +49,7 @@ struct GridCoordinateReader {
     ALWI static void read_grid_point(
         GridPtrType grid_ptr,
         uint32_t grid_idx,
+        uint32_t grid_k,
         float height_scale,
         float height_offset,
         float width_scale,
@@ -64,21 +65,28 @@ struct GridCoordinateReader {
         uint16_t& weight_sw_bf,
         uint16_t& weight_se_bf) {
         if constexpr (use_precomputed_grid) {
-            // Each precomputed grid entry has 6 values: h0, w0, weight_nw, weight_ne, weight_sw, weight_se
-            const uint32_t precomputed_data_offset = grid_idx * PRECOMPUTED_GRID_ELEMENTS_PER_POINT;
-            const int16_t h0_raw = *reinterpret_cast<volatile int16_t*>(&grid_ptr[precomputed_data_offset + 0]);
-            const int16_t w0_raw = *reinterpret_cast<volatile int16_t*>(&grid_ptr[precomputed_data_offset + 1]);
+            // FIELD-MAJOR within the stick: [h0 x K][w0 x K][nw x K][ne x K][sw x K][se x K],
+            // K being the grid batching factor. Grouping by field rather than by point lets
+            // the producer (grid_precompute's writer) emit each field as one contiguous run
+            // instead of interleaving two source tiles two bytes at a time — the interleaved
+            // form cost that writer ~40 instructions per value. This reader does the same
+            // six loads either way; only the offsets differ.
+            //
+            // NOTE this diverges from upstream's interleaved layout, and from what the host
+            // prepare_grid_sample_grid emits. In this repo the only producer of precomputed
+            // grids is ttnn.grid_precompute, which emits this layout.
+            const int16_t h0_raw = *reinterpret_cast<volatile int16_t*>(&grid_ptr[grid_idx]);
+            const int16_t w0_raw = *reinterpret_cast<volatile int16_t*>(&grid_ptr[grid_k + grid_idx]);
 
             h0 = static_cast<int32_t>(h0_raw);
             w0 = static_cast<int32_t>(w0_raw);
             h1 = h0 + 1;
             w1 = w0 + 1;
 
-            // Read precomputed weights
-            weight_nw_bf = grid_ptr[precomputed_data_offset + 2];
-            weight_ne_bf = grid_ptr[precomputed_data_offset + 3];
-            weight_sw_bf = grid_ptr[precomputed_data_offset + 4];
-            weight_se_bf = grid_ptr[precomputed_data_offset + 5];
+            weight_nw_bf = grid_ptr[2 * grid_k + grid_idx];
+            weight_ne_bf = grid_ptr[3 * grid_k + grid_idx];
+            weight_sw_bf = grid_ptr[4 * grid_k + grid_idx];
+            weight_se_bf = grid_ptr[5 * grid_k + grid_idx];
         } else {
             // Each regular grid entry has 2 values: x, y coordinates
             float h_coord_rel, w_coord_rel;
@@ -315,6 +323,7 @@ ALWI void process_grid_point(
     experimental::CB scalar_cb,
     GridPtrType grid_ptr,
     uint32_t grid_idx,
+    uint32_t grid_k,
     const TensorAccessor& input_tensor_accessor,
     uint32_t batch_offset) {
     // PyTorch grid_sample coordinate convention:
@@ -342,6 +351,7 @@ ALWI void process_grid_point(
     GridCoordinateReader<grid_dtype, use_precomputed_grid>::template read_grid_point(
         grid_ptr,
         grid_idx,
+        grid_k,
         height_scale,
         height_offset,
         width_scale,

--- a/tt-metal/ops/grouped_weighted_sum/device/grouped_weighted_sum_device_operation.cpp
+++ b/tt-metal/ops/grouped_weighted_sum/device/grouped_weighted_sum_device_operation.cpp
@@ -17,6 +17,17 @@ GroupedWeightedSumOperation::program_factory_t GroupedWeightedSumOperation::sele
 
 void GroupedWeightedSumOperation::validate_on_program_cache_miss(
     const operation_attributes_t& attrs, const tensor_args_t& t) {
+    if (t.perm.has_value()) {
+        TT_FATAL(attrs.clp_per_cam > 0, "skip mode needs clp_per_cam");
+        TT_FATAL(t.live.has_value(), "skip mode needs the live bitmap");
+        TT_FATAL(t.mbox.has_value(), "skip mode needs the L1 mailbox tensor");
+        TT_FATAL(t.features.layout() == Layout::ROW_MAJOR, "skip mode is RM-only");
+        TT_FATAL(t.perm->dtype() == DataType::UINT32 && t.perm->layout() == Layout::ROW_MAJOR,
+                 "perm must be uint32 ROW_MAJOR");
+        TT_FATAL(t.live->dtype() == DataType::UINT32 && t.live->layout() == Layout::ROW_MAJOR,
+                 "live must be uint32 ROW_MAJOR");
+    }
+
     TT_FATAL(t.features.storage_type() == StorageType::DEVICE, "features must be on device");
     TT_FATAL(t.weights.storage_type() == StorageType::DEVICE, "weights must be on device");
     TT_FATAL(t.features.layout() == Layout::TILE || t.features.layout() == Layout::ROW_MAJOR,
@@ -70,14 +81,20 @@ Tensor GroupedWeightedSumOperation::create_output_tensors(
 Tensor grouped_weighted_sum(
     const Tensor& features, const Tensor& weights,
     uint32_t num_groups, uint32_t group_dims,
-    const std::optional<MemoryConfig>& memory_config) {
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& perm,
+    const std::optional<Tensor>& live,
+    uint32_t clp_per_cam,
+    const std::optional<Tensor>& mbox) {
     using Op = GroupedWeightedSumOperation;
     return ttnn::device_operation::launch<Op>(
         Op::operation_attributes_t{
             .num_groups = num_groups, .group_dims = group_dims,
+            .clp_per_cam = perm.has_value() ? clp_per_cam : 0u,
             .output_mem_config = memory_config.value_or(features.memory_config()),
         },
-        Op::tensor_args_t{.features = features, .weights = weights});
+        Op::tensor_args_t{.features = features, .weights = weights,
+                          .perm = perm, .live = live, .mbox = mbox});
 }
 
 }  // namespace ttnn::prim

--- a/tt-metal/ops/grouped_weighted_sum/device/grouped_weighted_sum_device_operation.hpp
+++ b/tt-metal/ops/grouped_weighted_sum/device/grouped_weighted_sum_device_operation.hpp
@@ -33,6 +33,10 @@ tt::tt_metal::Tensor grouped_weighted_sum(
     const tt::tt_metal::Tensor& features,
     const tt::tt_metal::Tensor& weights,
     uint32_t num_groups, uint32_t group_dims,
-    const std::optional<tt::tt_metal::MemoryConfig>& memory_config = std::nullopt);
+    const std::optional<tt::tt_metal::MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<tt::tt_metal::Tensor>& perm = std::nullopt,
+    const std::optional<tt::tt_metal::Tensor>& live = std::nullopt,
+    uint32_t clp_per_cam = 0,
+    const std::optional<tt::tt_metal::Tensor>& mbox = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/tt-metal/ops/grouped_weighted_sum/device/grouped_weighted_sum_device_operation_types.hpp
+++ b/tt-metal/ops/grouped_weighted_sum/device/grouped_weighted_sum_device_operation_types.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <optional>
 #include <tt-metalium/constants.hpp>
 #include "ttnn/tensor/tensor.hpp"
 
@@ -11,12 +12,25 @@ namespace ttnn::prim {
 struct GroupedWeightedSumParams {
     uint32_t num_groups;
     uint32_t group_dims;
+    // Dead-pair skip: clp indices map to cameras as cam = clp / clp_per_cam;
+    // 0 disables. Requires the perm/live tensors below.
+    uint32_t clp_per_cam;
     tt::tt_metal::MemoryConfig output_mem_config;
 };
 
 struct GroupedWeightedSumInputs {
     const tt::tt_metal::Tensor& features;  // [n, clp, embed_dims]
     const tt::tt_metal::Tensor& weights;   // [n, clp, num_groups]
+    // SKIP mode (anchor_bucket outputs): anchors sorted by camera-visibility
+    // pattern. perm [1,1,1,>=N] u32 RM maps sorted position -> original anchor;
+    // live [1,1,1,32] u32 RM holds per-tile-row live-camera bits. Skipped
+    // (row, clp) terms are exactly 0.0 today (masked weights), so the output
+    // stays bit-identical.
+    std::optional<tt::tt_metal::Tensor> perm;
+    std::optional<tt::tt_metal::Tensor> live;
+    // L1-sharded u32 scratch, one 32-word shard per core at a single base
+    // address: the reader->compute count mailbox (MATH cannot address CBs).
+    std::optional<tt::tt_metal::Tensor> mbox;
 };
 
 }  // namespace ttnn::prim

--- a/tt-metal/ops/grouped_weighted_sum/device/grouped_weighted_sum_program_factory.cpp
+++ b/tt-metal/ops/grouped_weighted_sum/device/grouped_weighted_sum_program_factory.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
+#include <cstdlib>
 #include "tt-metalium/work_split.hpp"
 #include "tt-metalium/tensor_accessor_args.hpp"
 #include "ttnn/operations/cb_utils.hpp"
@@ -23,7 +24,15 @@ GroupedWeightedSumProgramFactory::cached_program_t GroupedWeightedSumProgramFact
     Program program{};
     IDevice* const device = output_tensor.device();
 
-    const uint32_t n = t.features.logical_shape()[0];    // CLP (batch/reduction)
+    uint32_t n = t.features.logical_shape()[0];          // CLP (batch/reduction)
+    if (const char* ab = std::getenv("TT_GWS_ABLATE_CLP")) {
+        // TIMING ABLATION ONLY: process just the first N reduction rows to
+        // measure how the op scales with CLP depth. The output becomes a
+        // partial sum — never set outside profiling runs. Use values whose
+        // chunking stays exact (n divisible by num_chunks) or the compute
+        // kernel waits for pages the clamped reader never sends.
+        n = std::min<uint32_t>(n, (uint32_t)atoi(ab));
+    }
     const uint32_t clp = t.features.logical_shape()[1];  // N (output anchors)
     const uint32_t G = attrs.num_groups;
     const uint32_t D = attrs.group_dims;
@@ -61,6 +70,15 @@ GroupedWeightedSumProgramFactory::cached_program_t GroupedWeightedSumProgramFact
     const uint32_t rm_stick_size = embed_dims * t.features.element_size();
     const uint32_t N_total = rm_mode ? t.features.logical_shape()[1] : 0;
 
+    // Dead-pair skip needs the sorted-anchor tables and the compact weights.
+    const bool skip_mode = t.perm.has_value() && attrs.clp_per_cam > 0;
+    uint32_t prm_cb = 0;
+    if (skip_mode) {
+        const uint32_t prm_bytes = ((N_total * 4 + 31) & ~31u) + 128;
+        auto [pm, _p] = create_cb(cb_idx++, program, all_cores, prm_bytes, 1, DataFormat::UInt32);
+        prm_cb = pm;
+    }
+
     // Reader
     std::vector<uint32_t> reader_ct_args = {
         feat_cb, wt_raw_cb, wt_col_cb,
@@ -81,6 +99,9 @@ GroupedWeightedSumProgramFactory::cached_program_t GroupedWeightedSumProgramFact
     const bool wt_compact = t.weights.logical_shape()[-1] == static_cast<int32_t>(G * n);
     reader_ct_args.push_back(wt_compact ? 1U : 0U);                 // WT_COMPACT
     reader_ct_args.push_back(wt_compact ? (G * n) / 32 : 0U);       // WT_TC: tiles per row
+    reader_ct_args.push_back(skip_mode ? 1U : 0U);                  // SKIP_MODE
+    reader_ct_args.push_back(attrs.clp_per_cam);                    // CLP_PER_CAM
+    reader_ct_args.push_back(prm_cb);                               // PRM_CB
 
     auto reader_kernel_id = CreateKernel(program,
         "ttnn/cpp/ttnn/operations/pool/grouped_weighted_sum/device/kernels/dataflow/reader_grouped_weighted_sum.cpp",
@@ -97,6 +118,7 @@ GroupedWeightedSumProgramFactory::cached_program_t GroupedWeightedSumProgramFact
         G,                                    // 3
         rm_mode ? 1U : 0U,                   // 4: RM_MODE
         rm_mode ? tile_cb : feat_cb,          // 5: tile_cb (intermediate for RM)
+        skip_mode ? 1U : 0U,                  // 6: SKIP_MODE
     };
     auto compute_kernel_id = CreateKernel(program,
         "ttnn/cpp/ttnn/operations/pool/grouped_weighted_sum/device/kernels/compute/compute_grouped_weighted_sum.cpp",
@@ -127,12 +149,18 @@ GroupedWeightedSumProgramFactory::cached_program_t GroupedWeightedSumProgramFact
             num_output_tile_rows, // for deriving tile_row from WU
             chunk_size,         // CLP batches per chunk
             n,                  // total CLP batches
+            skip_mode ? t.perm->buffer()->address() : 0u,   // 7
+            skip_mode ? t.live->buffer()->address() : 0u,   // 8
+            64u,                // 9: mailbox nonce (bumped every launch)
+            skip_mode ? t.mbox->buffer()->address() : 0u,   // 10
         });
 
         SetRuntimeArgs(program, compute_kernel_id, core, {
             core_wus,           // num work units
             chunk_size,         // max CLP per chunk (for compute loop)
             n,                  // total CLP
+            64u,                // 3: mailbox nonce (bumped every launch)
+            skip_mode ? t.mbox->buffer()->address() : 0u,   // 4
         });
 
         SetRuntimeArgs(program, writer_kernel_id, core, {
@@ -148,16 +176,24 @@ GroupedWeightedSumProgramFactory::cached_program_t GroupedWeightedSumProgramFact
 
     return cached_program_t{std::move(program),
         shared_variables_t{.reader_kernel_id=reader_kernel_id, .writer_kernel_id=writer_kernel_id,
+                           .compute_kernel_id=compute_kernel_id, .launch_seq=64u,
                            .num_cores=num_cores, .logical_cores=logical_cores}};
 }
 
 void GroupedWeightedSumProgramFactory::override_runtime_arguments(
     cached_program_t& cp, const GroupedWeightedSumParams&,
     const GroupedWeightedSumInputs& t, Tensor& out) {
-    auto& p = cp.program; const auto& sv = cp.shared_variables;
+    auto& p = cp.program; auto& sv = cp.shared_variables;
+    sv.launch_seq += 64u;   // tags: nonce + wu, wu < 64, so no value ever repeats
     for (uint32_t i = 0; i < sv.num_cores; i++) {
         auto& r = GetRuntimeArgs(p, sv.reader_kernel_id, sv.logical_cores[i]);
         r[0] = t.features.buffer()->address(); r[1] = t.weights.buffer()->address();
+        if (t.perm.has_value()) {
+            r[7] = t.perm->buffer()->address();
+            r[8] = t.live->buffer()->address();
+            r[9] = sv.launch_seq;
+            GetRuntimeArgs(p, sv.compute_kernel_id, sv.logical_cores[i])[3] = sv.launch_seq;
+        }
         GetRuntimeArgs(p, sv.writer_kernel_id, sv.logical_cores[i])[0] = out.buffer()->address();
     }
 }

--- a/tt-metal/ops/grouped_weighted_sum/device/grouped_weighted_sum_program_factory.hpp
+++ b/tt-metal/ops/grouped_weighted_sum/device/grouped_weighted_sum_program_factory.hpp
@@ -12,6 +12,11 @@ struct GroupedWeightedSumProgramFactory {
     struct shared_variables_t {
         tt::tt_metal::KernelHandle reader_kernel_id;
         tt::tt_metal::KernelHandle writer_kernel_id;
+        tt::tt_metal::KernelHandle compute_kernel_id;
+        // Launch nonce for the skip-mode mailbox: tags must never repeat
+        // across launches or a cached-program re-run matches last frame's
+        // stale tag before the reader writes this frame's count.
+        uint32_t launch_seq;
         uint32_t num_cores;
         std::vector<tt::tt_metal::CoreCoord> logical_cores;
     };

--- a/tt-metal/ops/grouped_weighted_sum/device/kernels/compute/compute_grouped_weighted_sum.cpp
+++ b/tt-metal/ops/grouped_weighted_sum/device/kernels/compute/compute_grouped_weighted_sum.cpp
@@ -20,10 +20,21 @@ void kernel_main() {
     constexpr uint32_t G         = get_compile_time_arg_val(3);
     constexpr uint32_t RM_MODE   = get_compile_time_arg_val(4);
     constexpr uint32_t tile_cb   = get_compile_time_arg_val(5);
+    // SKIP_MODE: the reader decides per work unit how many clp iterations are
+    // live (dead-camera rows are skipped) and promises the count in a header
+    // page. Control flow here runs identically on all three TRISCs, so a plain
+    // L1 read of the count is race-free — the same mechanism get_arg_val uses.
+    constexpr uint32_t SKIP_MODE = get_compile_time_arg_val(6);
 
     uint32_t num_wus     = get_arg_val<uint32_t>(0);
     uint32_t chunk_size  = get_arg_val<uint32_t>(1);
     uint32_t total_clp   = get_arg_val<uint32_t>(2);
+    uint32_t mbox_nonce  = get_arg_val<uint32_t>(3);
+    // Absolute L1 address of the per-core mailbox (an L1-sharded tensor whose
+    // shards sit at the SAME address on every core). MATH has no cb_interface
+    // at all in firmware, so a CB cannot carry this — a raw address can: every
+    // TRISC is a RISC-V core with plain L1 loads.
+    uint32_t mbox_addr   = get_arg_val<uint32_t>(4);
 
     if constexpr (RM_MODE) {
         // Configure BOTH pipelines up front. The loop below alternates between tilize and
@@ -38,7 +49,17 @@ void kernel_main() {
         for (uint32_t wu = 0; wu < num_wus; wu++) {
             cb_reserve_back(out_cb, G);
 
-            for (uint32_t clp = 0; clp < chunk_size; clp++) {
+            uint32_t iters = chunk_size;
+            if constexpr (SKIP_MODE) {
+                // all three TRISC threads execute this control flow; each
+                // spins until the reader tags this work unit's slot
+                volatile uint32_t* mbox = (volatile uint32_t*)mbox_addr;
+                const uint32_t slot = (wu & 3u) * 2u;
+                while (mbox[slot] != mbox_nonce + wu) {
+                }
+                iters = mbox[slot + 1];
+            }
+            for (uint32_t clp = 0; clp < iters; clp++) {
                 // 1. Tilize RM→TILE.
                 // L1 accumulate must be OFF here: tile_cb is only G pages deep, so every
                 // iteration packs to the same L1 address. With acc still enabled from the
@@ -86,7 +107,17 @@ void kernel_main() {
         for (uint32_t wu = 0; wu < num_wus; wu++) {
             cb_reserve_back(out_cb, G);
 
-            for (uint32_t clp = 0; clp < chunk_size; clp++) {
+            uint32_t iters = chunk_size;
+            if constexpr (SKIP_MODE) {
+                // all three TRISC threads execute this control flow; each
+                // spins until the reader tags this work unit's slot
+                volatile uint32_t* mbox = (volatile uint32_t*)mbox_addr;
+                const uint32_t slot = (wu & 3u) * 2u;
+                while (mbox[slot] != mbox_nonce + wu) {
+                }
+                iters = mbox[slot + 1];
+            }
+            for (uint32_t clp = 0; clp < iters; clp++) {
                 cb_wait_front(feat_cb, G);
                 cb_wait_front(wt_cb, G);
                 pack_reconfig_l1_acc(clp > 0 ? 1 : 0);

--- a/tt-metal/ops/grouped_weighted_sum/device/kernels/dataflow/reader_grouped_weighted_sum.cpp
+++ b/tt-metal/ops/grouped_weighted_sum/device/kernels/dataflow/reader_grouped_weighted_sum.cpp
@@ -17,6 +17,10 @@ void kernel_main() {
     uint32_t N_TR_TOTAL    = get_arg_val<uint32_t>(4);
     uint32_t chunk_size    = get_arg_val<uint32_t>(5);
     uint32_t total_clp     = get_arg_val<uint32_t>(6);
+    uint32_t perm_addr     = get_arg_val<uint32_t>(7);  // SKIP_MODE only
+    uint32_t live_addr     = get_arg_val<uint32_t>(8);  // SKIP_MODE only
+    uint32_t mbox_nonce    = get_arg_val<uint32_t>(9);  // SKIP_MODE only
+    uint32_t mbox_addr     = get_arg_val<uint32_t>(10); // SKIP_MODE only
 
     constexpr uint32_t feat_cb        = get_compile_time_arg_val(0);
     constexpr uint32_t wt_raw_cb      = get_compile_time_arg_val(1);
@@ -42,6 +46,14 @@ void kernel_main() {
     // that was the single most expensive op in the attention-weight path.
     constexpr uint32_t WT_COMPACT = get_compile_time_arg_val(RM_OFFSET + 3);
     constexpr uint32_t WT_TC      = get_compile_time_arg_val(RM_OFFSET + 4);  // tiles per row
+    // Dead-pair skip (see grid_compact): anchors arrive SORTED by camera
+    // visibility pattern, so a whole 32-anchor tile row shares its live-camera
+    // set and (row, clp) iterations whose camera is dead for the row can be
+    // skipped wholesale. Skipped terms are exactly 0.0 in today's math (the
+    // mask zeroed their weights), so the output is bit-identical.
+    constexpr uint32_t SKIP_MODE   = get_compile_time_arg_val(RM_OFFSET + 5);
+    constexpr uint32_t CLP_PER_CAM = get_compile_time_arg_val(RM_OFFSET + 6);
+    constexpr uint32_t PRM_CB      = get_compile_time_arg_val(RM_OFFSET + 7);
 
     // Feature accessor: use correct page_size based on mode
     const auto feat_acc = TensorAccessor(feat_args, feat_addr, feat_page_bytes);
@@ -65,6 +77,21 @@ void kernel_main() {
         }
     }
 
+    // SKIP_MODE: pull the whole permutation (RM_N u32) and the per-tile-row
+    // live-camera bitmap once; both are tiny and shared by every work unit.
+    volatile tt_l1_ptr uint32_t* perm = nullptr;
+    volatile tt_l1_ptr uint32_t* row_live = nullptr;
+    if constexpr (SKIP_MODE) {
+        const auto perm_acc = TensorAccessor(feat_args, perm_addr, ((RM_N + 32) & ~31u) * 4);
+        const auto live_acc = TensorAccessor(feat_args, live_addr, 32 * 4);
+        uint32_t pbuf = get_write_ptr(PRM_CB);
+        noc_async_read(perm_acc.get_noc_addr(0), pbuf, RM_N * 4);
+        noc_async_read(live_acc.get_noc_addr(0), pbuf + ((RM_N * 4 + 31) & ~31u), 32 * 4);
+        noc_async_read_barrier();
+        perm = (volatile tt_l1_ptr uint32_t*)pbuf;
+        row_live = (volatile tt_l1_ptr uint32_t*)(pbuf + ((RM_N * 4 + 31) & ~31u));
+    }
+
     // wt_raw_cb holds a single page that is never pushed or popped, so its address is
     // fixed and a tile already sitting there can be reused. In the compact layout the
     // inner loop walks clp one at a time while the tile only changes every 32/G steps.
@@ -79,18 +106,57 @@ void kernel_main() {
         uint32_t clp_end = clp_start + chunk_size;
         if (clp_end > total_clp) clp_end = total_clp;
 
+        uint32_t live_bits = 7;
+        uint32_t live_cnt = clp_end - clp_start;
+        if constexpr (SKIP_MODE) {
+            live_bits = row_live[n_tr];
+            live_cnt = 0;
+            for (uint32_t clp = clp_start; clp < clp_end; clp++) {
+                live_cnt += (live_bits >> (clp / CLP_PER_CAM)) & 1u;
+            }
+            // The compute kernel cannot see the bitmap, so the reader promises
+            // it an iteration count up front. NOT via a CB page: compute-side
+            // cb_wait_front only blocks the UNPACK thread, and MATH/PACK need
+            // the count too. Instead a never-pushed CB serves as a ring
+            // mailbox all three TRISC threads spin on: slot = (tag, count),
+            // count written before tag (volatile stores stay ordered). Ring
+            // of 4 cannot wrap: a core owns at most 2 work units.
+            // A fully dead chunk still runs ONE iteration: its weights are
+            // zeros (the mask guarantees it), and that first non-accumulating
+            // pack is what zero-fills the output.
+            {
+                volatile tt_l1_ptr uint32_t* mbox =
+                    (volatile tt_l1_ptr uint32_t*)mbox_addr;
+                const uint32_t slot = (wu & 3u) * 2u;
+                mbox[slot + 1] = (live_cnt == 0) ? 1u : live_cnt;
+                mbox[slot] = mbox_nonce + wu;
+            }
+
+        }
+
+
         for (uint32_t clp = clp_start; clp < clp_end; clp++) {
+            if constexpr (SKIP_MODE) {
+                const bool alive = (live_bits >> (clp / CLP_PER_CAM)) & 1u;
+                const bool forced = (live_cnt == 0) && (clp == clp_start);
+                if (!alive && !forced) {
+                    continue;
+                }
+            }
             // === Feature read ===
             cb_reserve_back(feat_cb, FEAT_TC);
             uint32_t feat_l1 = get_write_ptr(feat_cb);
 
             if constexpr (RM_MODE) {
                 // RM: read 32 sticks (1 tile-row) into feat_cb as contiguous RM data
-                // Page_id in RM tensor: clp * RM_N + anchor
+                // Page_id in RM tensor: clp * RM_N + anchor (permuted in skip mode)
                 uint32_t anchor_start = n_tr * TILE_H;
                 for (uint32_t r = 0; r < TILE_H; r++) {
                     uint32_t anchor = anchor_start + r;
                     if (anchor < RM_N) {
+                        if constexpr (SKIP_MODE) {
+                            anchor = perm[anchor];
+                        }
                         uint32_t page_id = clp * RM_N + anchor;
                         noc_async_read(feat_acc.get_noc_addr(page_id),
                                        feat_l1 + r * RM_STICK_SZ, RM_STICK_SZ);
@@ -106,9 +172,14 @@ void kernel_main() {
             }
 
             // === Weight read ===
+            // Skip mode gets weights PRE-PERMUTED into sorted-anchor order (one
+            // host-side row_gather per call), so both modes share the cached-tile
+            // read. Gathering 32 scattered rows per work unit here instead cost
+            // ~600 us/call in NOC issue latency and erased the skip's win.
+            uint32_t col_base = 0;
             // Compact: this clp's G columns start at column clp*G of tile-row n_tr, so one
             // tile serves 32/G consecutive clp and is only re-read when clp crosses it.
-            uint32_t wt_tile_id, col_base;
+            uint32_t wt_tile_id;
             if constexpr (WT_COMPACT) {
                 const uint32_t c0 = clp * NUM_GROUPS;
                 wt_tile_id = n_tr * WT_TC + (c0 >> 5);
@@ -122,6 +193,8 @@ void kernel_main() {
                 noc_async_read(wt_acc.get_noc_addr(wt_tile_id), wt_raw_l1, wt_tile_bytes);
                 cached_wt_tile = wt_tile_id;
             }
+            volatile tt_l1_ptr uint16_t* raw =
+                reinterpret_cast<volatile tt_l1_ptr uint16_t*>(wt_raw_l1);
             noc_async_read_barrier();
             cb_push_back(feat_cb, FEAT_TC);
 
@@ -129,15 +202,14 @@ void kernel_main() {
             // A 32x32 tile is stored as four 16x16 faces, so a column lands in face
             // (row>=16)*2 + (col>=16) at offset (row%16)*16 + col%16. col_base is 0 in the
             // non-compact layout, which reduces this to the original "column g" case.
-            volatile tt_l1_ptr uint16_t* raw = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(wt_raw_l1);
             cb_reserve_back(wt_col_cb, NUM_GROUPS);
             uint32_t col_l1 = get_write_ptr(wt_col_cb);
             for (uint32_t g = 0; g < NUM_GROUPS; g++) {
+                volatile tt_l1_ptr uint16_t* col = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(
+                    col_l1 + g * wt_tile_bytes);
                 const uint32_t sc = col_base + g;
                 const uint32_t cf = (sc >= 16) ? 1 : 0;
                 const uint32_t cc = sc & 15;
-                volatile tt_l1_ptr uint16_t* col = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(
-                    col_l1 + g * wt_tile_bytes);
                 for (uint32_t r = 0; r < 32; r++) {
                     uint32_t sf = ((r >= 16) ? 2 : 0) + cf;
                     uint32_t fr = r % 16;

--- a/tt-metal/ops/grouped_weighted_sum/grouped_weighted_sum.cpp
+++ b/tt-metal/ops/grouped_weighted_sum/grouped_weighted_sum.cpp
@@ -12,9 +12,13 @@ tt::tt_metal::Tensor grouped_weighted_sum(
     const tt::tt_metal::Tensor& weights,
     uint32_t num_groups,
     uint32_t group_dims,
-    const std::optional<tt::tt_metal::MemoryConfig>& memory_config) {
+    const std::optional<tt::tt_metal::MemoryConfig>& memory_config,
+    const std::optional<tt::tt_metal::Tensor>& perm,
+    const std::optional<tt::tt_metal::Tensor>& live,
+    uint32_t clp_per_cam,
+    const std::optional<tt::tt_metal::Tensor>& mbox) {
     return ttnn::prim::grouped_weighted_sum(
-        features, weights, num_groups, group_dims, memory_config);
+        features, weights, num_groups, group_dims, memory_config, perm, live, clp_per_cam, mbox);
 }
 
 }  // namespace ttnn::operations::grouped_weighted_sum

--- a/tt-metal/ops/grouped_weighted_sum/grouped_weighted_sum.hpp
+++ b/tt-metal/ops/grouped_weighted_sum/grouped_weighted_sum.hpp
@@ -13,7 +13,11 @@ ttnn::Tensor grouped_weighted_sum(
     const ttnn::Tensor& weights,    // [n, clp, num_groups] ROW_MAJOR bf16
     uint32_t num_groups,
     uint32_t group_dims,
-    const std::optional<MemoryConfig>& memory_config = std::nullopt);
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<ttnn::Tensor>& perm = std::nullopt,
+    const std::optional<ttnn::Tensor>& live = std::nullopt,
+    uint32_t clp_per_cam = 0,
+    const std::optional<ttnn::Tensor>& mbox = std::nullopt);
 
 }  // namespace operations::grouped_weighted_sum
 using ttnn::operations::grouped_weighted_sum::grouped_weighted_sum;

--- a/tt-metal/ops/grouped_weighted_sum/grouped_weighted_sum_nanobind.cpp
+++ b/tt-metal/ops/grouped_weighted_sum/grouped_weighted_sum_nanobind.cpp
@@ -27,7 +27,9 @@ void bind_grouped_weighted_sum(nb::module_& mod) {
         mod, doc, &ttnn::grouped_weighted_sum,
         nb::arg("features"), nb::arg("weights"),
         nb::arg("num_groups"), nb::arg("group_dims"),
-        nb::kw_only(), nb::arg("memory_config") = nb::none());
+        nb::kw_only(), nb::arg("memory_config") = nb::none(),
+        nb::arg("perm") = nb::none(), nb::arg("live") = nb::none(),
+        nb::arg("clp_per_cam") = 0, nb::arg("mbox") = nb::none());
 }
 
 }  // namespace ttnn::operations::grouped_weighted_sum

--- a/tt-metal/ops/row_gather/device/kernels/dataflow/row_gather.cpp
+++ b/tt-metal/ops/row_gather/device/kernels/dataflow/row_gather.cpp
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+// Paired row gather: out_a[r,:] = src_a[idx[r],:], out_b[r,:] = src_b[idx[r],:].
+//
+// Replaces ttnn.gather for the instance bank's top-k selection, which ran on
+// 4 cores at 1.1 GB/s — pure NOC round-trip latency, 655 us/call — plus a
+// typecast/reshape/to_layout/repeat_interleave chain per call just to expand
+// the indices into gather's format. This kernel takes topk_select's uint32
+// ROW_MAJOR indices directly and copies rows in parallel across cores with
+// deep async pipelining; feature and anchor ride the same index read.
+//
+// TILE row addressing: a 32x32 tile stores faces f0(r0-15,c0-15) f1(r0-15,
+// c16-31) f2(r16-31,c0-15) f3(r16-31,c16-31), each row-major 16 wide. Logical
+// row ls of one tile is two contiguous segments of 16 elements:
+//   ls < 16 : f0 + ls*16        and  f1 + ls*16   (f1 base = 256 elems)
+//   ls >= 16: f2 + (ls-16)*16   and  f3 + (ls-16)*16 (bases 512, 768)
+
+#include <stdint.h>
+#include "api/compile_time_args.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+
+// Reads and writes are issued for a WHOLE row before any barrier: one
+// read-barrier per row instead of one per tile (39 col-tiles for the gws
+// weight permute made per-tile barriers latency-bound).
+template <uint32_t E>
+FORCE_INLINE void read_row_seg(const uint64_t tile_base, const uint32_t ls, uint32_t l1_buf) {
+    const uint32_t half = (ls < 16) ? 0u : 512u * E;
+    const uint32_t off = ((ls & 15u) * 16u) * E;
+    noc_async_read(tile_base + half + off, l1_buf, 16 * E);
+    noc_async_read(tile_base + half + 256u * E + off, l1_buf + 16 * E, 16 * E);
+}
+
+template <uint32_t E>
+FORCE_INLINE void write_row_seg(uint32_t l1_buf, const uint64_t tile_base, const uint32_t lr) {
+    const uint32_t half = (lr < 16) ? 0u : 512u * E;
+    const uint32_t off = ((lr & 15u) * 16u) * E;
+    noc_async_write(l1_buf, tile_base + half + off, 16 * E);
+    noc_async_write(l1_buf + 16 * E, tile_base + half + 256u * E + off, 16 * E);
+}
+
+void kernel_main() {
+    constexpr uint32_t K     = get_compile_time_arg_val(0);   // rows to gather
+    constexpr uint32_t CT_A  = get_compile_time_arg_val(1);   // col tiles of a (8)
+    constexpr uint32_t CT_B  = get_compile_time_arg_val(2);   // col tiles of b (1)
+    constexpr uint32_t EA    = get_compile_time_arg_val(3);   // elem bytes a (2)
+    constexpr uint32_t EB    = get_compile_time_arg_val(4);   // elem bytes b (4)
+    constexpr uint32_t CB_IDX = get_compile_time_arg_val(5);
+    constexpr uint32_t CB_ROW = get_compile_time_arg_val(6);
+    // ROW_MAJOR pair-a: rows are whole sticks — one read + one write per row
+    // instead of per-tile face segments (used by the gws output un-permute,
+    // whose non-tile-aligned slice lands in RM).
+    constexpr uint32_t A_RM       = get_compile_time_arg_val(7);
+    constexpr uint32_t A_STICK_SZ = get_compile_time_arg_val(8);
+
+    constexpr auto sa_args = TensorAccessorArgs<9>();
+    constexpr auto sb_args = TensorAccessorArgs<sa_args.next_compile_time_args_offset()>();
+    constexpr auto ix_args = TensorAccessorArgs<sb_args.next_compile_time_args_offset()>();
+    constexpr auto oa_args = TensorAccessorArgs<ix_args.next_compile_time_args_offset()>();
+    constexpr auto ob_args = TensorAccessorArgs<oa_args.next_compile_time_args_offset()>();
+
+    const uint32_t sa_addr = get_arg_val<uint32_t>(0);
+    const uint32_t sb_addr = get_arg_val<uint32_t>(1);
+    const uint32_t ix_addr = get_arg_val<uint32_t>(2);
+    const uint32_t oa_addr = get_arg_val<uint32_t>(3);
+    const uint32_t ob_addr = get_arg_val<uint32_t>(4);
+    const uint32_t row0    = get_arg_val<uint32_t>(5);
+    const uint32_t nrows   = get_arg_val<uint32_t>(6);
+
+    const uint32_t ta_bytes = A_RM ? A_STICK_SZ : 32 * 32 * EA;
+    const uint32_t tb_bytes = 32 * 32 * EB;
+    const auto sa = TensorAccessor(sa_args, sa_addr, ta_bytes);
+    const auto oa = TensorAccessor(oa_args, oa_addr, ta_bytes);
+    const auto sb = TensorAccessor(sb_args, sb_addr, tb_bytes);
+    const auto ob = TensorAccessor(ob_args, ob_addr, tb_bytes);
+    const auto ix = TensorAccessor(ix_args, ix_addr, K * 4);
+
+    // whole index stick once (<= 2.4 KB)
+    cb_reserve_back(CB_IDX, 1);
+    const uint32_t ixb = get_write_ptr(CB_IDX);
+    noc_async_read(ix.get_noc_addr(0), ixb, K * 4);
+    noc_async_read_barrier();
+    volatile tt_l1_ptr uint32_t* idx = (volatile tt_l1_ptr uint32_t*)ixb;
+
+    cb_reserve_back(CB_ROW, 1);
+    const uint32_t rb = get_write_ptr(CB_ROW);
+
+    for (uint32_t i = 0; i < nrows; i++) {
+        const uint32_t r = row0 + i;      // destination row
+        const uint32_t s = idx[r];        // source row
+        const uint32_t st = s >> 5, ls = s & 31u;
+        const uint32_t dt = r >> 5, lr = r & 31u;
+        uint32_t buf = rb;
+        if constexpr (A_RM) {
+            noc_async_read(sa.get_noc_addr(s), buf, A_STICK_SZ);
+            buf += A_STICK_SZ;
+        } else {
+            for (uint32_t c = 0; c < CT_A; c++) {
+                read_row_seg<EA>(sa.get_noc_addr(st * CT_A + c), ls, buf);
+                buf += 32 * EA;
+            }
+        }
+        for (uint32_t c = 0; c < CT_B; c++) {
+            read_row_seg<EB>(sb.get_noc_addr(st * CT_B + c), ls, buf);
+            buf += 32 * EB;
+        }
+        noc_async_read_barrier();
+        buf = rb;
+        if constexpr (A_RM) {
+            noc_async_write(buf, oa.get_noc_addr(r), A_STICK_SZ);
+            buf += A_STICK_SZ;
+        } else {
+            for (uint32_t c = 0; c < CT_A; c++) {
+                write_row_seg<EA>(buf, oa.get_noc_addr(dt * CT_A + c), lr);
+                buf += 32 * EA;
+            }
+        }
+        for (uint32_t c = 0; c < CT_B; c++) {
+            write_row_seg<EB>(buf, ob.get_noc_addr(dt * CT_B + c), lr);
+            buf += 32 * EB;
+        }
+        // the row buffer is reused next iteration; wait until the NIU has
+        // pulled every write payload out of L1 (cheaper than a full ack)
+        noc_async_writes_flushed();
+    }
+    noc_async_write_barrier();
+}

--- a/tt-metal/ops/row_gather/device/row_gather_device_operation.cpp
+++ b/tt-metal/ops/row_gather/device/row_gather_device_operation.cpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include "row_gather_device_operation.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::prim {
+using namespace tt;
+using namespace tt::tt_metal;
+
+RowGatherOperation::program_factory_t RowGatherOperation::select_program_factory(
+    const operation_attributes_t&, const tensor_args_t&) {
+    return RowGatherProgramFactory{};
+}
+
+void RowGatherOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& a, const tensor_args_t& t) {
+    TT_FATAL(t.src_a.layout() == t.out_a.layout(), "a pair layout mismatch");
+    for (const Tensor* x : {&t.src_a, &t.out_a}) {
+        TT_FATAL(x->storage_type() == StorageType::DEVICE, "tensors must be on device");
+    }
+    TT_FATAL(t.src_b.has_value() == t.out_b.has_value(), "src_b needs out_b");
+    if (t.src_b.has_value()) {
+        for (const Tensor* x : {&*t.src_b, &*t.out_b}) {
+            TT_FATAL(x->layout() == Layout::TILE, "tensors must be TILE");
+            TT_FATAL(x->storage_type() == StorageType::DEVICE, "tensors must be on device");
+        }
+    }
+    TT_FATAL(t.indices.dtype() == DataType::UINT32, "indices must be UINT32");
+    TT_FATAL(t.indices.layout() == Layout::ROW_MAJOR, "indices must be ROW_MAJOR");
+    TT_FATAL(t.indices.logical_shape()[-1] >= a.k, "indices shorter than k");
+    TT_FATAL(t.src_a.dtype() == t.out_a.dtype(), "a dtype mismatch");
+    if (t.src_b.has_value()) {
+        TT_FATAL(t.src_b->dtype() == t.out_b->dtype(), "b dtype mismatch");
+    }
+    TT_FATAL(
+        t.src_a.padded_shape()[-1] == t.out_a.padded_shape()[-1],
+        "a width mismatch");
+    if (t.src_b.has_value()) {
+        TT_FATAL(
+            t.src_b->padded_shape()[-1] == t.out_b->padded_shape()[-1],
+            "b width mismatch");
+    }
+    TT_FATAL(t.out_a.padded_shape()[-2] >= a.k, "out_a shorter than k");
+    if (t.out_b.has_value()) {
+        TT_FATAL(t.out_b->padded_shape()[-2] >= a.k, "out_b shorter than k");
+    }
+}
+
+TensorSpec RowGatherOperation::compute_output_specs(
+    const operation_attributes_t&, const tensor_args_t& t) {
+    return t.out_a.tensor_spec();
+}
+
+Tensor RowGatherOperation::create_output_tensors(
+    const operation_attributes_t&, const tensor_args_t& t) {
+    return t.out_a;
+}
+
+void row_gather(
+    const Tensor& src_a, const Tensor& indices, Tensor& out_a,
+    const std::optional<Tensor>& src_b, const std::optional<Tensor>& out_b,
+    uint32_t k) {
+    using Op = RowGatherOperation;
+    ttnn::device_operation::launch<Op>(
+        Op::operation_attributes_t{
+            .k = k, .output_mem_config = out_a.memory_config()},
+        Op::tensor_args_t{
+            .src_a = src_a, .indices = indices, .out_a = out_a,
+            .src_b = src_b, .out_b = out_b});
+}
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/row_gather/device/row_gather_device_operation.hpp
+++ b/tt-metal/ops/row_gather/device/row_gather_device_operation.hpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <optional>
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/device_operation.hpp"
+#include "row_gather_device_operation_types.hpp"
+#include "row_gather_program_factory.hpp"
+
+namespace ttnn::prim {
+
+struct RowGatherOperation {
+    using operation_attributes_t = RowGatherParams;
+    using tensor_args_t = RowGatherInputs;
+    using spec_return_value_t = tt::tt_metal::TensorSpec;
+    using tensor_return_value_t = tt::tt_metal::Tensor;
+    using program_factory_t = std::variant<RowGatherProgramFactory>;
+
+    static program_factory_t select_program_factory(
+        const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(
+        const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(
+        const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t&, const tensor_args_t&);
+};
+
+void row_gather(
+    const tt::tt_metal::Tensor& src_a,
+    const tt::tt_metal::Tensor& indices,
+    tt::tt_metal::Tensor& out_a,
+    const std::optional<tt::tt_metal::Tensor>& src_b,
+    const std::optional<tt::tt_metal::Tensor>& out_b,
+    uint32_t k);
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/row_gather/device/row_gather_device_operation_types.hpp
+++ b/tt-metal/ops/row_gather/device/row_gather_device_operation_types.hpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <optional>
+#include <tt-metalium/constants.hpp>
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::prim {
+
+// Paired row gather for the instance bank's top-k selection:
+//   out_a[r,:] = src_a[idx[r],:]   (features, bf16)
+//   out_b[r,:] = src_b[idx[r],:]   (anchors, fp32)
+// Both selections always share one index vector, so one op replaces two
+// ttnn.gather calls plus the index-expansion chain each of them needed
+// (typecast + reshape + to_layout + repeat_interleave). ttnn.gather ran the
+// production shape on 4 cores at 1.1 GB/s — latency-bound, 655 us/call.
+struct RowGatherParams {
+    uint32_t k;  // rows to gather
+    tt::tt_metal::MemoryConfig output_mem_config;
+};
+
+struct RowGatherInputs {
+    const tt::tt_metal::Tensor& src_a;    // DEVICE TILE [1, N, Ca]
+    const tt::tt_metal::Tensor& indices;  // DEVICE ROW_MAJOR uint32 [1,1,1,K]
+    const tt::tt_metal::Tensor& out_a;    // DEVICE TILE [1, K, Ca], preallocated
+    // Optional second pair riding the same index read (the instance bank's
+    // feature/anchor selections always travel together).
+    std::optional<tt::tt_metal::Tensor> src_b;
+    std::optional<tt::tt_metal::Tensor> out_b;
+};
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/row_gather/device/row_gather_program_factory.cpp
+++ b/tt-metal/ops/row_gather/device/row_gather_program_factory.cpp
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "tt-metalium/tensor_accessor_args.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/work_split.hpp>
+#include "row_gather_program_factory.hpp"
+
+namespace ttnn::prim {
+using namespace tt;
+using namespace tt::tt_metal;
+
+RowGatherProgramFactory::cached_program_t RowGatherProgramFactory::create(
+    const RowGatherParams& attrs,
+    const RowGatherInputs& t,
+    Tensor& /*output_tensor*/) {
+
+    Program program{};
+
+    const bool has_b = t.src_b.has_value();
+    const bool a_rm = t.src_a.layout() == Layout::ROW_MAJOR;
+    const uint32_t a_stick = t.src_a.logical_shape()[-1] * t.src_a.element_size();
+    const uint32_t ct_a = t.src_a.padded_shape()[-1] / constants::TILE_WIDTH;
+    const uint32_t ct_b = has_b ? t.src_b->padded_shape()[-1] / constants::TILE_WIDTH : 0;
+    const uint32_t ea = t.src_a.element_size();
+    const uint32_t eb = has_b ? t.src_b->element_size() : 4;
+
+    const auto grid = t.src_a.device()->compute_with_storage_grid_size();
+    uint32_t num_cores = std::min<uint32_t>(grid.x * grid.y, (attrs.k + 7) / 8);
+    const uint32_t rows_base = attrs.k / num_cores;
+    const uint32_t rows_rem = attrs.k % num_cores;
+    const CoreRangeSet core_range = num_cores_to_corerangeset(num_cores, grid, true);
+
+    constexpr uint32_t CB_IDX = tt::CBIndex::c_0;
+    constexpr uint32_t CB_ROW = tt::CBIndex::c_1;
+    const uint32_t idx_bytes = ((attrs.k * 4 + 31) / 32) * 32;
+    const uint32_t row_bytes =
+        (a_rm ? ((a_stick + 31) & ~31u) : 32 * ct_a * ea) + 32 * ct_b * eb;
+
+    auto idx_cfg = CircularBufferConfig(idx_bytes, {{CB_IDX, DataFormat::UInt32}})
+                       .set_page_size(CB_IDX, idx_bytes);
+    CreateCircularBuffer(program, core_range, idx_cfg);
+    auto row_cfg = CircularBufferConfig(row_bytes, {{CB_ROW, DataFormat::UInt8}})
+                       .set_page_size(CB_ROW, row_bytes);
+    CreateCircularBuffer(program, core_range, row_cfg);
+
+    std::vector<uint32_t> ct_args = {attrs.k, ct_a, ct_b, ea, eb, CB_IDX, CB_ROW,
+                                     a_rm ? 1u : 0u, a_stick};
+    TensorAccessorArgs(*t.src_a.buffer()).append_to(ct_args);
+    TensorAccessorArgs(has_b ? *t.src_b->buffer() : *t.src_a.buffer()).append_to(ct_args);
+    TensorAccessorArgs(*t.indices.buffer()).append_to(ct_args);
+    TensorAccessorArgs(*t.out_a.buffer()).append_to(ct_args);
+    TensorAccessorArgs(has_b ? *t.out_b->buffer() : *t.out_a.buffer()).append_to(ct_args);
+
+    KernelHandle kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/pool/row_gather/device/kernels/dataflow/row_gather.cpp",
+        core_range, WriterDataMovementConfig(ct_args));
+
+    auto cores = corerange_to_cores(core_range, num_cores, true);
+    uint32_t r0 = 0;
+    for (uint32_t i = 0; i < num_cores; i++) {
+        const uint32_t my_rows = rows_base + (i < rows_rem ? 1 : 0);
+        SetRuntimeArgs(program, kernel_id, cores[i], {
+            t.src_a.buffer()->address(),
+            has_b ? t.src_b->buffer()->address() : 0u,
+            t.indices.buffer()->address(),
+            t.out_a.buffer()->address(),
+            has_b ? t.out_b->buffer()->address() : 0u,
+            r0, my_rows});
+        r0 += my_rows;
+    }
+
+    return cached_program_t{
+        std::move(program),
+        shared_variables_t{.kernel_id = kernel_id, .cores = std::move(cores)}};
+}
+
+void RowGatherProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const RowGatherParams&,
+    const RowGatherInputs& t,
+    Tensor& /*output_tensor*/) {
+    auto& prog = cached_program.program;
+    const auto& sv = cached_program.shared_variables;
+    for (const auto& c : sv.cores) {
+        auto& ra = GetRuntimeArgs(prog, sv.kernel_id, c);
+        ra[0] = t.src_a.buffer()->address();
+        ra[1] = t.src_b.has_value() ? t.src_b->buffer()->address() : 0u;
+        ra[2] = t.indices.buffer()->address();
+        ra[3] = t.out_a.buffer()->address();
+        ra[4] = t.out_b.has_value() ? t.out_b->buffer()->address() : 0u;
+    }
+}
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/row_gather/device/row_gather_program_factory.hpp
+++ b/tt-metal/ops/row_gather/device/row_gather_program_factory.hpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <vector>
+#include <tt-metalium/host_api.hpp>
+#include "ttnn/device_operation.hpp"
+#include "row_gather_device_operation_types.hpp"
+
+namespace ttnn::prim {
+
+struct RowGatherProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle kernel_id;
+        std::vector<tt::tt_metal::CoreCoord> cores;
+    };
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const RowGatherParams& attrs,
+        const RowGatherInputs& t,
+        tt::tt_metal::Tensor& output_tensor);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const RowGatherParams& attrs,
+        const RowGatherInputs& t,
+        tt::tt_metal::Tensor& output_tensor);
+};
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/row_gather/row_gather.cpp
+++ b/tt-metal/ops/row_gather/row_gather.cpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include "row_gather.hpp"
+#include "device/row_gather_device_operation.hpp"
+
+namespace ttnn::operations::row_gather {
+
+void row_gather(
+    const tt::tt_metal::Tensor& src_a, const tt::tt_metal::Tensor& indices,
+    tt::tt_metal::Tensor& out_a,
+    const std::optional<tt::tt_metal::Tensor>& src_b,
+    const std::optional<tt::tt_metal::Tensor>& out_b, uint32_t k) {
+    ttnn::prim::row_gather(src_a, indices, out_a, src_b, out_b, k);
+}
+
+}  // namespace ttnn::operations::row_gather

--- a/tt-metal/ops/row_gather/row_gather.hpp
+++ b/tt-metal/ops/row_gather/row_gather.hpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <optional>
+#include "ttnn/types.hpp"
+
+namespace ttnn {
+namespace operations::row_gather {
+
+void row_gather(
+    const ttnn::Tensor& src_a, const ttnn::Tensor& indices, ttnn::Tensor& out_a,
+    const std::optional<ttnn::Tensor>& src_b,
+    const std::optional<ttnn::Tensor>& out_b,
+    uint32_t k);
+
+}  // namespace operations::row_gather
+using ttnn::operations::row_gather::row_gather;
+}  // namespace ttnn

--- a/tt-metal/ops/row_gather/row_gather_nanobind.cpp
+++ b/tt-metal/ops/row_gather/row_gather_nanobind.cpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include "row_gather_nanobind.hpp"
+#include <nanobind/stl/optional.h>
+#include <nanobind/nanobind.h>
+#include "ttnn-nanobind/bind_function.hpp"
+#include "row_gather.hpp"
+
+namespace ttnn::operations::row_gather {
+
+void bind_row_gather(nb::module_& mod) {
+    ttnn::bind_function<"row_gather">(
+        mod,
+        "Paired row gather: out_a[r] = src_a[idx[r]], out_b[r] = src_b[idx[r]] "
+        "for r < k, with idx a uint32 ROW_MAJOR [1,1,1,>=k] vector (e.g. "
+        "topk_select's output, no expansion chain needed). src/out are TILE "
+        "tensors; both pairs ride one op and the rows fan out across cores "
+        "with async NOC pipelining. Bit-identical row copies.",
+        &ttnn::row_gather,
+        nb::arg("src_a"), nb::arg("indices"), nb::arg("out_a"),
+        nb::arg("src_b") = nb::none(), nb::arg("out_b") = nb::none(),
+        nb::arg("k"));
+}
+
+}  // namespace ttnn::operations::row_gather

--- a/tt-metal/ops/row_gather/row_gather_nanobind.hpp
+++ b/tt-metal/ops/row_gather/row_gather_nanobind.hpp
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <nanobind/nanobind.h>
+namespace nb = nanobind;
+
+namespace ttnn::operations::row_gather {
+void bind_row_gather(nb::module_& mod);
+}

--- a/tt-metal/ops/topk_select/device/kernels/dataflow/topk_select.cpp
+++ b/tt-metal/ops/topk_select/device/kernels/dataflow/topk_select.cpp
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+// Top-k selection over one row of scores.
+//
+// ttnn.topk on a [1, 900] input pads to a 32 x 928 TILE and bitonic-sorts all 32
+// rows on one core — 97% of its 1.9-2.8 ms/call is sorting tile padding. This
+// kernel reads only the one real row and sorts it with an LSD radix sort: all
+// integer compares and moves, so the FPU-less dataflow core runs it at full rate
+// (the soft-float trap only bites float ARITHMETIC; bf16 ordering is recovered
+// with a bit flip and compared as uint16).
+//
+// Ordering contract: descending by score, ties broken by the LOWER source index
+// (torch.topk semantics). The index bits ride in the low half of each record and
+// are never part of a sort digit, so the stable radix passes preserve their
+// original order within a tie.
+//
+// One core, no compute kernel. The sort is ~5k L1 word operations for N=900 —
+// far below the op's dispatch cost — so fanning out across cores would only add
+// synchronization for time nobody gets back.
+
+#include <stdint.h>
+#include "api/compile_time_args.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+
+void kernel_main() {
+    constexpr uint32_t N         = get_compile_time_arg_val(0);
+    constexpr uint32_t K         = get_compile_time_arg_val(1);
+    constexpr uint32_t SCORES_CB = get_compile_time_arg_val(2);
+    constexpr uint32_t REC_CB    = get_compile_time_arg_val(3);
+    constexpr uint32_t CNT_CB    = get_compile_time_arg_val(4);
+    constexpr uint32_t VAL_CB    = get_compile_time_arg_val(5);
+    constexpr uint32_t IDX_CB    = get_compile_time_arg_val(6);
+    constexpr uint32_t NT        = (N + 31) / 32;  // input tiles along the row
+
+    constexpr auto scores_args = TensorAccessorArgs<7>();
+    constexpr auto values_args =
+        TensorAccessorArgs<scores_args.next_compile_time_args_offset()>();
+    constexpr auto index_args =
+        TensorAccessorArgs<values_args.next_compile_time_args_offset()>();
+
+    const uint32_t scores_addr = get_arg_val<uint32_t>(0);
+    const uint32_t values_addr = get_arg_val<uint32_t>(1);
+    const uint32_t index_addr  = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t TILE_BYTES = 32 * 32 * 2;  // bf16 tile page
+    const auto scores_ta = TensorAccessor(scores_args, scores_addr, TILE_BYTES);
+    const auto values_ta = TensorAccessor(values_args, values_addr, K * 2);
+    const auto index_ta  = TensorAccessor(index_args, index_addr, K * 4);
+
+    // Logical row 0 of a 32x32 bf16 tile lives in two face rows: face 0 row 0 at
+    // byte 0 (cols 0-15) and face 1 row 0 at byte 512 (cols 16-31). Two 32 B
+    // reads per tile instead of untilizing the whole tensor first — which would
+    // be another op call, and the dispatch floor costs more than this sort.
+    cb_reserve_back(SCORES_CB, 1);
+    const uint32_t vbuf = get_write_ptr(SCORES_CB);
+    for (uint32_t t = 0; t < NT; t++) {
+        const uint64_t src = scores_ta.get_noc_addr(t);
+        noc_async_read(src, vbuf + t * 64, 32);
+        noc_async_read(src + 512, vbuf + t * 64 + 32, 32);
+    }
+    noc_async_read_barrier();
+
+    volatile tt_l1_ptr uint16_t* vals = (volatile tt_l1_ptr uint16_t*)vbuf;
+
+    cb_reserve_back(REC_CB, 1);
+    uint32_t* rec  = (uint32_t*)get_write_ptr(REC_CB);
+    uint32_t* rec2 = rec + N;
+    cb_reserve_back(CNT_CB, 1);
+    uint32_t* cnt = (uint32_t*)get_write_ptr(CNT_CB);
+
+    // Map bf16 bits to a key whose UNSIGNED ascending order is descending float
+    // order: flip to monotonic-ascending (sign set -> ~v, else v | 0x8000), then
+    // invert. record = key << 16 | index, so N must stay within 16 bits.
+    for (uint32_t i = 0; i < N; i++) {
+        const uint16_t v = vals[i];
+        const uint16_t asc =
+            (v & 0x8000) ? (uint16_t)~v : (uint16_t)(v | 0x8000);
+        const uint16_t key = (uint16_t)(asc ^ 0xFFFF);
+        rec[i] = ((uint32_t)key << 16) | i;
+    }
+
+    // Two stable counting-sort passes over the key bytes (bits 16-23, then
+    // 24-31). After the second pass the records are back in `rec`, fully sorted.
+    for (uint32_t shift = 16; shift <= 24; shift += 8) {
+        uint32_t* src = (shift == 16) ? rec : rec2;
+        uint32_t* dst = (shift == 16) ? rec2 : rec;
+        for (uint32_t b = 0; b < 256; b++) {
+            cnt[b] = 0;
+        }
+        for (uint32_t i = 0; i < N; i++) {
+            cnt[(src[i] >> shift) & 0xFF]++;
+        }
+        uint32_t run = 0;
+        for (uint32_t b = 0; b < 256; b++) {
+            const uint32_t c = cnt[b];
+            cnt[b] = run;
+            run += c;
+        }
+        for (uint32_t i = 0; i < N; i++) {
+            const uint32_t r = src[i];
+            dst[cnt[(r >> shift) & 0xFF]++] = r;
+        }
+    }
+
+    cb_reserve_back(VAL_CB, 1);
+    cb_reserve_back(IDX_CB, 1);
+    const uint32_t oval_addr = get_write_ptr(VAL_CB);
+    const uint32_t oidx_addr = get_write_ptr(IDX_CB);
+    uint16_t* oval = (uint16_t*)oval_addr;
+    uint32_t* oidx = (uint32_t*)oidx_addr;
+    for (uint32_t j = 0; j < K; j++) {
+        const uint32_t r = rec[j];
+        const uint32_t i = r & 0xFFFF;
+        oidx[j] = i;
+        oval[j] = vals[i];  // original bits, not a round-trip through the key
+    }
+    noc_async_write(oval_addr, values_ta.get_noc_addr(0), K * 2);
+    noc_async_write(oidx_addr, index_ta.get_noc_addr(0), K * 4);
+    noc_async_write_barrier();
+}

--- a/tt-metal/ops/topk_select/device/topk_select_device_operation.cpp
+++ b/tt-metal/ops/topk_select/device/topk_select_device_operation.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include "topk_select_device_operation.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::prim {
+using namespace tt;
+using namespace tt::tt_metal;
+
+TopkSelectOperation::program_factory_t TopkSelectOperation::select_program_factory(
+    const operation_attributes_t&, const tensor_args_t&) {
+    return TopkSelectProgramFactory{};
+}
+
+void TopkSelectOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& a, const tensor_args_t& t) {
+    TT_FATAL(t.scores.dtype() == DataType::BFLOAT16, "scores must be BFLOAT16");
+    TT_FATAL(t.scores.layout() == Layout::TILE, "scores must be TILE");
+    TT_FATAL(t.scores.storage_type() == StorageType::DEVICE, "scores must be on device");
+    // One real row: the kernel reads logical row 0 only, so any leading dims
+    // must be size 1 or the extra rows would be silently ignored.
+    TT_FATAL(
+        t.scores.logical_shape().volume() == a.n,
+        "scores must hold a single row of {} values (volume {})",
+        a.n, t.scores.logical_shape().volume());
+    TT_FATAL(a.n <= 65536, "index shares a 32-bit record with the key: n <= 65536");
+    TT_FATAL(a.k <= a.n, "k ({}) must not exceed n ({})", a.k, a.n);
+    TT_FATAL(t.values.dtype() == DataType::BFLOAT16, "values must be BFLOAT16");
+    TT_FATAL(t.values.layout() == Layout::ROW_MAJOR, "values must be ROW_MAJOR");
+    TT_FATAL(t.values.storage_type() == StorageType::DEVICE, "values must be on device");
+    TT_FATAL(
+        t.values.logical_shape()[-1] == a.k, "values last dim must equal k ({})", a.k);
+    TT_FATAL(t.indices.dtype() == DataType::UINT32, "indices must be UINT32");
+    TT_FATAL(t.indices.layout() == Layout::ROW_MAJOR, "indices must be ROW_MAJOR");
+    TT_FATAL(t.indices.storage_type() == StorageType::DEVICE, "indices must be on device");
+    TT_FATAL(
+        t.indices.logical_shape()[-1] == a.k, "indices last dim must equal k ({})", a.k);
+}
+
+TensorSpec TopkSelectOperation::compute_output_specs(
+    const operation_attributes_t&, const tensor_args_t& t) {
+    return t.indices.tensor_spec();
+}
+
+Tensor TopkSelectOperation::create_output_tensors(
+    const operation_attributes_t&, const tensor_args_t& t) {
+    return t.indices;
+}
+
+void topk_select(const Tensor& scores, Tensor& values, Tensor& indices, uint32_t k) {
+    const uint32_t n = scores.logical_shape()[-1];
+    using Op = TopkSelectOperation;
+    ttnn::device_operation::launch<Op>(
+        Op::operation_attributes_t{
+            .n = n, .k = k, .output_mem_config = indices.memory_config()},
+        Op::tensor_args_t{.scores = scores, .values = values, .indices = indices});
+}
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/topk_select/device/topk_select_device_operation.hpp
+++ b/tt-metal/ops/topk_select/device/topk_select_device_operation.hpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/device_operation.hpp"
+#include "topk_select_device_operation_types.hpp"
+#include "topk_select_program_factory.hpp"
+
+namespace ttnn::prim {
+
+struct TopkSelectOperation {
+    using operation_attributes_t = TopkSelectParams;
+    using tensor_args_t = TopkSelectInputs;
+    using spec_return_value_t = tt::tt_metal::TensorSpec;
+    using tensor_return_value_t = tt::tt_metal::Tensor;
+    using program_factory_t = std::variant<TopkSelectProgramFactory>;
+
+    static program_factory_t select_program_factory(
+        const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(
+        const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(
+        const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t&, const tensor_args_t&);
+};
+
+void topk_select(
+    const tt::tt_metal::Tensor& scores,
+    tt::tt_metal::Tensor& values,
+    tt::tt_metal::Tensor& indices,
+    uint32_t k);
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/topk_select/device/topk_select_device_operation_types.hpp
+++ b/tt-metal/ops/topk_select/device/topk_select_device_operation_types.hpp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <tt-metalium/constants.hpp>
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::prim {
+
+// Top-k over a single row of scores, replacing ttnn.topk for the instance
+// bank's two selections (top-300 and top-600 of 900 confidences).
+//
+// Exists because ttnn.topk tile-pads [1, N] to [32, N32] and bitonic-sorts all
+// 32 rows on one core — 97% padding work, 1.9-2.8 ms per call. One radix sort
+// over the real row is ~5k integer L1 ops.
+struct TopkSelectParams {
+    uint32_t n;  // scores in the row (<= 65536: the index shares a 32-bit record)
+    uint32_t k;  // entries to emit, descending, ties to the lower index
+    tt::tt_metal::MemoryConfig output_mem_config;
+};
+
+struct TopkSelectInputs {
+    const tt::tt_metal::Tensor& scores;  // DEVICE TILE bf16, volume n in the last dim
+    // Preallocated DEVICE ROW_MAJOR outputs, written every call:
+    const tt::tt_metal::Tensor& values;   // [1,1,1,k] bf16 — scores, sorted descending
+    const tt::tt_metal::Tensor& indices;  // [1,1,1,k] uint32 — source positions
+};
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/topk_select/device/topk_select_program_factory.cpp
+++ b/tt-metal/ops/topk_select/device/topk_select_program_factory.cpp
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "tt-metalium/tensor_accessor_args.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include "topk_select_program_factory.hpp"
+
+namespace ttnn::prim {
+using namespace tt;
+using namespace tt::tt_metal;
+
+// One core, one dataflow kernel, no compute. The whole job is ~5k integer L1
+// operations — well under the dispatch floor — so parallelism has nothing to
+// recover here; what mattered was not sorting 31 rows of tile padding.
+TopkSelectProgramFactory::cached_program_t TopkSelectProgramFactory::create(
+    const TopkSelectParams& attrs,
+    const TopkSelectInputs& t,
+    Tensor& /*output_tensor*/) {
+
+    Program program{};
+    const CoreCoord core{0, 0};
+    const CoreRangeSet core_range{CoreRange{core, core}};
+
+    const uint32_t nt = (attrs.n + 31) / 32;
+    const uint32_t scores_bytes = nt * 64;                       // row 0, 64 B per tile
+    const uint32_t rec_bytes = ((2 * attrs.n * 4 + 31) / 32) * 32;  // ping-pong records
+    const uint32_t cnt_bytes = 256 * 4;
+    const uint32_t val_bytes = ((attrs.k * 2 + 31) / 32) * 32;
+    const uint32_t idx_bytes = ((attrs.k * 4 + 31) / 32) * 32;
+
+    constexpr uint32_t SCORES_CB = tt::CBIndex::c_0;
+    constexpr uint32_t REC_CB    = tt::CBIndex::c_1;
+    constexpr uint32_t CNT_CB    = tt::CBIndex::c_2;
+    constexpr uint32_t VAL_CB    = tt::CBIndex::c_3;
+    constexpr uint32_t IDX_CB    = tt::CBIndex::c_4;
+
+    auto mk = [&](uint32_t cb, uint32_t bytes, DataFormat fmt) {
+        auto cfg = CircularBufferConfig(bytes, {{cb, fmt}}).set_page_size(cb, bytes);
+        CreateCircularBuffer(program, core_range, cfg);
+    };
+    mk(SCORES_CB, scores_bytes, DataFormat::UInt16);
+    mk(REC_CB, rec_bytes, DataFormat::UInt32);
+    mk(CNT_CB, cnt_bytes, DataFormat::UInt32);
+    mk(VAL_CB, val_bytes, DataFormat::UInt16);
+    mk(IDX_CB, idx_bytes, DataFormat::UInt32);
+
+    std::vector<uint32_t> ct_args = {
+        attrs.n,    // 0
+        attrs.k,    // 1
+        SCORES_CB,  // 2
+        REC_CB,     // 3
+        CNT_CB,     // 4
+        VAL_CB,     // 5
+        IDX_CB,     // 6
+    };
+    TensorAccessorArgs(*t.scores.buffer()).append_to(ct_args);
+    TensorAccessorArgs(*t.values.buffer()).append_to(ct_args);
+    TensorAccessorArgs(*t.indices.buffer()).append_to(ct_args);
+
+    KernelHandle kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/pool/topk_select/device/kernels/dataflow/topk_select.cpp",
+        core_range,
+        WriterDataMovementConfig(ct_args));
+
+    SetRuntimeArgs(program, kernel_id, core, {
+        t.scores.buffer()->address(),
+        t.values.buffer()->address(),
+        t.indices.buffer()->address()});
+
+    return cached_program_t{
+        std::move(program), shared_variables_t{.kernel_id = kernel_id}};
+}
+
+void TopkSelectProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const TopkSelectParams&,
+    const TopkSelectInputs& t,
+    Tensor& /*output_tensor*/) {
+    auto& prog = cached_program.program;
+    const auto& sv = cached_program.shared_variables;
+    auto& r = GetRuntimeArgs(prog, sv.kernel_id, CoreCoord{0, 0});
+    r[0] = t.scores.buffer()->address();
+    r[1] = t.values.buffer()->address();
+    r[2] = t.indices.buffer()->address();
+}
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/topk_select/device/topk_select_program_factory.hpp
+++ b/tt-metal/ops/topk_select/device/topk_select_program_factory.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <vector>
+#include <tt-metalium/host_api.hpp>
+#include "ttnn/device_operation.hpp"
+#include "topk_select_device_operation_types.hpp"
+
+namespace ttnn::prim {
+
+struct TopkSelectProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle kernel_id;
+    };
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const TopkSelectParams& attrs,
+        const TopkSelectInputs& t,
+        tt::tt_metal::Tensor& output_tensor);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const TopkSelectParams& attrs,
+        const TopkSelectInputs& t,
+        tt::tt_metal::Tensor& output_tensor);
+};
+
+}  // namespace ttnn::prim

--- a/tt-metal/ops/topk_select/topk_select.cpp
+++ b/tt-metal/ops/topk_select/topk_select.cpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include "topk_select.hpp"
+#include "device/topk_select_device_operation.hpp"
+
+namespace ttnn::operations::topk_select {
+
+void topk_select(
+    const tt::tt_metal::Tensor& scores,
+    tt::tt_metal::Tensor& values,
+    tt::tt_metal::Tensor& indices,
+    uint32_t k) {
+    ttnn::prim::topk_select(scores, values, indices, k);
+}
+
+}  // namespace ttnn::operations::topk_select

--- a/tt-metal/ops/topk_select/topk_select.hpp
+++ b/tt-metal/ops/topk_select/topk_select.hpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "ttnn/types.hpp"
+
+namespace ttnn {
+namespace operations::topk_select {
+
+void topk_select(
+    const ttnn::Tensor& scores, ttnn::Tensor& values, ttnn::Tensor& indices, uint32_t k);
+
+}  // namespace operations::topk_select
+using ttnn::operations::topk_select::topk_select;
+}  // namespace ttnn

--- a/tt-metal/ops/topk_select/topk_select_nanobind.cpp
+++ b/tt-metal/ops/topk_select/topk_select_nanobind.cpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include "topk_select_nanobind.hpp"
+#include <nanobind/nanobind.h>
+#include "ttnn-nanobind/bind_function.hpp"
+#include "topk_select.hpp"
+
+namespace ttnn::operations::topk_select {
+
+void bind_topk_select(nb::module_& mod) {
+    ttnn::bind_function<"topk_select">(
+        mod,
+        "Top-k over a single row of scores (TILE bf16, one logical row). Writes "
+        "the k best scores descending into values ([1,1,1,k] bf16 ROW_MAJOR) and "
+        "their source positions into indices ([1,1,1,k] uint32 ROW_MAJOR), ties "
+        "resolved to the lower index like torch.topk. Replaces ttnn.topk for "
+        "short rows, where tile padding makes the stock bitonic sort do 32x the "
+        "needed work on one core.",
+        &ttnn::topk_select,
+        nb::arg("scores"), nb::arg("values"), nb::arg("indices"), nb::arg("k"));
+}
+
+}  // namespace ttnn::operations::topk_select

--- a/tt-metal/ops/topk_select/topk_select_nanobind.hpp
+++ b/tt-metal/ops/topk_select/topk_select_nanobind.hpp
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <nanobind/nanobind.h>
+namespace nb = nanobind;
+
+namespace ttnn::operations::topk_select {
+void bind_topk_select(nb::module_& mod);
+}


### PR DESCRIPTION
## Summary
Takes the frame from 90.7 → 62.3 ms (11.02 → 16.05 FPS) with two new device kernels(topk_select, row_gather) and a chain of layout/fusion fixes on the decoder path.

## Changes
kps_project_fused: rotation/projection as tile matmuls on the FPU, perspective
  divide on the SFPU (now the default path)
- grid_precompute: grid_sample's coordinate math on Tensix with a field-major reader (default on)
- camera-embed add materialised instead of broadcast; FPN 3×3 convs take row-major IO, skipping conv2d's internal reshapes
- weights_fc emits folded attention rows directly via a block-diagonal weight
- topk_select: radix top-k for the instance bank, replacing the host round-trip; temporal anchor projection folded into one affine matmul
- linear ReLU fused as a real matmul epilogue (core_grid)
- row_gather: paired (feature, anchor) row gather straight off topk_select's indices — 655 → 55 us/call, whole-row read batching, one barrier per row
- gws dead-pair skip + anchor_bucket: built and bit-identical but parked OFF by default — the control machinery measures free (+2%), yet permuted stick reads pay ~3× in DRAM row misses and the win inverts (63.4/65.3 vs 62.3 ms). No effect unless TT_GWS_SKIP=1; kept for the scatter-time-permutation retry.

##Performance

|              | PyTorch (RTX 5060 Ti) | TT-NN Pure (N300) | TT-NN + Custom Kernels (N300) |
|--------------|----------------------|-------------------|-------------------------------|
| Latency      | ~95 ms               | 235 ms            | **62.3 ms**                   |
| FPS          | 10.5                 | 4.2               | **16.05**                     |

